### PR TITLE
feat(auth): add dedicated admin login and fix cross-microfrontend red…

### DIFF
--- a/microfrontends/apps/mf-admin/App.tsx
+++ b/microfrontends/apps/mf-admin/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Suspense } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import HomePage from './pages/HomePage';
-import ApoderadoLogin from './pages/ApoderadoLogin';
+import AdminLogin from './pages/AdminLogin';
 import ProfessorLoginPage from './pages/ProfessorLoginPage';
 import AdminDashboard from './pages/AdminDashboard';
 import ProtectedAdminRoute from './components/auth/ProtectedAdminRoute';
@@ -23,7 +23,7 @@ const LoadingFallback = () => (
 function App() {
   const legacyRedirects = createLegacyRedirectRoutes();
   const location = useLocation();
-  const isLoginPage = location.pathname === '/login' || location.pathname === '/profesor';
+  const isLoginPage = location.pathname === '/login' || location.pathname === '/admin/login' || location.pathname === '/profesor';
 
   return (
     <ErrorBoundary>
@@ -36,7 +36,8 @@ function App() {
                 <Routes>
 
         <Route path="/" element={<HomePage />} />
-        <Route path="/login" element={<ApoderadoLogin />} />
+        <Route path="/login" element={<AdminLogin />} />
+        <Route path="/admin/login" element={<AdminLogin />} />
         <Route path="/profesor" element={<ProfessorLoginPage />} />
         <Route path="/admin" element={<ProtectedAdminRoute><AdminDashboard /></ProtectedAdminRoute>} />
         {legacyRedirects}

--- a/microfrontends/apps/mf-admin/components/admin/AdminDataTables.tsx
+++ b/microfrontends/apps/mf-admin/components/admin/AdminDataTables.tsx
@@ -26,7 +26,7 @@ interface AdminDataTablesProps {
 }
 
 const AdminDataTables: React.FC<AdminDataTablesProps> = ({ className = '' }) => {
-    const [activeView, setActiveView] = useState<TableView>('users');
+    const [activeView, setActiveView] = useState<TableView>('postulantes');
     const [showCreateUserModal, setShowCreateUserModal] = useState(false);
     const [showEditUserModal, setShowEditUserModal] = useState(false);
     const [selectedUser, setSelectedUser] = useState<any>(null);

--- a/microfrontends/apps/mf-admin/components/auth/ProtectedAdminRoute.tsx
+++ b/microfrontends/apps/mf-admin/components/auth/ProtectedAdminRoute.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
+import { microfrontendUrls } from '../../utils/microfrontendUrls';
 
 interface ProtectedAdminRouteProps {
     children: React.ReactNode;
@@ -20,12 +21,10 @@ const ProtectedAdminRoute: React.FC<ProtectedAdminRouteProps> = ({ children }) =
 
     // Verificar que tenga permisos de admin
     if (user.role !== 'ADMIN') {
-        // Si no es admin, redirigir según su rol
-        if (user.role === 'APODERADO') {
-            return <Navigate to="/familia" replace />;
-        } else {
-            return <Navigate to="/profesor" replace />;
-        }
+        window.location.replace(user.role === 'APODERADO'
+            ? microfrontendUrls.guardianDashboard
+            : microfrontendUrls.professorDashboard);
+        return <div>Redirigiendo...</div>;
     }
 
     return <>{children}</>;

--- a/microfrontends/apps/mf-admin/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-admin/context/AuthContext.tsx
@@ -192,7 +192,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         localStorage.removeItem('auth_token');
         localStorage.removeItem('authenticated_user');
         setUser(null);
-        window.location.href = '/apoderado-login';
+        window.location.href = '/#/login';
     };
 
     const value: AuthContextType = {

--- a/microfrontends/apps/mf-admin/pages/AdminLogin.tsx
+++ b/microfrontends/apps/mf-admin/pages/AdminLogin.tsx
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import Card from '../components/ui/Card';
+import Button from '../components/ui/Button';
+import Input from '../components/ui/Input';
+import { useAuth } from '../context/AuthContext';
+import { useNotifications } from '../context/AppContext';
+import { microfrontendUrls } from '../utils/microfrontendUrls';
+
+const AdminLogin: React.FC = () => {
+    const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
+    const { login } = useAuth();
+    const { addNotification } = useNotifications();
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState('');
+
+    const redirectTo = searchParams.get('redirect') || '/admin';
+
+    const handleLogin = async (event: React.FormEvent) => {
+        event.preventDefault();
+        setError('');
+
+        if (!email || !password) {
+            const msg = 'Por favor complete todos los campos';
+            setError(msg);
+            addNotification({ type: 'error', title: 'Campos requeridos', message: msg });
+            return;
+        }
+
+        setIsLoading(true);
+        try {
+            await login(email, password, 'ADMIN');
+
+            const storedUser = JSON.parse(localStorage.getItem('authenticated_user') || 'null');
+            if (!storedUser || storedUser.role !== 'ADMIN') {
+                localStorage.removeItem('auth_token');
+                localStorage.removeItem('authenticated_user');
+
+                if (storedUser?.role === 'APODERADO') {
+                    window.location.href = microfrontendUrls.guardianDashboard;
+                    return;
+                }
+
+                window.location.href = microfrontendUrls.professorDashboard;
+                return;
+            }
+
+            navigate(redirectTo, { replace: true });
+        } catch (err: any) {
+            const msg = err.message || 'Credenciales inválidas. Verifique su email y contraseña.';
+            setError(msg);
+            addNotification({ type: 'error', title: 'Error al iniciar sesión', message: msg });
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <div className="min-h-screen bg-white flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+            <div className="max-w-md w-full space-y-8">
+                <Card className="p-5 sm:p-8">
+                    <div className="text-center">
+                        <div className="flex justify-center mb-8">
+                            <img src="/images/logoMTN.png" alt="Logo Monte Tabor y Nazaret" className="h-24" />
+                        </div>
+                        <h2 className="text-3xl sm:text-4xl font-bold text-azul-monte-tabor">
+                            Portal Administrador
+                        </h2>
+                        <p className="mt-2 text-lg text-azul-monte-tabor font-light">
+                            Accede a la consola de administración
+                        </p>
+                    </div>
+
+                    <form onSubmit={handleLogin} className="space-y-6 mt-8">
+                        {error && (
+                            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">
+                                {error}
+                            </div>
+                        )}
+
+                        <Input
+                            id="admin-email"
+                            label="Correo Electrónico"
+                            type="email"
+                            placeholder="admin@mtn.cl"
+                            value={email}
+                            onChange={(event) => setEmail(event.target.value)}
+                            isRequired
+                        />
+
+                        <Input
+                            id="admin-password"
+                            label="Contraseña"
+                            type="password"
+                            placeholder="••••••••"
+                            value={password}
+                            onChange={(event) => setPassword(event.target.value)}
+                            isRequired
+                            showPasswordToggle
+                        />
+
+                        <Button
+                            type="submit"
+                            variant="secondary"
+                            size="lg"
+                            isLoading={isLoading}
+                            loadingText="Iniciando sesión..."
+                            className="w-full bg-dorado-nazaret hover:bg-opacity-90 text-azul-monte-tabor font-bold"
+                        >
+                            Iniciar Sesión
+                        </Button>
+                    </form>
+                </Card>
+            </div>
+        </div>
+    );
+};
+
+export default AdminLogin;

--- a/microfrontends/apps/mf-admin/pages/ProfessorLoginPage.tsx
+++ b/microfrontends/apps/mf-admin/pages/ProfessorLoginPage.tsx
@@ -98,10 +98,10 @@ const ProfessorLoginPage: React.FC = () => {
                     // Redirigir según el rol del usuario
                     if (respRole === 'ADMIN') {
                         console.log('Usuario admin detectado, redirigiendo al panel de administración...');
-                        navigate('/admin');
+                        navigate('/admin', { replace: true });
                     } else {
                         console.log('Usuario profesor detectado, redirigiendo al dashboard de profesor...');
-                        navigate('/profesor');
+                        window.location.href = microfrontendUrls.professorDashboard;
                     }
                     
                 } else {

--- a/microfrontends/apps/mf-admin/services/api.ts
+++ b/microfrontends/apps/mf-admin/services/api.ts
@@ -135,7 +135,7 @@ api.interceptors.response.use(
                 localStorage.removeItem('currentProfessor');
 
                 // Solo redirigir si no estamos ya en una página de login o si no es una ruta pública
-                const currentPath = window.location.pathname;
+                const currentPath = window.location.hash || window.location.pathname;
                 const isLoginPage = currentPath.includes('/login') || currentPath === '/';
                 const requestUrl = error.config?.url || '';
                 const isPublicRoute = requestUrl.includes('/public/') ||
@@ -146,11 +146,7 @@ api.interceptors.response.use(
                     console.warn('Redirecting to login due to expired token');
                     // Usar setTimeout para evitar problemas con el contexto de React
                     setTimeout(() => {
-                        if (currentPath.includes('/admin') || currentPath.includes('/profesor')) {
-                            window.location.href = '/admin/login';
-                        } else {
-                            window.location.href = '/login';
-                        }
+                        window.location.href = '/#/login';
                     }, 100);
                 }
             }

--- a/microfrontends/apps/mf-admin/services/http.ts
+++ b/microfrontends/apps/mf-admin/services/http.ts
@@ -302,7 +302,7 @@ class HttpClient {
     const currentPath = window.location.pathname + window.location.search;
     sessionStorage.setItem('redirectAfterLogin', currentPath);
     
-    window.location.href = '/login';
+    window.location.href = '/#/login';
   }
 
   private createHttpError(error: AxiosError, correlationId?: string): HttpError {

--- a/microfrontends/apps/mf-evaluations/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-evaluations/context/AuthContext.tsx
@@ -192,7 +192,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         localStorage.removeItem('auth_token');
         localStorage.removeItem('authenticated_user');
         setUser(null);
-        window.location.href = '/apoderado-login';
+        window.location.href = '/#/profesor/login';
     };
 
     const value: AuthContextType = {

--- a/microfrontends/apps/mf-evaluations/pages/ProfessorLoginPage.tsx
+++ b/microfrontends/apps/mf-evaluations/pages/ProfessorLoginPage.tsx
@@ -99,7 +99,7 @@ const ProfessorLoginPage: React.FC = () => {
                     // Redirigir según el rol del usuario
                     if (respRole === 'ADMIN') {
                         console.log('Usuario admin detectado, redirigiendo al panel de administración...');
-                        navigate('/admin');
+                        window.location.href = microfrontendUrls.adminDashboard;
                     } else {
                         console.log('Usuario profesor detectado, redirigiendo al dashboard de profesor...');
                         navigate('/profesor');

--- a/microfrontends/apps/mf-evaluations/services/api.ts
+++ b/microfrontends/apps/mf-evaluations/services/api.ts
@@ -135,7 +135,7 @@ api.interceptors.response.use(
                 localStorage.removeItem('currentProfessor');
 
                 // Solo redirigir si no estamos ya en una página de login o si no es una ruta pública
-                const currentPath = window.location.pathname;
+                const currentPath = window.location.hash || window.location.pathname;
                 const isLoginPage = currentPath.includes('/login') || currentPath === '/';
                 const requestUrl = error.config?.url || '';
                 const isPublicRoute = requestUrl.includes('/public/') ||
@@ -146,11 +146,7 @@ api.interceptors.response.use(
                     console.warn('Redirecting to login due to expired token');
                     // Usar setTimeout para evitar problemas con el contexto de React
                     setTimeout(() => {
-                        if (currentPath.includes('/admin') || currentPath.includes('/profesor')) {
-                            window.location.href = '/admin/login';
-                        } else {
-                            window.location.href = '/login';
-                        }
+                        window.location.href = '/#/profesor/login';
                     }, 100);
                 }
             }

--- a/microfrontends/apps/mf-evaluations/services/http.ts
+++ b/microfrontends/apps/mf-evaluations/services/http.ts
@@ -302,7 +302,7 @@ class HttpClient {
     const currentPath = window.location.pathname + window.location.search;
     sessionStorage.setItem('redirectAfterLogin', currentPath);
     
-    window.location.href = '/login';
+    window.location.href = '/#/profesor/login';
   }
 
   private createHttpError(error: AxiosError, correlationId?: string): HttpError {

--- a/microfrontends/apps/mf-guardian/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-guardian/context/AuthContext.tsx
@@ -192,7 +192,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         localStorage.removeItem('auth_token');
         localStorage.removeItem('authenticated_user');
         setUser(null);
-        window.location.href = '/apoderado-login';
+        window.location.href = '/#/apoderado/login';
     };
 
     const value: AuthContextType = {

--- a/microfrontends/apps/mf-guardian/services/api.ts
+++ b/microfrontends/apps/mf-guardian/services/api.ts
@@ -135,7 +135,7 @@ api.interceptors.response.use(
                 localStorage.removeItem('currentProfessor');
 
                 // Solo redirigir si no estamos ya en una página de login o si no es una ruta pública
-                const currentPath = window.location.pathname;
+                const currentPath = window.location.hash || window.location.pathname;
                 const isLoginPage = currentPath.includes('/login') || currentPath === '/';
                 const requestUrl = error.config?.url || '';
                 const isPublicRoute = requestUrl.includes('/public/') ||
@@ -146,11 +146,7 @@ api.interceptors.response.use(
                     console.warn('Redirecting to login due to expired token');
                     // Usar setTimeout para evitar problemas con el contexto de React
                     setTimeout(() => {
-                        if (currentPath.includes('/admin') || currentPath.includes('/profesor')) {
-                            window.location.href = '/admin/login';
-                        } else {
-                            window.location.href = '/login';
-                        }
+                        window.location.href = '/#/apoderado/login';
                     }, 100);
                 }
             }

--- a/microfrontends/apps/mf-guardian/services/http.ts
+++ b/microfrontends/apps/mf-guardian/services/http.ts
@@ -302,7 +302,7 @@ class HttpClient {
     const currentPath = window.location.pathname + window.location.search;
     sessionStorage.setItem('redirectAfterLogin', currentPath);
     
-    window.location.href = '/login';
+    window.location.href = '/#/apoderado/login';
   }
 
   private createHttpError(error: AxiosError, correlationId?: string): HttpError {

--- a/microfrontends/apps/mf-student/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-student/context/AuthContext.tsx
@@ -192,7 +192,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         localStorage.removeItem('auth_token');
         localStorage.removeItem('authenticated_user');
         setUser(null);
-        window.location.href = '/apoderado-login';
+        window.location.href = '/#/examenes';
     };
 
     const value: AuthContextType = {

--- a/microfrontends/apps/mf-student/services/api.ts
+++ b/microfrontends/apps/mf-student/services/api.ts
@@ -135,7 +135,7 @@ api.interceptors.response.use(
                 localStorage.removeItem('currentProfessor');
 
                 // Solo redirigir si no estamos ya en una página de login o si no es una ruta pública
-                const currentPath = window.location.pathname;
+                const currentPath = window.location.hash || window.location.pathname;
                 const isLoginPage = currentPath.includes('/login') || currentPath === '/';
                 const requestUrl = error.config?.url || '';
                 const isPublicRoute = requestUrl.includes('/public/') ||
@@ -146,11 +146,7 @@ api.interceptors.response.use(
                     console.warn('Redirecting to login due to expired token');
                     // Usar setTimeout para evitar problemas con el contexto de React
                     setTimeout(() => {
-                        if (currentPath.includes('/admin') || currentPath.includes('/profesor')) {
-                            window.location.href = '/admin/login';
-                        } else {
-                            window.location.href = '/login';
-                        }
+                        window.location.href = '/#/examenes';
                     }, 100);
                 }
             }

--- a/microfrontends/apps/mf-student/services/http.ts
+++ b/microfrontends/apps/mf-student/services/http.ts
@@ -302,7 +302,7 @@ class HttpClient {
     const currentPath = window.location.pathname + window.location.search;
     sessionStorage.setItem('redirectAfterLogin', currentPath);
     
-    window.location.href = '/login';
+    window.location.href = '/#/examenes';
   }
 
   private createHttpError(error: AxiosError, correlationId?: string): HttpError {


### PR DESCRIPTION
…irects

- Add AdminLogin.tsx component for admin-specific authentication
- Replace ApoderadoLogin with AdminLogin in mf-admin routes
- Add /admin/login route alongside /login for admin access
- Update ProtectedAdminRoute to use window.location.replace for cross-MF redirects
- Fix logout redirects to use hash-based URLs for all microfrontends
- Update API interceptors to check window.location.hash for current path
- Simplify 401