### PR TITLE
fix(auth): corregir flujos de autenticación entre aplicaciones

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,4 +277,4 @@ microfrontends/
 
 - La integración con backend se mantiene con los mismos servicios y endpoints que usaba el frontend original.
 - El código legado raíz fue reemplazado por proyectos aislados; la evolución debe hacerse dentro de `microfrontends/apps/*`.
-- El repositorio ya no conserva el monolito original; la fuente de trabajo es cada microfrontend por separado.
+- El repositorio ya no conserva el monolito original; la fuente de trabajo es cada microfrontend por separado

--- a/microfrontends/apps/mf-admin/components/admin/ApplicationDecisionModal.tsx
+++ b/microfrontends/apps/mf-admin/components/admin/ApplicationDecisionModal.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import Modal from '../ui/Modal';
-import axios from 'axios';
-import { getApiBaseUrl } from '../../config/api.config';
+import api from '../../services/api';
 
 interface ApplicationDecisionModalProps {
   isOpen: boolean;
@@ -31,18 +30,9 @@ const ApplicationDecisionModal: React.FC<ApplicationDecisionModalProps> = ({
 
     setLoading(true);
     try {
-      const token = localStorage.getItem('auth_token');
-      await axios.post(
-        `${getApiBaseUrl()}/v1/applications/${application.id}/final-decision`,
-        {
-          decision,
-          note
-        },
-        {
-          headers: {
-            'Authorization': `Bearer ${token}`
-          }
-        }
+      await api.post(
+        `/v1/applications/${application.id}/final-decision`,
+        { decision, note }
       );
 
       setShowConfirmation(true);

--- a/microfrontends/apps/mf-admin/components/admin/ApplicationsDataTable.tsx
+++ b/microfrontends/apps/mf-admin/components/admin/ApplicationsDataTable.tsx
@@ -6,6 +6,12 @@ import Modal from '../ui/Modal';
 import { FiEdit, FiEye, FiDownload, FiCalendar, FiFileText, FiUser } from 'react-icons/fi';
 import { useNotifications } from '../../context/AppContext';
 import { applicationService } from '../../services/applicationService';
+import {
+    buildGradeDisplay,
+    buildGuardianContact,
+    buildStudentDisplayName,
+    mapBffApplicationStatusToTable
+} from '../../services/applicationTableMapper';
 
 interface Application {
     id: number;
@@ -65,7 +71,10 @@ const ApplicationsDataTable: React.FC<ApplicationsDataTableProps> = ({
                     <span className="font-medium text-gray-900">{record.studentName}</span>
                     <span className="text-sm text-gray-500">{record.studentRut}</span>
                     <span className="text-xs text-gray-400">
-                        Edad: {calculateAge(record.studentBirthDate)} años
+                        Edad: {(() => {
+                            const a = calculateAge(record.studentBirthDate);
+                            return typeof a === 'number' ? `${a} años` : a;
+                        })()}
                     </span>
                 </div>
             )
@@ -285,7 +294,8 @@ const ApplicationsDataTable: React.FC<ApplicationsDataTableProps> = ({
     ];
 
     // Función auxiliar para calcular edad
-    const calculateAge = (birthDate: string): number => {
+    const calculateAge = (birthDate: string): number | string => {
+        if (!birthDate) return '—';
         const today = new Date();
         const birth = new Date(birthDate);
         let age = today.getFullYear() - birth.getFullYear();
@@ -303,36 +313,37 @@ const ApplicationsDataTable: React.FC<ApplicationsDataTableProps> = ({
         setLoading(true);
         try {
             // Obtener aplicaciones reales del backend
-            const response = await applicationService.getAllApplications({
-                page: page - 1, // Backend usa 0-based indexing
-                size: size
+            const response = await applicationService.fetchApplicationsPage({
+                page: page - 1,
+                size
             });
-            
-            // Mapear datos del backend al formato esperado por el componente
-            const mappedApplications: Application[] = response.applications.map((app: any) => ({
-                id: app.id,
-                studentName: `${app.student.firstName} ${app.student.lastName}`,
-                studentRut: app.student.rut,
-                studentBirthDate: app.student.birthDate,
-                gradeApplied: app.student.grade,
-                status: app.status,
-                submissionDate: app.submissionDate || app.createdAt,
-                parentName: `${app.father?.firstName || ''} ${app.father?.lastName || ''}`.trim() || 
-                           `${app.mother?.firstName || ''} ${app.mother?.lastName || ''}`.trim() || 
-                           'No especificado',
-                parentEmail: app.father?.email || app.mother?.email || 'No especificado',
-                parentPhone: app.father?.phone || app.mother?.phone || 'No especificado',
-                previousSchool: app.student.currentSchool || 'No especificado',
-                hasSpecialNeeds: app.student.hasSpecialNeeds || false,
-                specialNeedsDescription: app.student.specialNeedsDescription || '',
-                academicYear: new Date().getFullYear().toString(),
-                evaluationStatus: app.evaluationStatus || 'PENDING',
-                interviewDate: app.interviewDate,
-                documentsComplete: app.documentsComplete || false,
-                admissionScore: app.admissionScore,
-                createdAt: app.createdAt,
-                updatedAt: app.updatedAt
-            }));
+
+            const mappedApplications: Application[] = response.applications.map((app: Record<string, any>) => {
+                const student = (app.student || {}) as Record<string, unknown>;
+                const contact = buildGuardianContact(app);
+                return {
+                    id: app.id,
+                    studentName: buildStudentDisplayName(student),
+                    studentRut: String(student.rut || '—'),
+                    studentBirthDate: String(student.birthDate || ''),
+                    gradeApplied: buildGradeDisplay(student),
+                    status: mapBffApplicationStatusToTable(app.status),
+                    submissionDate: app.submissionDate || app.createdAt || '',
+                    parentName: contact.parentName,
+                    parentEmail: contact.parentEmail,
+                    parentPhone: contact.parentPhone,
+                    previousSchool: String(student.currentSchool || 'No especificado'),
+                    hasSpecialNeeds: Boolean(student.specialNeeds),
+                    specialNeedsDescription: String(student.specialNeedsDescription || ''),
+                    academicYear: new Date().getFullYear().toString(),
+                    evaluationStatus: app.evaluationStatus || 'PENDING',
+                    interviewDate: app.interviewDate,
+                    documentsComplete: app.documentsComplete || false,
+                    admissionScore: app.admissionScore,
+                    createdAt: app.createdAt,
+                    updatedAt: app.updatedAt
+                };
+            });
 
             setApplications(mappedApplications);
             setPagination({

--- a/microfrontends/apps/mf-admin/components/admin/ApplicationsTable.tsx
+++ b/microfrontends/apps/mf-admin/components/admin/ApplicationsTable.tsx
@@ -3,6 +3,7 @@ import Button from '../ui/Button';
 import Badge from '../ui/Badge';
 import LoadingSpinner from '../ui/LoadingSpinner';
 import { Application } from '../../services/applicationService';
+import { buildGradeDisplay, buildStudentDisplayName } from '../../services/applicationTableMapper';
 import {
   FileTextIcon,
   EyeIcon,
@@ -170,7 +171,15 @@ const ApplicationsTable: React.FC<ApplicationsTableProps> = ({
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
-            {pagedApplications.map((application) => (
+            {pagedApplications.map((application) => {
+              const st = application.student as Record<string, unknown> | undefined;
+              const studentLine = buildStudentDisplayName(st);
+              const parts = studentLine.split(/\s+/).filter(Boolean);
+              const initials =
+                parts.length > 1
+                  ? `${parts[0]?.charAt(0) || 'N'}${parts[parts.length - 1]?.charAt(0) || ''}`
+                  : parts[0]?.slice(0, 2) || 'NN';
+              return (
               <tr key={application.id} className="hover:bg-gray-50">
                 {/* Estudiante */}
                 <td className="px-6 py-4 whitespace-nowrap">
@@ -178,13 +187,13 @@ const ApplicationsTable: React.FC<ApplicationsTableProps> = ({
                     <div className="flex-shrink-0 h-10 w-10">
                       <div className="h-10 w-10 rounded-full bg-azul-monte-tabor bg-opacity-10 flex items-center justify-center">
                         <span className="text-sm font-medium text-azul-monte-tabor">
-                          {application.student?.firstName?.charAt(0) || 'N'}{(application.student?.paternalLastName || application.student?.lastName)?.charAt(0) || 'N'}
+                          {(initials || 'NN').slice(0, 2).toUpperCase()}
                         </span>
                       </div>
                     </div>
                     <div className="ml-4">
                       <div className="text-sm font-medium text-gray-900">
-                        {application.student?.firstName || 'N/A'} {application.student?.paternalLastName || application.student?.lastName || 'N/A'} {application.student?.maternalLastName || ''}
+                        {studentLine}
                       </div>
                       <div className="text-sm text-gray-500">
                         RUT: {application.student?.rut || 'N/A'}
@@ -195,7 +204,7 @@ const ApplicationsTable: React.FC<ApplicationsTableProps> = ({
 
                 {/* Grado */}
                 <td className="px-6 py-4 whitespace-nowrap">
-                  <div className="text-sm text-gray-900">{application.student?.gradeApplied || 'N/A'}</div>
+                  <div className="text-sm text-gray-900">{buildGradeDisplay(st)}</div>
                 </td>
 
                 {/* Apoderado */}
@@ -270,7 +279,8 @@ const ApplicationsTable: React.FC<ApplicationsTableProps> = ({
                   </div>
                 </td>
               </tr>
-            ))}
+            );
+            })}
           </tbody>
         </table>
       </div>

--- a/microfrontends/apps/mf-admin/components/admin/StudentDetailModal.tsx
+++ b/microfrontends/apps/mf-admin/components/admin/StudentDetailModal.tsx
@@ -142,13 +142,12 @@ const StudentDetailModal: React.FC<StudentDetailModalProps> = ({
             if (app?.documents) {
                 const approvalStatus: Record<number, boolean> = {};
                 app.documents.forEach((doc: any, index: number) => {
-                    // approval_status from DB: 'PENDING', 'APPROVED', 'REJECTED'
-                    if (doc.approval_status === 'APPROVED') {
+                    const st = doc.approvalStatus ?? doc.approval_status;
+                    if (st === 'APPROVED') {
                         approvalStatus[index] = true;
-                    } else if (doc.approval_status === 'REJECTED') {
+                    } else if (st === 'REJECTED') {
                         approvalStatus[index] = false;
                     }
-                    // PENDING documents are not set (undefined) so checkbox is unchecked
                 });
                 console.log('Estado de aprobación inicializado:', approvalStatus);
                 setDocumentApprovalStatus(approvalStatus);
@@ -372,7 +371,7 @@ const StudentDetailModal: React.FC<StudentDetailModalProps> = ({
         console.log('Document:', document);
 
         // LOCK: Prevent toggling if document is already approved in database (permanent lock)
-        if (document.approval_status === 'APPROVED') {
+        if ((document.approvalStatus ?? document.approval_status) === 'APPROVED') {
             console.log('Document already approved, showing notification');
             addNotification({
                 type: 'info',
@@ -507,7 +506,7 @@ const StudentDetailModal: React.FC<StudentDetailModalProps> = ({
         // - rejectedDocsNow: Documentos marcados como rechazados EN ESTA SESIÓN
         const approvedDocsNow = fullApplication.documents.filter((doc, index) => {
             const currentStatus = documentApprovalStatus[index];
-            const dbStatus = doc.approvalStatus;
+            const dbStatus = doc.approvalStatus ?? doc.approval_status;
             // Solo incluir si fue marcado como aprobado AHORA (no si ya estaba aprobado en BD)
             return currentStatus === true && dbStatus !== 'APPROVED';
         });
@@ -520,7 +519,10 @@ const StudentDetailModal: React.FC<StudentDetailModalProps> = ({
 
         // Contar todos los documentos actualmente aprobados (en BD + en sesión)
         const allApprovedDocs = fullApplication.documents.filter((doc, index) => {
-            return documentApprovalStatus[index] === true || doc.approvalStatus === 'APPROVED';
+            return (
+                documentApprovalStatus[index] === true ||
+                (doc.approvalStatus ?? doc.approval_status) === 'APPROVED'
+            );
         });
 
         console.log('DEBUG - documentApprovalStatus:', documentApprovalStatus);
@@ -910,8 +912,39 @@ const StudentDetailModal: React.FC<StudentDetailModalProps> = ({
                     <div className="space-y-3 bg-gray-50 p-4 rounded-lg">
                         <div className="flex justify-between items-center">
                             <span className="text-gray-600">Documentos:</span>
-                            <Badge variant={postulante.documentosCompletos ? 'green' : 'red'} size="sm">
-                                {postulante.documentosCompletos ? 'Completos' : 'Incompletos'} ({postulante.cantidadDocumentos})
+                            <Badge
+                                variant={
+                                    (() => {
+                                        const docs = fullApplication?.documents;
+                                        if (docs && docs.length > 0) {
+                                            const allApproved = docs.every(
+                                                (d: any) => (d.approvalStatus ?? d.approval_status) === 'APPROVED'
+                                            );
+                                            return allApproved ? 'green' : 'red';
+                                        }
+                                        return postulante.documentosCompletos ? 'green' : 'red';
+                                    })()
+                                }
+                                size="sm"
+                            >
+                                {(() => {
+                                    const docs = fullApplication?.documents;
+                                    if (loading) return 'Cargando…';
+                                    if (docs && docs.length > 0) {
+                                        const n = docs.length;
+                                        const pending = docs.filter(
+                                            (d: any) =>
+                                                !(d.approvalStatus ?? d.approval_status) ||
+                                                (d.approvalStatus ?? d.approval_status) === 'PENDING'
+                                        ).length;
+                                        if (pending > 0) return `En revisión (${n})`;
+                                        const allOk = docs.every(
+                                            (d: any) => (d.approvalStatus ?? d.approval_status) === 'APPROVED'
+                                        );
+                                        return allOk ? `Completos (${n})` : `Incompletos (${n})`;
+                                    }
+                                    return `${postulante.documentosCompletos ? 'Completos' : 'Incompletos'} (${postulante.cantidadDocumentos})`;
+                                })()}
                             </Badge>
                         </div>
                         <div className="flex justify-between items-center">
@@ -1481,7 +1514,8 @@ const StudentDetailModal: React.FC<StudentDetailModalProps> = ({
                                         const isApproved = documentApprovalStatus[originalIndex];
                                         const isRejected = documentApprovalStatus[originalIndex] === false;
                                         // Show if document was previously approved in database (visual indicator only)
-                                        const wasPreviouslyApproved = doc.approvalStatus === 'APPROVED';
+                                        const wasPreviouslyApproved =
+                                            (doc.approvalStatus ?? doc.approval_status) === 'APPROVED';
 
                                         return (
                                             <div

--- a/microfrontends/apps/mf-admin/components/auth/ProtectedCoordinatorRoute.tsx
+++ b/microfrontends/apps/mf-admin/components/auth/ProtectedCoordinatorRoute.tsx
@@ -5,6 +5,7 @@
 
 import React, { ReactNode } from 'react';
 import { Navigate } from 'react-router-dom';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 interface ProtectedCoordinatorRouteProps {
   children: ReactNode;
@@ -12,14 +13,14 @@ interface ProtectedCoordinatorRouteProps {
 
 const ProtectedCoordinatorRoute: React.FC<ProtectedCoordinatorRouteProps> = ({ children }) => {
   // Verificar autenticación - revisar múltiples posibles tokens
-  const authToken = localStorage.getItem('auth_token');
+  const authToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
   const adminToken = localStorage.getItem('admin_token');
-  const professorToken = localStorage.getItem('professor_token');
+  const professorToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
 
   // Verificar múltiples ubicaciones de usuario en localStorage
-  const userStr = localStorage.getItem('authenticated_user') ||
+  const userStr = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER)) ||
                   localStorage.getItem('user') ||
-                  localStorage.getItem('professor_user');
+                  localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
 
   // Si hay un token de autenticación
   const isAuthenticated = !!(authToken || adminToken || professorToken);

--- a/microfrontends/apps/mf-admin/components/layout/Header.tsx
+++ b/microfrontends/apps/mf-admin/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import Button from '../ui/Button';
 import { microfrontendUrls } from '../../utils/microfrontendUrls';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 const Header: React.FC = () => {
     const navigate = useNavigate();
@@ -15,10 +16,10 @@ const Header: React.FC = () => {
     useEffect(() => {
         const checkAuthStatus = () => {
             // Verificar múltiples fuentes de autenticación
-            const currentProfessor = localStorage.getItem('currentProfessor');
-            const authToken = localStorage.getItem('auth_token');
-            const professorToken = localStorage.getItem('professor_token');
-            const apoderadoToken = localStorage.getItem('apoderado_token');
+            const currentProfessor = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
+            const authToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+            const professorToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+            const apoderadoToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
 
             // Verificar si hay profesor autenticado
             const hasProfessorAuth = !!(professorToken && currentProfessor);
@@ -66,10 +67,10 @@ const Header: React.FC = () => {
             e.preventDefault(); // Prevenir navegación predeterminada
 
             // Limpiar TODOS los tokens y datos de autenticación
-            localStorage.removeItem('auth_token');
-            localStorage.removeItem('professor_token');
-            localStorage.removeItem('apoderado_token');
-            localStorage.removeItem('currentProfessor');
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
             localStorage.removeItem('currentUser');
             localStorage.removeItem('currentApoderado');
 

--- a/microfrontends/apps/mf-admin/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-admin/context/AuthContext.tsx
@@ -3,6 +3,7 @@ import { onAuthStateChanged } from 'firebase/auth';
 import { auth, hasFirebaseConfig } from '../src/lib/firebase';
 import { authService } from '../services/authService';
 import api from '../services/api';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 interface User {
     id: string;
@@ -57,7 +58,7 @@ const buildUserFromBff = (u: any): User => ({
 
 const setAdminCompat = (user: User, token: string, subject?: string) => {
     if (user.role === 'ADMIN') {
-        localStorage.setItem('currentProfessor', JSON.stringify({
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR), JSON.stringify({
             id: user.id,
             firstName: user.firstName,
             lastName: user.lastName,
@@ -67,8 +68,8 @@ const setAdminCompat = (user: User, token: string, subject?: string) => {
             assignedGrades: ['prekinder', 'kinder', '1basico', '2basico', '3basico', '4basico', '5basico', '6basico', '7basico', '8basico', '1medio', '2medio', '3medio', '4medio'],
             isAdmin: true,
         }));
-        localStorage.setItem('professor_token', token);
-        localStorage.setItem('professor_user', JSON.stringify({
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN), token);
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER), JSON.stringify({
             email: user.email,
             firstName: user.firstName,
             lastName: user.lastName,
@@ -93,17 +94,17 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 // Firebase user is signed in — get fresh idToken and fetch profile from BFF
                 try {
                     const idToken = await firebaseUser.getIdToken();
-                    localStorage.setItem('auth_token', idToken);
+                    localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
                     // Check if we already have cached user data
-                    const cached = localStorage.getItem('authenticated_user');
+                    const cached = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                     if (cached) {
                         try {
                             setUser(JSON.parse(cached));
                             setIsLoading(false);
                             return;
                         } catch {
-                            localStorage.removeItem('authenticated_user');
+                            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                         }
                     }
 
@@ -111,20 +112,20 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                     const response = await api.get('/v1/auth/check');
                     if (response.data?.success && response.data?.user) {
                         const userData = buildUserFromBff(response.data.user);
-                        localStorage.setItem('authenticated_user', JSON.stringify(userData));
+                        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(userData));
                         setAdminCompat(userData, idToken, response.data.user?.subject);
                         setUser(userData);
                     }
                 } catch {
                     // BFF call failed — clear state
-                    localStorage.removeItem('auth_token');
-                    localStorage.removeItem('authenticated_user');
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                     setUser(null);
                 }
             } else {
                 // No Firebase user — clear everything
-                localStorage.removeItem('auth_token');
-                localStorage.removeItem('authenticated_user');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                 setUser(null);
             }
             setIsLoading(false);
@@ -141,7 +142,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             if (response.success && u) {
                 const userData = buildUserFromBff(u);
                 setAdminCompat(userData, response.token ?? '', u?.subject);
-                localStorage.setItem('authenticated_user', JSON.stringify(userData));
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(userData));
                 setUser(userData);
             } else {
                 throw new Error(response.message || 'Error en la autenticación');
@@ -170,7 +171,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 const newUser = buildUserFromBff(u);
                 newUser.phone = userData.phone;
                 newUser.rut = userData.rut;
-                localStorage.setItem('authenticated_user', JSON.stringify(newUser));
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(newUser));
                 setUser(newUser);
             } else {
                 throw new Error(response.message || 'Error al crear la cuenta');
@@ -184,13 +185,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
     const logout = () => {
         authService.logout();
-        localStorage.removeItem('currentProfessor');
-        localStorage.removeItem('professor_token');
-        localStorage.removeItem('professor_user');
-        localStorage.removeItem('apoderado_token');
-        localStorage.removeItem('apoderado_user');
-        localStorage.removeItem('auth_token');
-        localStorage.removeItem('authenticated_user');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
         setUser(null);
         window.location.href = '/#/login';
     };

--- a/microfrontends/apps/mf-admin/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-admin/context/AuthContext.tsx
@@ -82,6 +82,39 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     const [user, setUser] = useState<User | null>(null);
     const [isLoading, setIsLoading] = useState(true);
 
+    // Quick session restoration from localStorage before Firebase check
+    useEffect(() => {
+        const restoreSessionFromStorage = async () => {
+            const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+            const cachedUser = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
+
+            if (token && cachedUser) {
+                try {
+                    const userData = JSON.parse(cachedUser);
+                    // Quick validation of token with BFF (200ms timeout)
+                    try {
+                        const response = await Promise.race([
+                            api.get('/v1/auth/check'),
+                            new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 200))
+                        ]);
+
+                        if (response.data?.success && response.data?.user) {
+                            setUser(userData);
+                            setIsLoading(false);
+                            return;
+                        }
+                    } catch {
+                        // Token validation failed or timed out, will retry with Firebase
+                    }
+                } catch {
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
+                }
+            }
+        };
+
+        restoreSessionFromStorage();
+    }, []);
+
     // Listen to Firebase auth state changes for automatic session restore
     useEffect(() => {
         if (!auth || !hasFirebaseConfig) {

--- a/microfrontends/apps/mf-admin/services/api.ts
+++ b/microfrontends/apps/mf-admin/services/api.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { csrfService } from './csrfService';
 import { getApiBaseUrl } from '../config/api.config';
 import { auth } from '../src/lib/firebase';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 // Configuración base de axios - Using nginx gateway for microservices
 // NO baseURL here - will be set in request interceptor for runtime detection
@@ -61,11 +62,11 @@ api.interceptors.request.use(
                     const idToken = await currentUser.getIdToken();
                     config.headers.Authorization = `Bearer ${idToken}`;
                 } catch {
-                    const token = localStorage.getItem('auth_token');
+                    const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
                     if (token) config.headers.Authorization = `Bearer ${token}`;
                 }
             } else {
-                const token = localStorage.getItem('auth_token') || localStorage.getItem('professor_token');
+                const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN)) || localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
                 if (token) config.headers.Authorization = `Bearer ${token}`;
             }
         }
@@ -126,16 +127,16 @@ api.interceptors.response.use(
                 console.warn('JWT token expired or invalid - cleaning session');
 
                 // Limpiar token de usuario regular
-                localStorage.removeItem('auth_token');
-                localStorage.removeItem('authenticated_user');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
 
                 // Limpiar token de profesor
-                localStorage.removeItem('professor_token');
-                localStorage.removeItem('professor_user');
-                localStorage.removeItem('currentProfessor');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
 
                 // Solo redirigir si no estamos ya en una página de login o si no es una ruta pública
-                const currentPath = window.location.hash || window.location.pathname;
+                const currentPath = window.location.pathname;
                 const isLoginPage = currentPath.includes('/login') || currentPath === '/';
                 const requestUrl = error.config?.url || '';
                 const isPublicRoute = requestUrl.includes('/public/') ||
@@ -146,7 +147,11 @@ api.interceptors.response.use(
                     console.warn('Redirecting to login due to expired token');
                     // Usar setTimeout para evitar problemas con el contexto de React
                     setTimeout(() => {
-                        window.location.href = '/#/login';
+                        if (currentPath.includes('/admin') || currentPath.includes('/profesor')) {
+                            window.location.href = '/admin/login';
+                        } else {
+                            window.location.href = '/login';
+                        }
                     }, 100);
                 }
             }

--- a/microfrontends/apps/mf-admin/services/applicationService.ts
+++ b/microfrontends/apps/mf-admin/services/applicationService.ts
@@ -1,5 +1,6 @@
 import api from './api';
 import { DataAdapter } from './dataAdapter';
+import { extractBffList } from '../src/api/bffResponse';
 
 export interface ApplicationRequest {
     // Datos del estudiante
@@ -71,6 +72,9 @@ export interface Application {
         email?: string;
         address?: string;
         gradeApplied?: string;
+        /** Alias BFF / columna grade_applied */
+        gradeApplying?: string;
+        grade?: string;
         currentSchool?: string;
         additionalNotes?: string;
         // Campos de categorías especiales
@@ -123,6 +127,28 @@ export interface Application {
     documents?: any[];
 }
 
+/** Filtros alineados a GET /v1/applications del BFF (page, size, status, gradeApplying, search). */
+export interface GetApplicationsFilters {
+    page?: number;
+    size?: number;
+    limit?: number;
+    status?: string;
+    gradeApplying?: string;
+    search?: string;
+    /** Reservado: el BFF actual no filtra por año en este endpoint. */
+    applicationYear?: number;
+    /** Reservado: el BFF actual no filtra por RUT apoderado en este endpoint. */
+    guardianRUT?: string;
+}
+
+export interface ApplicationsPageResponse {
+    applications: Application[];
+    totalElements: number;
+    totalPages: number;
+    page: number;
+    size: number;
+}
+
 class ApplicationService {
 
     // Helper function to transform frontend grade format to backend format
@@ -149,63 +175,64 @@ class ApplicationService {
         return gradeMap[grade] || grade.toUpperCase().replace('BASICO', '_BASICO').replace('MEDIO', '_MEDIO');
     }
 
-    // Método mejorado para administradores: obtener todas las postulaciones desde microservicio
-    async getAllApplications(): Promise<Application[]> {
+    /**
+     * Página de postulaciones (misma semántica que el ex–Node: lista + total + filtros).
+     * BFF: GET /v1/applications → Spring Page (`content`, `totalElements`, `totalPages`, …).
+     */
+    async fetchApplicationsPage(filters: GetApplicationsFilters = {}): Promise<ApplicationsPageResponse> {
+        const page = filters.page ?? 0;
+        const size = filters.size ?? filters.limit ?? 15;
+        const params: Record<string, string | number> = { page, size };
+        if (filters.status) params.status = filters.status;
+        if (filters.gradeApplying) params.gradeApplying = filters.gradeApplying;
+        if (filters.search) params.search = filters.search;
+
         try {
-            console.log('Admin: Obteniendo postulaciones desde microservicio');
+            const response = await api.get('/v1/applications', { params });
+            const body = response.data as Record<string, unknown>;
+            const applications = extractBffList<Application>(body);
+            const totalElements =
+                typeof body.totalElements === 'number' ? (body.totalElements as number) : applications.length;
+            const totalPages =
+                typeof body.totalPages === 'number'
+                    ? (body.totalPages as number)
+                    : Math.max(1, Math.ceil(totalElements / Math.max(1, size)));
+            return {
+                applications,
+                totalElements,
+                totalPages,
+                page: typeof body.number === 'number' ? (body.number as number) : page,
+                size: typeof body.size === 'number' ? (body.size as number) : size
+            };
+        } catch (mainError) {
+            console.warn('fetchApplicationsPage: falló /v1/applications, intentando público…', mainError);
+            const response = await api.get('/v1/applications/public/all', {
+                params: { page, limit: size }
+            });
+            const adapted = DataAdapter.adaptApplicationApiResponse(response) as Application[];
+            return {
+                applications: adapted,
+                totalElements: adapted.length,
+                totalPages: 1,
+                page: 0,
+                size: adapted.length
+            };
+        }
+    }
 
-            // Primero intentar el endpoint principal que devuelve la estructura completa
-            try {
-                console.log('Probando endpoint principal: /v1/applications');
-                // BFF espera parámetro 'size' (no 'limit') para el tamaño de página
-                const response = await api.get('/v1/applications?size=1000');
-                console.log('Respuesta del endpoint principal:', response.data);
-
-                // El backend devuelve {success: true, data: [...]}
-                const applications = response.data?.data || response.data || [];
-                console.log('Aplicaciones recibidas:', applications.length);
-
-                // El endpoint /v1/applications ya devuelve la estructura correcta
-                // No necesitamos adaptador, solo filtrar las aplicaciones válidas
-                const validApplications = applications.filter((app: any) =>
-                    app &&
-                    app.id &&
-                    app.student &&
-                    app.student.firstName &&
-                    app.student.lastName &&
-                    app.student.firstName !== null &&
-                    app.student.lastName !== null
-                );
-
-                console.log('Aplicaciones válidas filtradas:', validApplications.length);
-                if (validApplications.length > 0) {
-                    console.log('Primera aplicación completa:', validApplications[0]);
-                    console.log('Student object:', validApplications[0]?.student);
-                    console.log('firstName:', validApplications[0]?.student?.firstName);
-                    console.log('lastName:', validApplications[0]?.student?.lastName);
-                    console.log('paternalLastName:', validApplications[0]?.student?.paternalLastName);
-                    console.log('maternalLastName:', validApplications[0]?.student?.maternalLastName);
-                }
-                return validApplications;
-
-            } catch (mainError) {
-                console.log('Falló endpoint principal, intentando público...');
-
-                // Como fallback, usar el endpoint público con adaptador si es necesario
-                const response = await api.get('/v1/applications/public/all');
-                console.log('Éxito con endpoint público:', response.data);
-
-                // Este endpoint devuelve formato diferente, usar adaptador
-                const adaptedApplications = DataAdapter.adaptApplicationApiResponse(response);
-                console.log('Aplicaciones adaptadas desde público:', adaptedApplications.length);
-                return adaptedApplications;
-            }
-
+    /** Lista plana (compatibilidad). Por defecto pide hasta 2000 filas en página 0. */
+    async getAllApplications(filters?: GetApplicationsFilters): Promise<Application[]> {
+        try {
+            const { applications } = await this.fetchApplicationsPage({
+                page: filters?.page ?? 0,
+                size: filters?.size ?? filters?.limit ?? 2000,
+                status: filters?.status,
+                gradeApplying: filters?.gradeApplying,
+                search: filters?.search
+            });
+            return applications.filter((app) => app?.id && app?.student);
         } catch (error: any) {
             console.error('Error obteniendo postulaciones desde microservicio:', error);
-
-            // Como fallback, devolver un array vacío
-            console.log('Devolviendo array vacío como fallback');
             return [];
         }
     }
@@ -231,7 +258,9 @@ class ApplicationService {
             }, {} as Record<string, number>);
             
             const applicationsByGrade = applications.reduce((acc, app) => {
-                const grade = app.student?.gradeApplied || 'Sin especificar';
+                const st = app.student as Record<string, string | undefined> | undefined;
+                const grade =
+                    st?.gradeApplied || st?.gradeApplying || (st as { grade?: string })?.grade || 'Sin especificar';
                 acc[grade] = (acc[grade] || 0) + 1;
                 return acc;
             }, {} as Record<string, number>);

--- a/microfrontends/apps/mf-admin/services/applicationTableMapper.ts
+++ b/microfrontends/apps/mf-admin/services/applicationTableMapper.ts
@@ -1,0 +1,82 @@
+/**
+ * Adapta postulaciones del BFF (y formato compatible con el ex–Node) al modelo de tablas admin.
+ * El listado del BFF expone student.*, guardian.*, status enum JPA; el front legacy esperaba
+ * shape similar a Application.toJSON() del application-service Node.
+ */
+
+/** Estados del BFF → etiquetas usadas en ApplicationsDataTable (subset legacy). */
+export function mapBffApplicationStatusToTable(
+  status: string | undefined
+): 'DRAFT' | 'SUBMITTED' | 'UNDER_REVIEW' | 'INTERVIEW_SCHEDULED' | 'ACCEPTED' | 'REJECTED' | 'WAITLIST' {
+  const s = (status || '').toUpperCase();
+  switch (s) {
+    case 'PENDING':
+    case 'SUBMITTED':
+      return 'SUBMITTED';
+    case 'UNDER_REVIEW':
+    case 'DOCUMENTS_REQUESTED':
+    case 'PENDING_DOCUMENTS':
+    case 'INCOMPLETE':
+    case 'EXAM_SCHEDULED':
+      return 'UNDER_REVIEW';
+    case 'INTERVIEW_SCHEDULED':
+      return 'INTERVIEW_SCHEDULED';
+    case 'APPROVED':
+      return 'ACCEPTED';
+    case 'REJECTED':
+      return 'REJECTED';
+    case 'WAITLIST':
+      return 'WAITLIST';
+    case 'ARCHIVED':
+      return 'REJECTED';
+    default:
+      return 'UNDER_REVIEW';
+  }
+}
+
+export function buildStudentDisplayName(student: Record<string, unknown> | null | undefined): string {
+  if (!student) return 'Sin nombre';
+  const full = String(student.fullName || '').trim();
+  if (full) return full;
+  const first = String(student.firstName || '').trim();
+  const last = String(student.lastName || '').trim();
+  if (last) return `${first} ${last}`.trim() || last;
+  const p = String(student.paternalLastName || '').trim();
+  const m = String(student.maternalLastName || '').trim();
+  const combined = [first, p, m].filter(Boolean).join(' ').trim();
+  return combined || 'Sin nombre';
+}
+
+/** Grado: BFF usa gradeApplying / gradeApplied / grade (misma columna grade_applied). */
+export function buildGradeDisplay(student: Record<string, unknown> | null | undefined): string {
+  const raw = String(
+    student?.gradeApplying || student?.gradeApplied || student?.grade || ''
+  ).trim();
+  if (!raw) return '—';
+  return raw
+    .replace(/_/g, ' ')
+    .toLowerCase()
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function buildGuardianContact(app: Record<string, unknown>): {
+  parentName: string;
+  parentEmail: string;
+  parentPhone: string;
+} {
+  const guardian = (app.guardian || null) as Record<string, string> | null;
+  const father = (app.father || null) as Record<string, string> | null;
+  const mother = (app.mother || null) as Record<string, string> | null;
+
+  const gName = guardian?.fullName?.trim();
+  const fName = father?.fullName?.trim();
+  const mName = mother?.fullName?.trim();
+
+  const parentName = gName || fName || mName || 'No especificado';
+  const parentEmail =
+    guardian?.email || father?.email || mother?.email || 'No especificado';
+  const parentPhone =
+    guardian?.phone || father?.phone || mother?.phone || 'No especificado';
+
+  return { parentName, parentEmail, parentPhone };
+}

--- a/microfrontends/apps/mf-admin/services/authService.ts
+++ b/microfrontends/apps/mf-admin/services/authService.ts
@@ -5,6 +5,7 @@ import {
     signOut,
 } from 'firebase/auth';
 import { auth } from '../src/lib/firebase';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 export interface LoginRequest {
     email: string;
@@ -64,7 +65,7 @@ class AuthService {
             const data = response.data;
 
             // 3. Store the Firebase idToken for immediate use until interceptor takes over
-            localStorage.setItem('auth_token', idToken);
+            localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
             return {
                 success: true,
@@ -104,7 +105,7 @@ class AuthService {
             });
             const data = response.data;
 
-            localStorage.setItem('auth_token', idToken);
+            localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
             return {
                 success: true,
@@ -141,8 +142,8 @@ class AuthService {
         } catch (e) {
             // Ignore Firebase signOut errors
         }
-        localStorage.removeItem('auth_token');
-        localStorage.removeItem('authenticated_user');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
     }
 }
 

--- a/microfrontends/apps/mf-admin/services/dataService.ts
+++ b/microfrontends/apps/mf-admin/services/dataService.ts
@@ -1,5 +1,6 @@
 import api from './api';
 import { applicationService } from './applicationService';
+import { extractBffList } from '../src/api/bffResponse';
 
 // Interfaces centralizadas
 export interface DataServiceResponse<T> {
@@ -109,9 +110,14 @@ class DataService {
             const response = await api.get(`/v1/evaluations`, {
                 params: { page, size }
             });
-            
-            // Transformar datos del backend
-            const evaluations = response.data.map(this.transformBackendToEvaluation);
+
+            const rawList = extractBffList(response.data);
+            const evaluations = rawList.map((row) =>
+                this.transformBackendToEvaluation({
+                    ...row,
+                    evaluationType: (row as any).evaluationType || (row as any).type
+                })
+            );
             console.log(`Evaluaciones cargadas: ${evaluations.length}`);
             
             return evaluations;
@@ -131,7 +137,7 @@ class DataService {
             studentRut: backendEval.application?.student?.rut || 'N/A',
             gradeApplied: backendEval.grade || backendEval.application?.student?.gradeApplied || 'N/A',
             applicationStatus: backendEval.application?.status || 'PENDING',
-            evaluationType: backendEval.evaluationType,
+            evaluationType: backendEval.evaluationType || backendEval.type,
             status: backendEval.status,
             score: backendEval.score,
             evaluationDate: backendEval.evaluationDate,

--- a/microfrontends/apps/mf-admin/services/evaluationService.ts
+++ b/microfrontends/apps/mf-admin/services/evaluationService.ts
@@ -397,11 +397,12 @@ class EvaluationService {
 
             const response = await api.get(`/v1/evaluations/application/${applicationId}`);
 
-            // Backend returns { success: true, data: [...] }
-            const evaluations = response.data.data || response.data;
-            // console.log(`${evaluations.length} evaluaciones obtenidas`);
-            // console.log('Evaluaciones:', evaluations);
-            return evaluations;
+            const raw = response.data?.data ?? response.data;
+            const list = Array.isArray(raw) ? raw : [];
+            return list.map((e: Record<string, unknown>) => ({
+                ...e,
+                evaluationType: (e.evaluationType || e.type) as string
+            })) as Evaluation[];
         } catch (error: any) {
             console.error('Error obteniendo evaluaciones por application:', error);
             throw new Error(

--- a/microfrontends/apps/mf-admin/services/evaluatorService.ts
+++ b/microfrontends/apps/mf-admin/services/evaluatorService.ts
@@ -156,7 +156,12 @@ export const evaluatorService = {
   async getEvaluationsByApplication(applicationId: number): Promise<Evaluation[]> {
     try {
       const response = await api.get(`/v1/evaluations/application/${applicationId}`);
-      return response.data;
+      const raw = response.data?.data ?? response.data;
+      const list = Array.isArray(raw) ? raw : [];
+      return list.map((e: Record<string, unknown>) => ({
+        ...e,
+        evaluationType: (e.evaluationType || e.type) as string
+      })) as Evaluation[];
     } catch (error) {
       console.error('Error getting evaluations by application:', error);
       throw error;

--- a/microfrontends/apps/mf-admin/services/http.ts
+++ b/microfrontends/apps/mf-admin/services/http.ts
@@ -7,6 +7,7 @@ import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosError } f
 import { oidcService } from './oidcService';
 import { getApiBaseUrl } from '../config/api.config';
 import { csrfService } from './csrfService';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 // Tipos
 interface RetryConfig {
@@ -154,12 +155,12 @@ class HttpClient {
   private async getAccessToken(): Promise<string | null> {
     try {
       // Primero intentar obtener el token de usuario regular (apoderado)
-      let token = localStorage.getItem('auth_token');
+      let token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
       console.log('http.ts - auth_token:', token ? `${token.substring(0, 20)}...` : 'NOT FOUND');
 
       // Si no hay token de usuario regular, intentar con token de profesor
       if (!token) {
-        token = localStorage.getItem('professor_token');
+        token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
         console.log('http.ts - professor_token:', token ? `${token.substring(0, 20)}...` : 'NOT FOUND');
       }
 
@@ -257,8 +258,8 @@ class HttpClient {
       console.warn('Session invalidated - User logged in from another device');
 
       // Clear ALL tokens
-      localStorage.removeItem('auth_token');
-      localStorage.removeItem('professor_token');
+      localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+      localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
       sessionStorage.clear();
 
       // Show alert to user
@@ -294,7 +295,7 @@ class HttpClient {
     const currentPath = window.location.pathname + window.location.search;
     sessionStorage.setItem('redirectAfterLogin', currentPath);
     
-    window.location.href = '/#/login';
+    window.location.href = '/login';
   }
 
   private createHttpError(error: AxiosError, correlationId?: string): HttpError {

--- a/microfrontends/apps/mf-admin/services/microservicesService.ts
+++ b/microfrontends/apps/mf-admin/services/microservicesService.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { getApiBaseUrl } from '../config/api.config';
+import { extractBffList } from '../src/api/bffResponse';
 
 /**
  * Servicio para conectar el frontend con la arquitectura de microservicios REAL
@@ -198,14 +199,12 @@ export class MicroservicesService {
   async getApplicationsFromMicroservice(): Promise<any[]> {
     try {
       console.log('Obteniendo aplicaciones del microservicio real...');
-      const response = await axios.get(APPLICATION_SERVICE_URL);
-      
-      if (response.data.success) {
-        console.log('Aplicaciones obtenidas del microservicio:', response.data.data);
-        return response.data.data;
-      } else {
-        throw new Error('Invalid response format');
+      const response = await axios.get(APPLICATION_SERVICE_URL, { params: { size: 500, page: 0 } });
+      const body = response.data;
+      if (body?.success && Array.isArray(body.data)) {
+        return body.data;
       }
+      return extractBffList(body);
     } catch (error) {
       console.error('Error obteniendo aplicaciones del microservicio:', error);
       throw new Error('No se pudieron obtener aplicaciones del microservicio');

--- a/microfrontends/apps/mf-admin/services/professorAuthService.ts
+++ b/microfrontends/apps/mf-admin/services/professorAuthService.ts
@@ -1,4 +1,5 @@
 import api from './api';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 // RSA encryption removed - credentials sent over HTTPS only
 // import encryptionService from './encryptionService';
 
@@ -45,9 +46,9 @@ class ProfessorAuthService {
 
             // Guardar token en localStorage
             if (data.token) {
-                localStorage.setItem('professor_token', data.token);
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN), data.token);
                 const u = data.user;
-                localStorage.setItem('professor_user', JSON.stringify({
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER), JSON.stringify({
                     email: u?.email || data.email,
                     firstName: u?.firstName || data.firstName,
                     lastName: u?.lastName || data.lastName,
@@ -75,7 +76,7 @@ class ProfessorAuthService {
     
     async getCurrentProfessor(): Promise<ProfessorUser | null> {
         try {
-            const token = localStorage.getItem('professor_token');
+            const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
             if (!token) {
                 return null;
             }
@@ -100,19 +101,19 @@ class ProfessorAuthService {
     }
     
     isAuthenticated(): boolean {
-        const token = localStorage.getItem('professor_token');
+        const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
         return !!token;
     }
     
     getStoredProfessor() {
-        const stored = localStorage.getItem('professor_user');
+        const stored = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
         return stored ? JSON.parse(stored) : null;
     }
     
     logout() {
-        localStorage.removeItem('professor_token');
-        localStorage.removeItem('professor_user');
-        localStorage.removeItem('currentProfessor');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
     }
     
     // Método para verificar si el usuario es un profesor válido

--- a/microfrontends/apps/mf-admin/src/api/applications.client.ts
+++ b/microfrontends/apps/mf-admin/src/api/applications.client.ts
@@ -4,6 +4,7 @@
  */
 
 import httpClient from '../../services/http';
+import { extractBffList, unwrapBffData } from './bffResponse';
 import type {
   Application,
   CreateApplicationRequest,
@@ -20,64 +21,48 @@ export class ApplicationsClient {
    * Get all applications with optional filtering and pagination
    */
   async getApplications(params?: ApplicationSearchParams): Promise<PaginatedResponse<Application>> {
-    const response = await httpClient.get(
-      this.basePath,
-      { params }
-    );
-    return response.data as PaginatedResponse<Application>;
+    const body = await httpClient.get(this.basePath, { params });
+    return body as PaginatedResponse<Application>;
   }
 
   /**
    * Get public applications (for admin dashboard)
    */
   async getPublicApplications(params?: ApplicationSearchParams): Promise<Application[]> {
-    const response = await httpClient.get<{ success: boolean; data: Application[] }>(
-      `${this.basePath}/public/all`,
-      { params }
-    );
-    return (response.data as any).data;
+    const body = await httpClient.get(`${this.basePath}/public/all`, { params });
+    return unwrapBffData<Application[]>(body);
   }
 
   /**
    * Get application by ID with full details
    */
   async getApplicationById(id: number): Promise<Application> {
-    const response = await httpClient.get(
-      `${this.basePath}/${id}`
-    );
-    return response.data as Application;
+    const body = await httpClient.get(`${this.basePath}/${id}`);
+    return unwrapBffData<Application>(body);
   }
 
   /**
    * Create new application
    */
   async createApplication(applicationData: CreateApplicationRequest): Promise<Application> {
-    const response = await httpClient.post<{ success: boolean; data: Application }>(
-      this.basePath,
-      applicationData
-    );
-    return (response.data as any).data;
+    const body = await httpClient.post(this.basePath, applicationData);
+    return unwrapBffData<Application>(body);
   }
 
   /**
    * Update application status and details
    */
   async updateApplication(id: number, applicationData: UpdateApplicationRequest): Promise<Application> {
-    const response = await httpClient.put<{ success: boolean; data: Application }>(
-      `${this.basePath}/${id}`,
-      applicationData
-    );
-    return (response.data as any).data;
+    const body = await httpClient.put(`${this.basePath}/${id}`, applicationData);
+    return unwrapBffData<Application>(body);
   }
 
   /**
    * Archive application (admin only)
    */
   async archiveApplication(id: number): Promise<Application> {
-    const response = await httpClient.put<{ success: boolean; data: Application }>(
-      `${this.basePath}/${id}/archive`
-    );
-    return (response.data as any).data;
+    const body = await httpClient.put(`${this.basePath}/${id}/archive`);
+    return unwrapBffData<Application>(body);
   }
 
   /**
@@ -94,31 +79,24 @@ export class ApplicationsClient {
     status: Application['status'], 
     params?: Omit<ApplicationSearchParams, 'status'>
   ): Promise<Application[]> {
-    const response = await httpClient.get(
-      `${this.basePath}/status/${status}`,
-      { params }
-    );
-    return (response.data?.content || response.data?.data || []) as Application[];
+    const body = await httpClient.get(`${this.basePath}/status/${status}`, { params });
+    return extractBffList<Application>(body);
   }
 
   /**
    * Get applications by user (for families)
    */
   async getUserApplications(userId: number): Promise<Application[]> {
-    const response = await httpClient.get<{ success: boolean; data: Application[] }>(
-      `${this.basePath}/user/${userId}`
-    );
-    return (response.data as any).data;
+    const body = await httpClient.get(`${this.basePath}/user/${userId}`);
+    return unwrapBffData<Application[]>(body);
   }
 
   /**
    * Get application statistics (admin only)
    */
   async getApplicationStatistics(): Promise<ApplicationStatistics> {
-    const response = await httpClient.get<{ success: boolean; data: ApplicationStatistics }>(
-      `${this.basePath}/statistics`
-    );
-    return (response.data as any).data;
+    const body = await httpClient.get(`${this.basePath}/statistics`);
+    return unwrapBffData<ApplicationStatistics>(body);
   }
 
   /**
@@ -128,31 +106,24 @@ export class ApplicationsClient {
     query: string, 
     params?: Omit<ApplicationSearchParams, 'studentName'>
   ): Promise<Application[]> {
-    const response = await httpClient.get<{ success: boolean; data: Application[] }>(
-      `${this.basePath}/search`,
-      { params: { query, ...params } }
-    );
-    return (response.data as any).data;
+    const body = await httpClient.get(`${this.basePath}/search`, { params: { query, ...params } });
+    return unwrapBffData<Application[]>(body);
   }
 
   /**
    * Get applications requiring evaluation
    */
   async getApplicationsForEvaluation(evaluatorId: number): Promise<Application[]> {
-    const response = await httpClient.get<{ success: boolean; data: Application[] }>(
-      `${this.basePath}/for-evaluation/${evaluatorId}`
-    );
-    return (response.data as any).data;
+    const body = await httpClient.get(`${this.basePath}/for-evaluation/${evaluatorId}`);
+    return unwrapBffData<Application[]>(body);
   }
 
   /**
    * Get applications with special categories
    */
   async getSpecialCategoryApplications(category: 'employee' | 'alumni' | 'inclusion'): Promise<Application[]> {
-    const response = await httpClient.get<{ success: boolean; data: Application[] }>(
-      `${this.basePath}/special-category/${category}`
-    );
-    return (response.data as any).data;
+    const body = await httpClient.get(`${this.basePath}/special-category/${category}`);
+    return unwrapBffData<Application[]>(body);
   }
 
   /**
@@ -177,32 +148,24 @@ export class ApplicationsClient {
     applicationIds: number[], 
     status: Application['status']
   ): Promise<Application[]> {
-    const response = await httpClient.post<{ success: boolean; data: Application[] }>(
-      `${this.basePath}/bulk/update-status`,
-      { applicationIds, status }
-    );
-    return (response.data as any).data;
+    const body = await httpClient.post(`${this.basePath}/bulk/update-status`, { applicationIds, status });
+    return unwrapBffData<Application[]>(body);
   }
 
   /**
    * Get applications requiring documents
    */
   async getApplicationsRequiringDocuments(): Promise<Application[]> {
-    const response = await httpClient.get<{ success: boolean; data: Application[] }>(
-      `${this.basePath}/requiring-documents`
-    );
-    return (response.data as any).data;
+    const body = await httpClient.get(`${this.basePath}/requiring-documents`);
+    return unwrapBffData<Application[]>(body);
   }
 
   /**
    * Get recent applications (last 7 days)
    */
   async getRecentApplications(days: number = 7): Promise<Application[]> {
-    const response = await httpClient.get<{ success: boolean; data: Application[] }>(
-      `${this.basePath}/recent`,
-      { params: { days } }
-    );
-    return (response.data as any).data;
+    const body = await httpClient.get(`${this.basePath}/recent`, { params: { days } });
+    return unwrapBffData<Application[]>(body);
   }
 }
 

--- a/microfrontends/apps/mf-admin/src/api/bffResponse.ts
+++ b/microfrontends/apps/mf-admin/src/api/bffResponse.ts
@@ -1,0 +1,79 @@
+/**
+ * Parseo de respuestas admitia-bff.
+ *
+ * `services/http.ts` (import `../../services/http`) devuelve ya el cuerpo JSON
+ * (= `axiosResponse.data`), no el `AxiosResponse` completo.
+ */
+
+import type { PaginatedResponse } from './evaluations.types';
+
+export function isSpringPage<T = unknown>(
+  body: unknown
+): body is { content: T[] } & Record<string, unknown> {
+  return (
+    body !== null &&
+    typeof body === 'object' &&
+    Array.isArray((body as { content: unknown }).content)
+  );
+}
+
+/**
+ * Lista desde página Spring (`content`) o envoltorio `{ data: [] }` o un array suelto.
+ * Útil también con `axios`: pasar `response.data`.
+ */
+export function extractBffList<T = unknown>(body: unknown): T[] {
+  if (isSpringPage<T>(body)) {
+    return body.content;
+  }
+  const o = body as { data?: unknown } | null;
+  if (o && Array.isArray(o.data)) {
+    return o.data as T[];
+  }
+  if (Array.isArray(body)) {
+    return body as T[];
+  }
+  return [];
+}
+
+/**
+ * Quita `{ success, data }` / `{ success, data, count }` sin romper páginas Spring
+ * ni cuerpos planos (p. ej. GET /v1/applications/:id).
+ */
+export function unwrapBffData<T>(body: unknown): T {
+  if (body === null || typeof body !== 'object') {
+    return body as T;
+  }
+  const o = body as Record<string, unknown>;
+  if (isSpringPage(body)) {
+    return body as T;
+  }
+  if ('data' in o && o.data !== undefined) {
+    if (o.success === true || o.success === false) {
+      return o.data as T;
+    }
+    if (typeof o.count === 'number' && Array.isArray(o.data)) {
+      return o.data as T;
+    }
+  }
+  return body as T;
+}
+
+/** Normaliza GET /v1/evaluations cuando el BFF devuelve `{ success, data, content, count }`. */
+export function evaluationsToPaginated<T>(body: Record<string, unknown>): PaginatedResponse<T> {
+  const content = (
+    Array.isArray(body.content) ? body.content : Array.isArray(body.data) ? body.data : []
+  ) as T[];
+  const n = content.length;
+  const count = typeof body.count === 'number' ? body.count : n;
+  return {
+    content,
+    totalElements: typeof body.totalElements === 'number' ? (body.totalElements as number) : count,
+    totalPages: typeof body.totalPages === 'number' ? (body.totalPages as number) : 1,
+    size: typeof body.size === 'number' ? (body.size as number) : n,
+    number: typeof body.number === 'number' ? (body.number as number) : 0,
+    first: body.first !== false,
+    last: body.last !== false,
+    numberOfElements: typeof body.numberOfElements === 'number' ? (body.numberOfElements as number) : n,
+    empty: n === 0
+  };
+}

--- a/microfrontends/apps/mf-admin/src/api/evaluations.client.ts
+++ b/microfrontends/apps/mf-admin/src/api/evaluations.client.ts
@@ -4,6 +4,7 @@
  */
 
 import httpClient from '../../services/http';
+import { evaluationsToPaginated, unwrapBffData } from './bffResponse';
 import type {
   Evaluation,
   CreateEvaluationRequest,
@@ -21,43 +22,35 @@ export class EvaluationsClient {
    * Get all evaluations with optional filtering and pagination
    */
   async getEvaluations(params?: EvaluationSearchParams): Promise<PaginatedResponse<Evaluation>> {
-    const response = await httpClient.get(
-      this.basePath,
-      { params }
-    );
-    return response.data as PaginatedResponse<Evaluation>;
+    const body = (await httpClient.get(this.basePath, { params })) as Record<string, unknown>;
+    if (Array.isArray(body.content) || Array.isArray(body.data)) {
+      return evaluationsToPaginated<Evaluation>(body);
+    }
+    return body as PaginatedResponse<Evaluation>;
   }
 
   /**
    * Get evaluation by ID
    */
   async getEvaluationById(id: number): Promise<Evaluation> {
-    const response = await httpClient.get<{ success: boolean; data: Evaluation }>(
-      `${this.basePath}/${id}`
-    );
-    return (response.data as any).data;
+    const body = await httpClient.get(`${this.basePath}/${id}`);
+    return unwrapBffData<Evaluation>(body);
   }
 
   /**
    * Create new evaluation
    */
   async createEvaluation(evaluationData: CreateEvaluationRequest): Promise<Evaluation> {
-    const response = await httpClient.post<{ success: boolean; data: Evaluation }>(
-      this.basePath,
-      evaluationData
-    );
-    return (response.data as any).data;
+    const body = await httpClient.post(this.basePath, evaluationData);
+    return unwrapBffData<Evaluation>(body);
   }
 
   /**
    * Update evaluation with scores and comments
    */
   async updateEvaluation(id: number, evaluationData: UpdateEvaluationRequest): Promise<Evaluation> {
-    const response = await httpClient.put<{ success: boolean; data: Evaluation }>(
-      `${this.basePath}/${id}`,
-      evaluationData
-    );
-    return (response.data as any).data;
+    const body = await httpClient.put(`${this.basePath}/${id}`, evaluationData);
+    return unwrapBffData<Evaluation>(body);
   }
 
   /**
@@ -74,21 +67,16 @@ export class EvaluationsClient {
     id: number, 
     data: { score: number; maxScore: number; comments?: string; recommendations?: string }
   ): Promise<Evaluation> {
-    const response = await httpClient.post<{ success: boolean; data: Evaluation }>(
-      `${this.basePath}/${id}/complete`,
-      data
-    );
-    return (response.data as any).data;
+    const body = await httpClient.post(`${this.basePath}/${id}/complete`, data);
+    return unwrapBffData<Evaluation>(body);
   }
 
   /**
    * Get evaluations by application
    */
   async getEvaluationsByApplication(applicationId: number): Promise<Evaluation[]> {
-    const response = await httpClient.get<{ success: boolean; data: Evaluation[] }>(
-      `${this.basePath}/application/${applicationId}`
-    );
-    return (response.data as any).data;
+    const body = await httpClient.get(`${this.basePath}/application/${applicationId}`);
+    return unwrapBffData<Evaluation[]>(body);
   }
 
   /**
@@ -98,11 +86,8 @@ export class EvaluationsClient {
     evaluatorId: number, 
     params?: Omit<EvaluationSearchParams, 'evaluatorId'>
   ): Promise<Evaluation[]> {
-    const response = await httpClient.get<{ success: boolean; data: Evaluation[] }>(
-      `${this.basePath}/evaluator/${evaluatorId}`,
-      { params }
-    );
-    return (response.data as any).data;
+    const body = await httpClient.get(`${this.basePath}/evaluator/${evaluatorId}`, { params });
+    return unwrapBffData<Evaluation[]>(body);
   }
 
   /**
@@ -112,11 +97,8 @@ export class EvaluationsClient {
     type: Evaluation['type'],
     params?: Omit<EvaluationSearchParams, 'type'>
   ): Promise<Evaluation[]> {
-    const response = await httpClient.get<{ success: boolean; data: Evaluation[] }>(
-      `${this.basePath}/type/${type}`,
-      { params }
-    );
-    return (response.data as any).data;
+    const body = await httpClient.get(`${this.basePath}/type/${type}`, { params });
+    return unwrapBffData<Evaluation[]>(body);
   }
 
   /**
@@ -126,84 +108,64 @@ export class EvaluationsClient {
     subject: Evaluation['subject'],
     educationalLevel?: Evaluation['educationalLevel']
   ): Promise<Evaluation[]> {
-    const response = await httpClient.get<{ success: boolean; data: Evaluation[] }>(
-      `${this.basePath}/subject/${subject}`,
-      { params: { educationalLevel } }
-    );
-    return (response.data as any).data;
+    const body = await httpClient.get(`${this.basePath}/subject/${subject}`, { params: { educationalLevel } });
+    return unwrapBffData<Evaluation[]>(body);
   }
 
   /**
    * Get pending evaluations for evaluator
    */
   async getPendingEvaluations(evaluatorId: number): Promise<Evaluation[]> {
-    const response = await httpClient.get<{ success: boolean; data: Evaluation[] }>(
-      `${this.basePath}/evaluator/${evaluatorId}/pending`
-    );
-    return (response.data as any).data;
+    const body = await httpClient.get(`${this.basePath}/evaluator/${evaluatorId}/pending`);
+    return unwrapBffData<Evaluation[]>(body);
   }
 
   /**
    * Get completed evaluations for evaluator
    */
   async getCompletedEvaluations(evaluatorId: number): Promise<Evaluation[]> {
-    const response = await httpClient.get<{ success: boolean; data: Evaluation[] }>(
-      `${this.basePath}/evaluator/${evaluatorId}/completed`
-    );
-    return (response.data as any).data;
+    const body = await httpClient.get(`${this.basePath}/evaluator/${evaluatorId}/completed`);
+    return unwrapBffData<Evaluation[]>(body);
   }
 
   /**
    * Get evaluation statistics
    */
   async getEvaluationStatistics(): Promise<EvaluationStatistics> {
-    const response = await httpClient.get<{ success: boolean; data: EvaluationStatistics }>(
-      `${this.basePath}/statistics`
-    );
-    return (response.data as any).data;
+    const body = await httpClient.get(`${this.basePath}/statistics`);
+    return unwrapBffData<EvaluationStatistics>(body);
   }
 
   /**
    * Get evaluator workload and assignments
    */
   async getEvaluatorAssignments(): Promise<EvaluatorAssignment[]> {
-    const response = await httpClient.get<{ success: boolean; data: EvaluatorAssignment[] }>(
-      `${this.basePath}/assignments`
-    );
-    return (response.data as any).data;
+    const body = await httpClient.get(`${this.basePath}/assignments`);
+    return unwrapBffData<EvaluatorAssignment[]>(body);
   }
 
   /**
    * Assign evaluation to evaluator
    */
   async assignEvaluator(evaluationId: number, evaluatorId: number): Promise<Evaluation> {
-    const response = await httpClient.post<{ success: boolean; data: Evaluation }>(
-      `${this.basePath}/${evaluationId}/assign`,
-      { evaluatorId }
-    );
-    return (response.data as any).data;
+    const body = await httpClient.post(`${this.basePath}/${evaluationId}/assign`, { evaluatorId });
+    return unwrapBffData<Evaluation>(body);
   }
 
   /**
    * Reschedule evaluation
    */
   async rescheduleEvaluation(id: number, newDate: string): Promise<Evaluation> {
-    const response = await httpClient.post<{ success: boolean; data: Evaluation }>(
-      `${this.basePath}/${id}/reschedule`,
-      { scheduledDate: newDate }
-    );
-    return (response.data as any).data;
+    const body = await httpClient.post(`${this.basePath}/${id}/reschedule`, { scheduledDate: newDate });
+    return unwrapBffData<Evaluation>(body);
   }
 
   /**
    * Cancel evaluation
    */
   async cancelEvaluation(id: number, reason?: string): Promise<Evaluation> {
-    const response = await httpClient.post<{ success: boolean; data: Evaluation }>(
-      `${this.basePath}/${id}/cancel`,
-      { reason }
-    );
-    return (response.data as any).data;
+    const body = await httpClient.post(`${this.basePath}/${id}/cancel`, { reason });
+    return unwrapBffData<Evaluation>(body);
   }
 
   /**
@@ -228,11 +190,8 @@ export class EvaluationsClient {
     evaluationIds: number[], 
     evaluatorId: number
   ): Promise<Evaluation[]> {
-    const response = await httpClient.post<{ success: boolean; data: Evaluation[] }>(
-      `${this.basePath}/bulk/assign`,
-      { evaluationIds, evaluatorId }
-    );
-    return (response.data as any).data;
+    const body = await httpClient.post(`${this.basePath}/bulk/assign`, { evaluationIds, evaluatorId });
+    return unwrapBffData<Evaluation[]>(body);
   }
 }
 

--- a/microfrontends/apps/mf-admin/src/api/users.client.ts
+++ b/microfrontends/apps/mf-admin/src/api/users.client.ts
@@ -4,6 +4,7 @@
  */
 
 import httpClient from '../../services/http';
+import { unwrapBffData } from './bffResponse';
 import type {
   User,
   CreateUserRequest,
@@ -20,43 +21,32 @@ export class UsersClient {
    * Get all users with optional filtering and pagination
    */
   async getUsers(params?: UserSearchParams): Promise<PaginatedResponse<User>> {
-    const response = await httpClient.get(
-      this.basePath,
-      { params }
-    );
-    return response.data as PaginatedResponse<User>;
+    const body = await httpClient.get(this.basePath, { params });
+    return body as PaginatedResponse<User>;
   }
 
   /**
    * Get user by ID
    */
   async getUserById(id: number): Promise<User> {
-    const response = await httpClient.get(
-      `${this.basePath}/${id}`
-    );
-    return response.data as User;
+    const body = await httpClient.get(`${this.basePath}/${id}`);
+    return unwrapBffData<User>(body);
   }
 
   /**
    * Create new user (admin only)
    */
   async createUser(userData: CreateUserRequest): Promise<User> {
-    const response = await httpClient.post<{ success: boolean; data: User }>(
-      this.basePath,
-      userData
-    );
-    return (response.data as any).data;
+    const body = await httpClient.post(this.basePath, userData);
+    return unwrapBffData<User>(body);
   }
 
   /**
    * Update existing user
    */
   async updateUser(id: number, userData: UpdateUserRequest): Promise<User> {
-    const response = await httpClient.put<{ success: boolean; data: User }>(
-      `${this.basePath}/${id}`,
-      userData
-    );
-    return (response.data as any).data;
+    const body = await httpClient.put(`${this.basePath}/${id}`, userData);
+    return unwrapBffData<User>(body);
   }
 
   /**
@@ -70,11 +60,8 @@ export class UsersClient {
    * Activate/deactivate user
    */
   async toggleUserStatus(id: number, active: boolean): Promise<User> {
-    const response = await httpClient.patch<{ success: boolean; data: User }>(
-      `${this.basePath}/${id}/status`,
-      { active }
-    );
-    return (response.data as any).data;
+    const body = await httpClient.patch(`${this.basePath}/${id}/status`, { active });
+    return unwrapBffData<User>(body);
   }
 
   /**

--- a/microfrontends/apps/mf-admin/utils/microfrontendUrls.ts
+++ b/microfrontends/apps/mf-admin/utils/microfrontendUrls.ts
@@ -1,3 +1,5 @@
+import { resolveEnvironmentDomain } from '../../../packages/backend-sdk/src/index';
+
 const isBrowser = typeof window !== 'undefined';
 const host = isBrowser ? window.location.hostname : 'localhost';
 const protocol = isBrowser ? window.location.protocol : 'http:';
@@ -24,21 +26,6 @@ const subdomains: Partial<Record<keyof typeof localPorts, string>> = {
   coordinator: 'coordinadores',
 };
 
-const defaultBaseDomain = 'admitia.dedyn.io';
-
-const getEnvironmentDomain = () => {
-  const baseDomain = ((import.meta as any).env?.VITE_MF_BASE_DOMAIN || defaultBaseDomain)
-    .replace(/^https?:\/\//, '')
-    .replace(/\/$/, '');
-  const environment = ((import.meta as any).env?.VITE_MF_ENV || '').trim().toLowerCase();
-
-  if (!environment || environment === 'production' || environment === 'prod') {
-    return baseDomain;
-  }
-
-  return `${environment}.${baseDomain}`;
-};
-
 const buildUrl = (app: keyof typeof localPorts, hashPath: string) => {
   const envUrl = (import.meta as any).env?.[`VITE_MF_${app.toUpperCase()}_URL`];
   if (envUrl) return `${envUrl.replace(/\/$/, '')}/#${hashPath}`;
@@ -49,7 +36,7 @@ const buildUrl = (app: keyof typeof localPorts, hashPath: string) => {
 
   const subdomain = subdomains[app];
   if (subdomain) {
-    return `https://${subdomain}.${getEnvironmentDomain()}/#${hashPath}`;
+    return `https://${subdomain}.${resolveEnvironmentDomain((import.meta as any).env)}/#${hashPath}`;
   }
 
   return `${protocol}//${host}/#${hashPath}`;

--- a/microfrontends/apps/mf-admissions/components/admin/ApplicationDecisionModal.tsx
+++ b/microfrontends/apps/mf-admissions/components/admin/ApplicationDecisionModal.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import Modal from '../ui/Modal';
-import axios from 'axios';
-import { getApiBaseUrl } from '../../config/api.config';
+import api from '../../services/api';
 
 interface ApplicationDecisionModalProps {
   isOpen: boolean;
@@ -31,18 +30,9 @@ const ApplicationDecisionModal: React.FC<ApplicationDecisionModalProps> = ({
 
     setLoading(true);
     try {
-      const token = localStorage.getItem('auth_token');
-      await axios.post(
-        `${getApiBaseUrl()}/v1/applications/${application.id}/final-decision`,
-        {
-          decision,
-          note
-        },
-        {
-          headers: {
-            'Authorization': `Bearer ${token}`
-          }
-        }
+      await api.post(
+        `/v1/applications/${application.id}/final-decision`,
+        { decision, note }
       );
 
       setShowConfirmation(true);

--- a/microfrontends/apps/mf-admissions/components/auth/ProtectedCoordinatorRoute.tsx
+++ b/microfrontends/apps/mf-admissions/components/auth/ProtectedCoordinatorRoute.tsx
@@ -5,6 +5,7 @@
 
 import React, { ReactNode } from 'react';
 import { Navigate } from 'react-router-dom';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 interface ProtectedCoordinatorRouteProps {
   children: ReactNode;
@@ -12,14 +13,14 @@ interface ProtectedCoordinatorRouteProps {
 
 const ProtectedCoordinatorRoute: React.FC<ProtectedCoordinatorRouteProps> = ({ children }) => {
   // Verificar autenticación - revisar múltiples posibles tokens
-  const authToken = localStorage.getItem('auth_token');
+  const authToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
   const adminToken = localStorage.getItem('admin_token');
-  const professorToken = localStorage.getItem('professor_token');
+  const professorToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
 
   // Verificar múltiples ubicaciones de usuario en localStorage
-  const userStr = localStorage.getItem('authenticated_user') ||
+  const userStr = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER)) ||
                   localStorage.getItem('user') ||
-                  localStorage.getItem('professor_user');
+                  localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
 
   // Si hay un token de autenticación
   const isAuthenticated = !!(authToken || adminToken || professorToken);

--- a/microfrontends/apps/mf-admissions/components/layout/Header.tsx
+++ b/microfrontends/apps/mf-admissions/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import Button from '../ui/Button';
 import { microfrontendUrls } from '../../utils/microfrontendUrls';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 const Header: React.FC = () => {
     const navigate = useNavigate();
@@ -15,10 +16,10 @@ const Header: React.FC = () => {
     useEffect(() => {
         const checkAuthStatus = () => {
             // Verificar múltiples fuentes de autenticación
-            const currentProfessor = localStorage.getItem('currentProfessor');
-            const authToken = localStorage.getItem('auth_token');
-            const professorToken = localStorage.getItem('professor_token');
-            const apoderadoToken = localStorage.getItem('apoderado_token');
+            const currentProfessor = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
+            const authToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+            const professorToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+            const apoderadoToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
 
             // Verificar si hay profesor autenticado
             const hasProfessorAuth = !!(professorToken && currentProfessor);
@@ -66,10 +67,10 @@ const Header: React.FC = () => {
             e.preventDefault(); // Prevenir navegación predeterminada
 
             // Limpiar TODOS los tokens y datos de autenticación
-            localStorage.removeItem('auth_token');
-            localStorage.removeItem('professor_token');
-            localStorage.removeItem('apoderado_token');
-            localStorage.removeItem('currentProfessor');
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
             localStorage.removeItem('currentUser');
             localStorage.removeItem('currentApoderado');
 

--- a/microfrontends/apps/mf-admissions/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-admissions/context/AuthContext.tsx
@@ -3,6 +3,7 @@ import { onAuthStateChanged } from 'firebase/auth';
 import { auth, hasFirebaseConfig } from '../src/lib/firebase';
 import { authService } from '../services/authService';
 import api from '../services/api';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 interface User {
     id: string;
@@ -57,7 +58,7 @@ const buildUserFromBff = (u: any): User => ({
 
 const setAdminCompat = (user: User, token: string, subject?: string) => {
     if (user.role === 'ADMIN') {
-        localStorage.setItem('currentProfessor', JSON.stringify({
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR), JSON.stringify({
             id: user.id,
             firstName: user.firstName,
             lastName: user.lastName,
@@ -67,8 +68,8 @@ const setAdminCompat = (user: User, token: string, subject?: string) => {
             assignedGrades: ['prekinder', 'kinder', '1basico', '2basico', '3basico', '4basico', '5basico', '6basico', '7basico', '8basico', '1medio', '2medio', '3medio', '4medio'],
             isAdmin: true,
         }));
-        localStorage.setItem('professor_token', token);
-        localStorage.setItem('professor_user', JSON.stringify({
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN), token);
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER), JSON.stringify({
             email: user.email,
             firstName: user.firstName,
             lastName: user.lastName,
@@ -93,17 +94,17 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 // Firebase user is signed in — get fresh idToken and fetch profile from BFF
                 try {
                     const idToken = await firebaseUser.getIdToken();
-                    localStorage.setItem('auth_token', idToken);
+                    localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
                     // Check if we already have cached user data
-                    const cached = localStorage.getItem('authenticated_user');
+                    const cached = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                     if (cached) {
                         try {
                             setUser(JSON.parse(cached));
                             setIsLoading(false);
                             return;
                         } catch {
-                            localStorage.removeItem('authenticated_user');
+                            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                         }
                     }
 
@@ -111,20 +112,20 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                     const response = await api.get('/v1/auth/check');
                     if (response.data?.success && response.data?.user) {
                         const userData = buildUserFromBff(response.data.user);
-                        localStorage.setItem('authenticated_user', JSON.stringify(userData));
+                        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(userData));
                         setAdminCompat(userData, idToken, response.data.user?.subject);
                         setUser(userData);
                     }
                 } catch {
                     // BFF call failed — clear state
-                    localStorage.removeItem('auth_token');
-                    localStorage.removeItem('authenticated_user');
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                     setUser(null);
                 }
             } else {
                 // No Firebase user — clear everything
-                localStorage.removeItem('auth_token');
-                localStorage.removeItem('authenticated_user');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                 setUser(null);
             }
             setIsLoading(false);
@@ -141,7 +142,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             if (response.success && u) {
                 const userData = buildUserFromBff(u);
                 setAdminCompat(userData, response.token ?? '', u?.subject);
-                localStorage.setItem('authenticated_user', JSON.stringify(userData));
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(userData));
                 setUser(userData);
             } else {
                 throw new Error(response.message || 'Error en la autenticación');
@@ -170,7 +171,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 const newUser = buildUserFromBff(u);
                 newUser.phone = userData.phone;
                 newUser.rut = userData.rut;
-                localStorage.setItem('authenticated_user', JSON.stringify(newUser));
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(newUser));
                 setUser(newUser);
             } else {
                 throw new Error(response.message || 'Error al crear la cuenta');
@@ -184,13 +185,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
     const logout = () => {
         authService.logout();
-        localStorage.removeItem('currentProfessor');
-        localStorage.removeItem('professor_token');
-        localStorage.removeItem('professor_user');
-        localStorage.removeItem('apoderado_token');
-        localStorage.removeItem('apoderado_user');
-        localStorage.removeItem('auth_token');
-        localStorage.removeItem('authenticated_user');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
         setUser(null);
         window.location.href = '/apoderado-login';
     };

--- a/microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx
+++ b/microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx
@@ -390,6 +390,25 @@ const ApplicationForm: React.FC = () => {
         }
     }, []);
 
+    // Verificar si el usuario se acaba de registrar y validar token rápidamente
+    useEffect(() => {
+        const hashParams = new URLSearchParams(window.location.hash.split('?')[1] || '');
+        if (hashParams.get('justRegistered') === 'true') {
+            console.log('👤 Usuario registrado, verificando autenticación rápidamente...');
+            api.get('/v1/auth/check')
+                .then(response => {
+                    if (response.data?.success && response.data?.user) {
+                        console.log('✅ Token válido, usuario autenticado');
+                        setShowAuthForm(false);
+                    }
+                })
+                .catch(error => {
+                    console.log('❌ Verificación de token falló, mostrando login');
+                    setShowAuthForm(true);
+                });
+        }
+    }, []);
+
     // Helper function to check if current school is required
     const requiresCurrentSchool = useCallback((grade: string): boolean => {
         const schoolRequiredGrades = [

--- a/microfrontends/apps/mf-admissions/services/api.ts
+++ b/microfrontends/apps/mf-admissions/services/api.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { csrfService } from './csrfService';
 import { getApiBaseUrl } from '../config/api.config';
 import { auth } from '../src/lib/firebase';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 // Configuración base de axios - Using nginx gateway for microservices
 // NO baseURL here - will be set in request interceptor for runtime detection
@@ -61,11 +62,11 @@ api.interceptors.request.use(
                     const idToken = await currentUser.getIdToken();
                     config.headers.Authorization = `Bearer ${idToken}`;
                 } catch {
-                    const token = localStorage.getItem('auth_token');
+                    const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
                     if (token) config.headers.Authorization = `Bearer ${token}`;
                 }
             } else {
-                const token = localStorage.getItem('auth_token') || localStorage.getItem('professor_token');
+                const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN)) || localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
                 if (token) config.headers.Authorization = `Bearer ${token}`;
             }
         }
@@ -126,13 +127,13 @@ api.interceptors.response.use(
                 console.warn('JWT token expired or invalid - cleaning session');
 
                 // Limpiar token de usuario regular
-                localStorage.removeItem('auth_token');
-                localStorage.removeItem('authenticated_user');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
 
                 // Limpiar token de profesor
-                localStorage.removeItem('professor_token');
-                localStorage.removeItem('professor_user');
-                localStorage.removeItem('currentProfessor');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
 
                 // Solo redirigir si no estamos ya en una página de login o si no es una ruta pública
                 const currentPath = window.location.pathname;

--- a/microfrontends/apps/mf-admissions/services/authService.ts
+++ b/microfrontends/apps/mf-admissions/services/authService.ts
@@ -5,6 +5,7 @@ import {
     signOut,
 } from 'firebase/auth';
 import { auth } from '../src/lib/firebase';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 export interface LoginRequest {
     email: string;
@@ -64,7 +65,7 @@ class AuthService {
             const data = response.data;
 
             // 3. Store the Firebase idToken for immediate use until interceptor takes over
-            localStorage.setItem('auth_token', idToken);
+            localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
             return {
                 success: true,
@@ -104,7 +105,7 @@ class AuthService {
             });
             const data = response.data;
 
-            localStorage.setItem('auth_token', idToken);
+            localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
             return {
                 success: true,
@@ -141,8 +142,8 @@ class AuthService {
         } catch (e) {
             // Ignore Firebase signOut errors
         }
-        localStorage.removeItem('auth_token');
-        localStorage.removeItem('authenticated_user');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
     }
 }
 

--- a/microfrontends/apps/mf-admissions/services/http.ts
+++ b/microfrontends/apps/mf-admissions/services/http.ts
@@ -7,6 +7,7 @@ import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosError } f
 import { oidcService } from './oidcService';
 import { getApiBaseUrl } from '../config/api.config';
 import { csrfService } from './csrfService';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 // Tipos
 interface RetryConfig {
@@ -154,12 +155,12 @@ class HttpClient {
   private async getAccessToken(): Promise<string | null> {
     try {
       // Primero intentar obtener el token de usuario regular (apoderado)
-      let token = localStorage.getItem('auth_token');
+      let token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
       console.log('http.ts - auth_token:', token ? `${token.substring(0, 20)}...` : 'NOT FOUND');
 
       // Si no hay token de usuario regular, intentar con token de profesor
       if (!token) {
-        token = localStorage.getItem('professor_token');
+        token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
         console.log('http.ts - professor_token:', token ? `${token.substring(0, 20)}...` : 'NOT FOUND');
       }
 
@@ -257,8 +258,8 @@ class HttpClient {
       console.warn('Session invalidated - User logged in from another device');
 
       // Clear ALL tokens
-      localStorage.removeItem('auth_token');
-      localStorage.removeItem('professor_token');
+      localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+      localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
       sessionStorage.clear();
 
       // Show alert to user

--- a/microfrontends/apps/mf-admissions/services/professorAuthService.ts
+++ b/microfrontends/apps/mf-admissions/services/professorAuthService.ts
@@ -1,4 +1,5 @@
 import api from './api';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 // RSA encryption removed - credentials sent over HTTPS only
 // import encryptionService from './encryptionService';
 
@@ -45,9 +46,9 @@ class ProfessorAuthService {
 
             // Guardar token en localStorage
             if (data.token) {
-                localStorage.setItem('professor_token', data.token);
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN), data.token);
                 const u = data.user;
-                localStorage.setItem('professor_user', JSON.stringify({
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER), JSON.stringify({
                     email: u?.email || data.email,
                     firstName: u?.firstName || data.firstName,
                     lastName: u?.lastName || data.lastName,
@@ -75,7 +76,7 @@ class ProfessorAuthService {
     
     async getCurrentProfessor(): Promise<ProfessorUser | null> {
         try {
-            const token = localStorage.getItem('professor_token');
+            const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
             if (!token) {
                 return null;
             }
@@ -100,19 +101,19 @@ class ProfessorAuthService {
     }
     
     isAuthenticated(): boolean {
-        const token = localStorage.getItem('professor_token');
+        const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
         return !!token;
     }
     
     getStoredProfessor() {
-        const stored = localStorage.getItem('professor_user');
+        const stored = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
         return stored ? JSON.parse(stored) : null;
     }
     
     logout() {
-        localStorage.removeItem('professor_token');
-        localStorage.removeItem('professor_user');
-        localStorage.removeItem('currentProfessor');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
     }
     
     // Método para verificar si el usuario es un profesor válido

--- a/microfrontends/apps/mf-admissions/utils/microfrontendUrls.ts
+++ b/microfrontends/apps/mf-admissions/utils/microfrontendUrls.ts
@@ -1,3 +1,5 @@
+import { resolveEnvironmentDomain } from '../../../packages/backend-sdk/src/index';
+
 const isBrowser = typeof window !== 'undefined';
 const host = isBrowser ? window.location.hostname : 'localhost';
 const protocol = isBrowser ? window.location.protocol : 'http:';
@@ -24,21 +26,6 @@ const subdomains: Partial<Record<keyof typeof localPorts, string>> = {
   coordinator: 'coordinadores',
 };
 
-const defaultBaseDomain = 'admitia.dedyn.io';
-
-const getEnvironmentDomain = () => {
-  const baseDomain = ((import.meta as any).env?.VITE_MF_BASE_DOMAIN || defaultBaseDomain)
-    .replace(/^https?:\/\//, '')
-    .replace(/\/$/, '');
-  const environment = ((import.meta as any).env?.VITE_MF_ENV || '').trim().toLowerCase();
-
-  if (!environment || environment === 'production' || environment === 'prod') {
-    return baseDomain;
-  }
-
-  return `${environment}.${baseDomain}`;
-};
-
 const buildUrl = (app: keyof typeof localPorts, hashPath: string) => {
   const envUrl = (import.meta as any).env?.[`VITE_MF_${app.toUpperCase()}_URL`];
   if (envUrl) return `${envUrl.replace(/\/$/, '')}/#${hashPath}`;
@@ -49,7 +36,7 @@ const buildUrl = (app: keyof typeof localPorts, hashPath: string) => {
 
   const subdomain = subdomains[app];
   if (subdomain) {
-    return `https://${subdomain}.${getEnvironmentDomain()}/#${hashPath}`;
+    return `https://${subdomain}.${resolveEnvironmentDomain((import.meta as any).env)}/#${hashPath}`;
   }
 
   return `${protocol}//${host}/#${hashPath}`;

--- a/microfrontends/apps/mf-coordinator/components/admin/ApplicationDecisionModal.tsx
+++ b/microfrontends/apps/mf-coordinator/components/admin/ApplicationDecisionModal.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import Modal from '../ui/Modal';
-import axios from 'axios';
-import { getApiBaseUrl } from '../../config/api.config';
+import api from '../../services/api';
 
 interface ApplicationDecisionModalProps {
   isOpen: boolean;
@@ -31,18 +30,9 @@ const ApplicationDecisionModal: React.FC<ApplicationDecisionModalProps> = ({
 
     setLoading(true);
     try {
-      const token = localStorage.getItem('auth_token');
-      await axios.post(
-        `${getApiBaseUrl()}/v1/applications/${application.id}/final-decision`,
-        {
-          decision,
-          note
-        },
-        {
-          headers: {
-            'Authorization': `Bearer ${token}`
-          }
-        }
+      await api.post(
+        `/v1/applications/${application.id}/final-decision`,
+        { decision, note }
       );
 
       setShowConfirmation(true);

--- a/microfrontends/apps/mf-coordinator/components/auth/ProtectedCoordinatorRoute.tsx
+++ b/microfrontends/apps/mf-coordinator/components/auth/ProtectedCoordinatorRoute.tsx
@@ -5,6 +5,7 @@
 
 import React, { ReactNode } from 'react';
 import { Navigate } from 'react-router-dom';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 interface ProtectedCoordinatorRouteProps {
   children: ReactNode;
@@ -12,14 +13,14 @@ interface ProtectedCoordinatorRouteProps {
 
 const ProtectedCoordinatorRoute: React.FC<ProtectedCoordinatorRouteProps> = ({ children }) => {
   // Verificar autenticación - revisar múltiples posibles tokens
-  const authToken = localStorage.getItem('auth_token');
+  const authToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
   const adminToken = localStorage.getItem('admin_token');
-  const professorToken = localStorage.getItem('professor_token');
+  const professorToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
 
   // Verificar múltiples ubicaciones de usuario en localStorage
-  const userStr = localStorage.getItem('authenticated_user') ||
+  const userStr = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER)) ||
                   localStorage.getItem('user') ||
-                  localStorage.getItem('professor_user');
+                  localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
 
   // Si hay un token de autenticación
   const isAuthenticated = !!(authToken || adminToken || professorToken);

--- a/microfrontends/apps/mf-coordinator/components/layout/Header.tsx
+++ b/microfrontends/apps/mf-coordinator/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import Button from '../ui/Button';
 import { microfrontendUrls } from '../../utils/microfrontendUrls';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 const Header: React.FC = () => {
     const navigate = useNavigate();
@@ -15,10 +16,10 @@ const Header: React.FC = () => {
     useEffect(() => {
         const checkAuthStatus = () => {
             // Verificar múltiples fuentes de autenticación
-            const currentProfessor = localStorage.getItem('currentProfessor');
-            const authToken = localStorage.getItem('auth_token');
-            const professorToken = localStorage.getItem('professor_token');
-            const apoderadoToken = localStorage.getItem('apoderado_token');
+            const currentProfessor = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
+            const authToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+            const professorToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+            const apoderadoToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
 
             // Verificar si hay profesor autenticado
             const hasProfessorAuth = !!(professorToken && currentProfessor);
@@ -66,10 +67,10 @@ const Header: React.FC = () => {
             e.preventDefault(); // Prevenir navegación predeterminada
 
             // Limpiar TODOS los tokens y datos de autenticación
-            localStorage.removeItem('auth_token');
-            localStorage.removeItem('professor_token');
-            localStorage.removeItem('apoderado_token');
-            localStorage.removeItem('currentProfessor');
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
             localStorage.removeItem('currentUser');
             localStorage.removeItem('currentApoderado');
 

--- a/microfrontends/apps/mf-coordinator/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-coordinator/context/AuthContext.tsx
@@ -3,6 +3,7 @@ import { onAuthStateChanged } from 'firebase/auth';
 import { auth, hasFirebaseConfig } from '../src/lib/firebase';
 import { authService } from '../services/authService';
 import api from '../services/api';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 interface User {
     id: string;
@@ -57,7 +58,7 @@ const buildUserFromBff = (u: any): User => ({
 
 const setAdminCompat = (user: User, token: string, subject?: string) => {
     if (user.role === 'ADMIN') {
-        localStorage.setItem('currentProfessor', JSON.stringify({
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR), JSON.stringify({
             id: user.id,
             firstName: user.firstName,
             lastName: user.lastName,
@@ -67,8 +68,8 @@ const setAdminCompat = (user: User, token: string, subject?: string) => {
             assignedGrades: ['prekinder', 'kinder', '1basico', '2basico', '3basico', '4basico', '5basico', '6basico', '7basico', '8basico', '1medio', '2medio', '3medio', '4medio'],
             isAdmin: true,
         }));
-        localStorage.setItem('professor_token', token);
-        localStorage.setItem('professor_user', JSON.stringify({
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN), token);
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER), JSON.stringify({
             email: user.email,
             firstName: user.firstName,
             lastName: user.lastName,
@@ -93,17 +94,17 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 // Firebase user is signed in — get fresh idToken and fetch profile from BFF
                 try {
                     const idToken = await firebaseUser.getIdToken();
-                    localStorage.setItem('auth_token', idToken);
+                    localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
                     // Check if we already have cached user data
-                    const cached = localStorage.getItem('authenticated_user');
+                    const cached = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                     if (cached) {
                         try {
                             setUser(JSON.parse(cached));
                             setIsLoading(false);
                             return;
                         } catch {
-                            localStorage.removeItem('authenticated_user');
+                            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                         }
                     }
 
@@ -111,20 +112,20 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                     const response = await api.get('/v1/auth/check');
                     if (response.data?.success && response.data?.user) {
                         const userData = buildUserFromBff(response.data.user);
-                        localStorage.setItem('authenticated_user', JSON.stringify(userData));
+                        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(userData));
                         setAdminCompat(userData, idToken, response.data.user?.subject);
                         setUser(userData);
                     }
                 } catch {
                     // BFF call failed — clear state
-                    localStorage.removeItem('auth_token');
-                    localStorage.removeItem('authenticated_user');
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                     setUser(null);
                 }
             } else {
                 // No Firebase user — clear everything
-                localStorage.removeItem('auth_token');
-                localStorage.removeItem('authenticated_user');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                 setUser(null);
             }
             setIsLoading(false);
@@ -141,7 +142,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             if (response.success && u) {
                 const userData = buildUserFromBff(u);
                 setAdminCompat(userData, response.token ?? '', u?.subject);
-                localStorage.setItem('authenticated_user', JSON.stringify(userData));
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(userData));
                 setUser(userData);
             } else {
                 throw new Error(response.message || 'Error en la autenticación');
@@ -170,7 +171,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 const newUser = buildUserFromBff(u);
                 newUser.phone = userData.phone;
                 newUser.rut = userData.rut;
-                localStorage.setItem('authenticated_user', JSON.stringify(newUser));
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(newUser));
                 setUser(newUser);
             } else {
                 throw new Error(response.message || 'Error al crear la cuenta');
@@ -184,13 +185,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
     const logout = () => {
         authService.logout();
-        localStorage.removeItem('currentProfessor');
-        localStorage.removeItem('professor_token');
-        localStorage.removeItem('professor_user');
-        localStorage.removeItem('apoderado_token');
-        localStorage.removeItem('apoderado_user');
-        localStorage.removeItem('auth_token');
-        localStorage.removeItem('authenticated_user');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
         setUser(null);
         window.location.href = '/apoderado-login';
     };

--- a/microfrontends/apps/mf-coordinator/services/api.ts
+++ b/microfrontends/apps/mf-coordinator/services/api.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { csrfService } from './csrfService';
 import { getApiBaseUrl } from '../config/api.config';
 import { auth } from '../src/lib/firebase';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 // Configuración base de axios - Using nginx gateway for microservices
 // NO baseURL here - will be set in request interceptor for runtime detection
@@ -61,11 +62,11 @@ api.interceptors.request.use(
                     const idToken = await currentUser.getIdToken();
                     config.headers.Authorization = `Bearer ${idToken}`;
                 } catch {
-                    const token = localStorage.getItem('auth_token');
+                    const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
                     if (token) config.headers.Authorization = `Bearer ${token}`;
                 }
             } else {
-                const token = localStorage.getItem('auth_token') || localStorage.getItem('professor_token');
+                const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN)) || localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
                 if (token) config.headers.Authorization = `Bearer ${token}`;
             }
         }
@@ -126,13 +127,13 @@ api.interceptors.response.use(
                 console.warn('JWT token expired or invalid - cleaning session');
 
                 // Limpiar token de usuario regular
-                localStorage.removeItem('auth_token');
-                localStorage.removeItem('authenticated_user');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
 
                 // Limpiar token de profesor
-                localStorage.removeItem('professor_token');
-                localStorage.removeItem('professor_user');
-                localStorage.removeItem('currentProfessor');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
 
                 // Solo redirigir si no estamos ya en una página de login o si no es una ruta pública
                 const currentPath = window.location.pathname;

--- a/microfrontends/apps/mf-coordinator/services/authService.ts
+++ b/microfrontends/apps/mf-coordinator/services/authService.ts
@@ -5,6 +5,7 @@ import {
     signOut,
 } from 'firebase/auth';
 import { auth } from '../src/lib/firebase';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 export interface LoginRequest {
     email: string;
@@ -64,7 +65,7 @@ class AuthService {
             const data = response.data;
 
             // 3. Store the Firebase idToken for immediate use until interceptor takes over
-            localStorage.setItem('auth_token', idToken);
+            localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
             return {
                 success: true,
@@ -104,7 +105,7 @@ class AuthService {
             });
             const data = response.data;
 
-            localStorage.setItem('auth_token', idToken);
+            localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
             return {
                 success: true,
@@ -141,8 +142,8 @@ class AuthService {
         } catch (e) {
             // Ignore Firebase signOut errors
         }
-        localStorage.removeItem('auth_token');
-        localStorage.removeItem('authenticated_user');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
     }
 }
 

--- a/microfrontends/apps/mf-coordinator/services/http.ts
+++ b/microfrontends/apps/mf-coordinator/services/http.ts
@@ -7,6 +7,7 @@ import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosError } f
 import { oidcService } from './oidcService';
 import { getApiBaseUrl } from '../config/api.config';
 import { csrfService } from './csrfService';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 // Tipos
 interface RetryConfig {
@@ -154,12 +155,12 @@ class HttpClient {
   private async getAccessToken(): Promise<string | null> {
     try {
       // Primero intentar obtener el token de usuario regular (apoderado)
-      let token = localStorage.getItem('auth_token');
+      let token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
       console.log('http.ts - auth_token:', token ? `${token.substring(0, 20)}...` : 'NOT FOUND');
 
       // Si no hay token de usuario regular, intentar con token de profesor
       if (!token) {
-        token = localStorage.getItem('professor_token');
+        token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
         console.log('http.ts - professor_token:', token ? `${token.substring(0, 20)}...` : 'NOT FOUND');
       }
 
@@ -257,8 +258,8 @@ class HttpClient {
       console.warn('Session invalidated - User logged in from another device');
 
       // Clear ALL tokens
-      localStorage.removeItem('auth_token');
-      localStorage.removeItem('professor_token');
+      localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+      localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
       sessionStorage.clear();
 
       // Show alert to user

--- a/microfrontends/apps/mf-coordinator/services/professorAuthService.ts
+++ b/microfrontends/apps/mf-coordinator/services/professorAuthService.ts
@@ -1,4 +1,5 @@
 import api from './api';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 // RSA encryption removed - credentials sent over HTTPS only
 // import encryptionService from './encryptionService';
 
@@ -45,9 +46,9 @@ class ProfessorAuthService {
 
             // Guardar token en localStorage
             if (data.token) {
-                localStorage.setItem('professor_token', data.token);
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN), data.token);
                 const u = data.user;
-                localStorage.setItem('professor_user', JSON.stringify({
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER), JSON.stringify({
                     email: u?.email || data.email,
                     firstName: u?.firstName || data.firstName,
                     lastName: u?.lastName || data.lastName,
@@ -75,7 +76,7 @@ class ProfessorAuthService {
     
     async getCurrentProfessor(): Promise<ProfessorUser | null> {
         try {
-            const token = localStorage.getItem('professor_token');
+            const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
             if (!token) {
                 return null;
             }
@@ -100,19 +101,19 @@ class ProfessorAuthService {
     }
     
     isAuthenticated(): boolean {
-        const token = localStorage.getItem('professor_token');
+        const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
         return !!token;
     }
     
     getStoredProfessor() {
-        const stored = localStorage.getItem('professor_user');
+        const stored = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
         return stored ? JSON.parse(stored) : null;
     }
     
     logout() {
-        localStorage.removeItem('professor_token');
-        localStorage.removeItem('professor_user');
-        localStorage.removeItem('currentProfessor');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
     }
     
     // Método para verificar si el usuario es un profesor válido

--- a/microfrontends/apps/mf-coordinator/utils/microfrontendUrls.ts
+++ b/microfrontends/apps/mf-coordinator/utils/microfrontendUrls.ts
@@ -1,3 +1,5 @@
+import { resolveEnvironmentDomain } from '../../../packages/backend-sdk/src/index';
+
 const isBrowser = typeof window !== 'undefined';
 const host = isBrowser ? window.location.hostname : 'localhost';
 const protocol = isBrowser ? window.location.protocol : 'http:';
@@ -24,21 +26,6 @@ const subdomains: Partial<Record<keyof typeof localPorts, string>> = {
   coordinator: 'coordinadores',
 };
 
-const defaultBaseDomain = 'admitia.dedyn.io';
-
-const getEnvironmentDomain = () => {
-  const baseDomain = ((import.meta as any).env?.VITE_MF_BASE_DOMAIN || defaultBaseDomain)
-    .replace(/^https?:\/\//, '')
-    .replace(/\/$/, '');
-  const environment = ((import.meta as any).env?.VITE_MF_ENV || '').trim().toLowerCase();
-
-  if (!environment || environment === 'production' || environment === 'prod') {
-    return baseDomain;
-  }
-
-  return `${environment}.${baseDomain}`;
-};
-
 const buildUrl = (app: keyof typeof localPorts, hashPath: string) => {
   const envUrl = (import.meta as any).env?.[`VITE_MF_${app.toUpperCase()}_URL`];
   if (envUrl) return `${envUrl.replace(/\/$/, '')}/#${hashPath}`;
@@ -49,7 +36,7 @@ const buildUrl = (app: keyof typeof localPorts, hashPath: string) => {
 
   const subdomain = subdomains[app];
   if (subdomain) {
-    return `https://${subdomain}.${getEnvironmentDomain()}/#${hashPath}`;
+    return `https://${subdomain}.${resolveEnvironmentDomain((import.meta as any).env)}/#${hashPath}`;
   }
 
   return `${protocol}//${host}/#${hashPath}`;

--- a/microfrontends/apps/mf-evaluations/components/admin/ApplicationDecisionModal.tsx
+++ b/microfrontends/apps/mf-evaluations/components/admin/ApplicationDecisionModal.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import Modal from '../ui/Modal';
-import axios from 'axios';
-import { getApiBaseUrl } from '../../config/api.config';
+import api from '../../services/api';
 
 interface ApplicationDecisionModalProps {
   isOpen: boolean;
@@ -31,18 +30,9 @@ const ApplicationDecisionModal: React.FC<ApplicationDecisionModalProps> = ({
 
     setLoading(true);
     try {
-      const token = localStorage.getItem('auth_token');
-      await axios.post(
-        `${getApiBaseUrl()}/v1/applications/${application.id}/final-decision`,
-        {
-          decision,
-          note
-        },
-        {
-          headers: {
-            'Authorization': `Bearer ${token}`
-          }
-        }
+      await api.post(
+        `/v1/applications/${application.id}/final-decision`,
+        { decision, note }
       );
 
       setShowConfirmation(true);

--- a/microfrontends/apps/mf-evaluations/components/auth/ProtectedCoordinatorRoute.tsx
+++ b/microfrontends/apps/mf-evaluations/components/auth/ProtectedCoordinatorRoute.tsx
@@ -5,6 +5,7 @@
 
 import React, { ReactNode } from 'react';
 import { Navigate } from 'react-router-dom';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 interface ProtectedCoordinatorRouteProps {
   children: ReactNode;
@@ -12,14 +13,14 @@ interface ProtectedCoordinatorRouteProps {
 
 const ProtectedCoordinatorRoute: React.FC<ProtectedCoordinatorRouteProps> = ({ children }) => {
   // Verificar autenticación - revisar múltiples posibles tokens
-  const authToken = localStorage.getItem('auth_token');
+  const authToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
   const adminToken = localStorage.getItem('admin_token');
-  const professorToken = localStorage.getItem('professor_token');
+  const professorToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
 
   // Verificar múltiples ubicaciones de usuario en localStorage
-  const userStr = localStorage.getItem('authenticated_user') ||
+  const userStr = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER)) ||
                   localStorage.getItem('user') ||
-                  localStorage.getItem('professor_user');
+                  localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
 
   // Si hay un token de autenticación
   const isAuthenticated = !!(authToken || adminToken || professorToken);

--- a/microfrontends/apps/mf-evaluations/components/layout/Header.tsx
+++ b/microfrontends/apps/mf-evaluations/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import Button from '../ui/Button';
 import { microfrontendUrls } from '../../utils/microfrontendUrls';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 const Header: React.FC = () => {
     const navigate = useNavigate();
@@ -15,10 +16,10 @@ const Header: React.FC = () => {
     useEffect(() => {
         const checkAuthStatus = () => {
             // Verificar múltiples fuentes de autenticación
-            const currentProfessor = localStorage.getItem('currentProfessor');
-            const authToken = localStorage.getItem('auth_token');
-            const professorToken = localStorage.getItem('professor_token');
-            const apoderadoToken = localStorage.getItem('apoderado_token');
+            const currentProfessor = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
+            const authToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+            const professorToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+            const apoderadoToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
 
             // Verificar si hay profesor autenticado
             const hasProfessorAuth = !!(professorToken && currentProfessor);
@@ -66,10 +67,10 @@ const Header: React.FC = () => {
             e.preventDefault(); // Prevenir navegación predeterminada
 
             // Limpiar TODOS los tokens y datos de autenticación
-            localStorage.removeItem('auth_token');
-            localStorage.removeItem('professor_token');
-            localStorage.removeItem('apoderado_token');
-            localStorage.removeItem('currentProfessor');
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
             localStorage.removeItem('currentUser');
             localStorage.removeItem('currentApoderado');
 

--- a/microfrontends/apps/mf-evaluations/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-evaluations/context/AuthContext.tsx
@@ -3,6 +3,7 @@ import { onAuthStateChanged } from 'firebase/auth';
 import { auth, hasFirebaseConfig } from '../src/lib/firebase';
 import { authService } from '../services/authService';
 import api from '../services/api';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 interface User {
     id: string;
@@ -57,7 +58,7 @@ const buildUserFromBff = (u: any): User => ({
 
 const setAdminCompat = (user: User, token: string, subject?: string) => {
     if (user.role === 'ADMIN') {
-        localStorage.setItem('currentProfessor', JSON.stringify({
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR), JSON.stringify({
             id: user.id,
             firstName: user.firstName,
             lastName: user.lastName,
@@ -67,8 +68,8 @@ const setAdminCompat = (user: User, token: string, subject?: string) => {
             assignedGrades: ['prekinder', 'kinder', '1basico', '2basico', '3basico', '4basico', '5basico', '6basico', '7basico', '8basico', '1medio', '2medio', '3medio', '4medio'],
             isAdmin: true,
         }));
-        localStorage.setItem('professor_token', token);
-        localStorage.setItem('professor_user', JSON.stringify({
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN), token);
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER), JSON.stringify({
             email: user.email,
             firstName: user.firstName,
             lastName: user.lastName,
@@ -93,17 +94,17 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 // Firebase user is signed in — get fresh idToken and fetch profile from BFF
                 try {
                     const idToken = await firebaseUser.getIdToken();
-                    localStorage.setItem('auth_token', idToken);
+                    localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
                     // Check if we already have cached user data
-                    const cached = localStorage.getItem('authenticated_user');
+                    const cached = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                     if (cached) {
                         try {
                             setUser(JSON.parse(cached));
                             setIsLoading(false);
                             return;
                         } catch {
-                            localStorage.removeItem('authenticated_user');
+                            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                         }
                     }
 
@@ -111,20 +112,20 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                     const response = await api.get('/v1/auth/check');
                     if (response.data?.success && response.data?.user) {
                         const userData = buildUserFromBff(response.data.user);
-                        localStorage.setItem('authenticated_user', JSON.stringify(userData));
+                        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(userData));
                         setAdminCompat(userData, idToken, response.data.user?.subject);
                         setUser(userData);
                     }
                 } catch {
                     // BFF call failed — clear state
-                    localStorage.removeItem('auth_token');
-                    localStorage.removeItem('authenticated_user');
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                     setUser(null);
                 }
             } else {
                 // No Firebase user — clear everything
-                localStorage.removeItem('auth_token');
-                localStorage.removeItem('authenticated_user');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                 setUser(null);
             }
             setIsLoading(false);
@@ -141,7 +142,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             if (response.success && u) {
                 const userData = buildUserFromBff(u);
                 setAdminCompat(userData, response.token ?? '', u?.subject);
-                localStorage.setItem('authenticated_user', JSON.stringify(userData));
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(userData));
                 setUser(userData);
             } else {
                 throw new Error(response.message || 'Error en la autenticación');
@@ -170,7 +171,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 const newUser = buildUserFromBff(u);
                 newUser.phone = userData.phone;
                 newUser.rut = userData.rut;
-                localStorage.setItem('authenticated_user', JSON.stringify(newUser));
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(newUser));
                 setUser(newUser);
             } else {
                 throw new Error(response.message || 'Error al crear la cuenta');
@@ -184,13 +185,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
     const logout = () => {
         authService.logout();
-        localStorage.removeItem('currentProfessor');
-        localStorage.removeItem('professor_token');
-        localStorage.removeItem('professor_user');
-        localStorage.removeItem('apoderado_token');
-        localStorage.removeItem('apoderado_user');
-        localStorage.removeItem('auth_token');
-        localStorage.removeItem('authenticated_user');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
         setUser(null);
         window.location.href = '/#/profesor/login';
     };

--- a/microfrontends/apps/mf-evaluations/pages/AdminLoginPage.tsx
+++ b/microfrontends/apps/mf-evaluations/pages/AdminLoginPage.tsx
@@ -6,6 +6,7 @@ import Input from '../components/ui/Input';
 import Button from '../components/ui/Button';
 import { useAuth } from '../context/AuthContext';
 import { useNotifications } from '../context/AppContext';
+import { microfrontendUrls } from '../utils/microfrontendUrls';
 
 const LoginPage: React.FC = () => {
     const [userType, setUserType] = useState<'familia' | 'admin'>('familia');
@@ -21,7 +22,7 @@ const LoginPage: React.FC = () => {
     React.useEffect(() => {
         if (isAuthenticated && user) {
             if (user.role === 'ADMIN') {
-                navigate('/admin');
+                window.location.href = microfrontendUrls.adminDashboard;
             } else if (user.role === 'APODERADO') {
                 navigate('/familia');
             } else {
@@ -93,7 +94,7 @@ const LoginPage: React.FC = () => {
                             if (userType === 'familia') {
                                 navigate('/familia');
                             } else {
-                                navigate('/admin');
+                                window.location.href = microfrontendUrls.adminDashboard;
                             }
                         } catch (error: any) {
                             const msg = error.message || 'Credenciales inválidas. Verifique su email y contraseña.';

--- a/microfrontends/apps/mf-evaluations/services/api.ts
+++ b/microfrontends/apps/mf-evaluations/services/api.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { csrfService } from './csrfService';
 import { getApiBaseUrl } from '../config/api.config';
 import { auth } from '../src/lib/firebase';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 // Configuración base de axios - Using nginx gateway for microservices
 // NO baseURL here - will be set in request interceptor for runtime detection
@@ -61,11 +62,11 @@ api.interceptors.request.use(
                     const idToken = await currentUser.getIdToken();
                     config.headers.Authorization = `Bearer ${idToken}`;
                 } catch {
-                    const token = localStorage.getItem('auth_token');
+                    const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
                     if (token) config.headers.Authorization = `Bearer ${token}`;
                 }
             } else {
-                const token = localStorage.getItem('auth_token') || localStorage.getItem('professor_token');
+                const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN)) || localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
                 if (token) config.headers.Authorization = `Bearer ${token}`;
             }
         }
@@ -126,16 +127,16 @@ api.interceptors.response.use(
                 console.warn('JWT token expired or invalid - cleaning session');
 
                 // Limpiar token de usuario regular
-                localStorage.removeItem('auth_token');
-                localStorage.removeItem('authenticated_user');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
 
                 // Limpiar token de profesor
-                localStorage.removeItem('professor_token');
-                localStorage.removeItem('professor_user');
-                localStorage.removeItem('currentProfessor');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
 
                 // Solo redirigir si no estamos ya en una página de login o si no es una ruta pública
-                const currentPath = window.location.hash || window.location.pathname;
+                const currentPath = window.location.pathname;
                 const isLoginPage = currentPath.includes('/login') || currentPath === '/';
                 const requestUrl = error.config?.url || '';
                 const isPublicRoute = requestUrl.includes('/public/') ||
@@ -146,7 +147,11 @@ api.interceptors.response.use(
                     console.warn('Redirecting to login due to expired token');
                     // Usar setTimeout para evitar problemas con el contexto de React
                     setTimeout(() => {
-                        window.location.href = '/#/profesor/login';
+                        if (currentPath.includes('/admin') || currentPath.includes('/profesor')) {
+                            window.location.href = '/admin/login';
+                        } else {
+                            window.location.href = '/login';
+                        }
                     }, 100);
                 }
             }

--- a/microfrontends/apps/mf-evaluations/services/authService.ts
+++ b/microfrontends/apps/mf-evaluations/services/authService.ts
@@ -5,6 +5,7 @@ import {
     signOut,
 } from 'firebase/auth';
 import { auth } from '../src/lib/firebase';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 export interface LoginRequest {
     email: string;
@@ -64,7 +65,7 @@ class AuthService {
             const data = response.data;
 
             // 3. Store the Firebase idToken for immediate use until interceptor takes over
-            localStorage.setItem('auth_token', idToken);
+            localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
             return {
                 success: true,
@@ -104,7 +105,7 @@ class AuthService {
             });
             const data = response.data;
 
-            localStorage.setItem('auth_token', idToken);
+            localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
             return {
                 success: true,
@@ -141,8 +142,8 @@ class AuthService {
         } catch (e) {
             // Ignore Firebase signOut errors
         }
-        localStorage.removeItem('auth_token');
-        localStorage.removeItem('authenticated_user');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
     }
 }
 

--- a/microfrontends/apps/mf-evaluations/services/http.ts
+++ b/microfrontends/apps/mf-evaluations/services/http.ts
@@ -7,6 +7,7 @@ import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosError } f
 import { oidcService } from './oidcService';
 import { getApiBaseUrl } from '../config/api.config';
 import { csrfService } from './csrfService';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 // Tipos
 interface RetryConfig {
@@ -154,12 +155,12 @@ class HttpClient {
   private async getAccessToken(): Promise<string | null> {
     try {
       // Primero intentar obtener el token de usuario regular (apoderado)
-      let token = localStorage.getItem('auth_token');
+      let token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
       console.log('http.ts - auth_token:', token ? `${token.substring(0, 20)}...` : 'NOT FOUND');
 
       // Si no hay token de usuario regular, intentar con token de profesor
       if (!token) {
-        token = localStorage.getItem('professor_token');
+        token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
         console.log('http.ts - professor_token:', token ? `${token.substring(0, 20)}...` : 'NOT FOUND');
       }
 
@@ -257,8 +258,8 @@ class HttpClient {
       console.warn('Session invalidated - User logged in from another device');
 
       // Clear ALL tokens
-      localStorage.removeItem('auth_token');
-      localStorage.removeItem('professor_token');
+      localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+      localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
       sessionStorage.clear();
 
       // Show alert to user
@@ -294,7 +295,7 @@ class HttpClient {
     const currentPath = window.location.pathname + window.location.search;
     sessionStorage.setItem('redirectAfterLogin', currentPath);
     
-    window.location.href = '/#/profesor/login';
+    window.location.href = '/login';
   }
 
   private createHttpError(error: AxiosError, correlationId?: string): HttpError {

--- a/microfrontends/apps/mf-evaluations/services/professorAuthService.ts
+++ b/microfrontends/apps/mf-evaluations/services/professorAuthService.ts
@@ -1,4 +1,5 @@
 import api from './api';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 // RSA encryption removed - credentials sent over HTTPS only
 // import encryptionService from './encryptionService';
 
@@ -45,9 +46,9 @@ class ProfessorAuthService {
 
             // Guardar token en localStorage
             if (data.token) {
-                localStorage.setItem('professor_token', data.token);
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN), data.token);
                 const u = data.user;
-                localStorage.setItem('professor_user', JSON.stringify({
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER), JSON.stringify({
                     email: u?.email || data.email,
                     firstName: u?.firstName || data.firstName,
                     lastName: u?.lastName || data.lastName,
@@ -75,7 +76,7 @@ class ProfessorAuthService {
     
     async getCurrentProfessor(): Promise<ProfessorUser | null> {
         try {
-            const token = localStorage.getItem('professor_token');
+            const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
             if (!token) {
                 return null;
             }
@@ -100,19 +101,19 @@ class ProfessorAuthService {
     }
     
     isAuthenticated(): boolean {
-        const token = localStorage.getItem('professor_token');
+        const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
         return !!token;
     }
     
     getStoredProfessor() {
-        const stored = localStorage.getItem('professor_user');
+        const stored = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
         return stored ? JSON.parse(stored) : null;
     }
     
     logout() {
-        localStorage.removeItem('professor_token');
-        localStorage.removeItem('professor_user');
-        localStorage.removeItem('currentProfessor');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
     }
     
     // Método para verificar si el usuario es un profesor válido

--- a/microfrontends/apps/mf-evaluations/utils/microfrontendUrls.ts
+++ b/microfrontends/apps/mf-evaluations/utils/microfrontendUrls.ts
@@ -1,3 +1,5 @@
+import { resolveEnvironmentDomain } from '../../../packages/backend-sdk/src/index';
+
 const isBrowser = typeof window !== 'undefined';
 const host = isBrowser ? window.location.hostname : 'localhost';
 const protocol = isBrowser ? window.location.protocol : 'http:';
@@ -24,21 +26,6 @@ const subdomains: Partial<Record<keyof typeof localPorts, string>> = {
   coordinator: 'coordinadores',
 };
 
-const defaultBaseDomain = 'admitia.dedyn.io';
-
-const getEnvironmentDomain = () => {
-  const baseDomain = ((import.meta as any).env?.VITE_MF_BASE_DOMAIN || defaultBaseDomain)
-    .replace(/^https?:\/\//, '')
-    .replace(/\/$/, '');
-  const environment = ((import.meta as any).env?.VITE_MF_ENV || '').trim().toLowerCase();
-
-  if (!environment || environment === 'production' || environment === 'prod') {
-    return baseDomain;
-  }
-
-  return `${environment}.${baseDomain}`;
-};
-
 const buildUrl = (app: keyof typeof localPorts, hashPath: string) => {
   const envUrl = (import.meta as any).env?.[`VITE_MF_${app.toUpperCase()}_URL`];
   if (envUrl) return `${envUrl.replace(/\/$/, '')}/#${hashPath}`;
@@ -49,7 +36,7 @@ const buildUrl = (app: keyof typeof localPorts, hashPath: string) => {
 
   const subdomain = subdomains[app];
   if (subdomain) {
-    return `https://${subdomain}.${getEnvironmentDomain()}/#${hashPath}`;
+    return `https://${subdomain}.${resolveEnvironmentDomain((import.meta as any).env)}/#${hashPath}`;
   }
 
   return `${protocol}//${host}/#${hashPath}`;

--- a/microfrontends/apps/mf-guardian/components/admin/ApplicationDecisionModal.tsx
+++ b/microfrontends/apps/mf-guardian/components/admin/ApplicationDecisionModal.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import Modal from '../ui/Modal';
-import axios from 'axios';
-import { getApiBaseUrl } from '../../config/api.config';
+import api from '../../services/api';
 
 interface ApplicationDecisionModalProps {
   isOpen: boolean;
@@ -31,18 +30,9 @@ const ApplicationDecisionModal: React.FC<ApplicationDecisionModalProps> = ({
 
     setLoading(true);
     try {
-      const token = localStorage.getItem('auth_token');
-      await axios.post(
-        `${getApiBaseUrl()}/v1/applications/${application.id}/final-decision`,
-        {
-          decision,
-          note
-        },
-        {
-          headers: {
-            'Authorization': `Bearer ${token}`
-          }
-        }
+      await api.post(
+        `/v1/applications/${application.id}/final-decision`,
+        { decision, note }
       );
 
       setShowConfirmation(true);

--- a/microfrontends/apps/mf-guardian/components/auth/ProtectedCoordinatorRoute.tsx
+++ b/microfrontends/apps/mf-guardian/components/auth/ProtectedCoordinatorRoute.tsx
@@ -5,6 +5,7 @@
 
 import React, { ReactNode } from 'react';
 import { Navigate } from 'react-router-dom';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 interface ProtectedCoordinatorRouteProps {
   children: ReactNode;
@@ -12,14 +13,14 @@ interface ProtectedCoordinatorRouteProps {
 
 const ProtectedCoordinatorRoute: React.FC<ProtectedCoordinatorRouteProps> = ({ children }) => {
   // Verificar autenticación - revisar múltiples posibles tokens
-  const authToken = localStorage.getItem('auth_token');
+  const authToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
   const adminToken = localStorage.getItem('admin_token');
-  const professorToken = localStorage.getItem('professor_token');
+  const professorToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
 
   // Verificar múltiples ubicaciones de usuario en localStorage
-  const userStr = localStorage.getItem('authenticated_user') ||
+  const userStr = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER)) ||
                   localStorage.getItem('user') ||
-                  localStorage.getItem('professor_user');
+                  localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
 
   // Si hay un token de autenticación
   const isAuthenticated = !!(authToken || adminToken || professorToken);

--- a/microfrontends/apps/mf-guardian/components/layout/Header.tsx
+++ b/microfrontends/apps/mf-guardian/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import Button from '../ui/Button';
 import { microfrontendUrls } from '../../utils/microfrontendUrls';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 const Header: React.FC = () => {
     const navigate = useNavigate();
@@ -15,10 +16,10 @@ const Header: React.FC = () => {
     useEffect(() => {
         const checkAuthStatus = () => {
             // Verificar múltiples fuentes de autenticación
-            const currentProfessor = localStorage.getItem('currentProfessor');
-            const authToken = localStorage.getItem('auth_token');
-            const professorToken = localStorage.getItem('professor_token');
-            const apoderadoToken = localStorage.getItem('apoderado_token');
+            const currentProfessor = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
+            const authToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+            const professorToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+            const apoderadoToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
 
             // Verificar si hay profesor autenticado
             const hasProfessorAuth = !!(professorToken && currentProfessor);
@@ -66,10 +67,10 @@ const Header: React.FC = () => {
             e.preventDefault(); // Prevenir navegación predeterminada
 
             // Limpiar TODOS los tokens y datos de autenticación
-            localStorage.removeItem('auth_token');
-            localStorage.removeItem('professor_token');
-            localStorage.removeItem('apoderado_token');
-            localStorage.removeItem('currentProfessor');
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
             localStorage.removeItem('currentUser');
             localStorage.removeItem('currentApoderado');
 

--- a/microfrontends/apps/mf-guardian/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-guardian/context/AuthContext.tsx
@@ -3,6 +3,7 @@ import { onAuthStateChanged } from 'firebase/auth';
 import { auth, hasFirebaseConfig } from '../src/lib/firebase';
 import { authService } from '../services/authService';
 import api from '../services/api';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 interface User {
     id: string;
@@ -57,7 +58,7 @@ const buildUserFromBff = (u: any): User => ({
 
 const setAdminCompat = (user: User, token: string, subject?: string) => {
     if (user.role === 'ADMIN') {
-        localStorage.setItem('currentProfessor', JSON.stringify({
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR), JSON.stringify({
             id: user.id,
             firstName: user.firstName,
             lastName: user.lastName,
@@ -67,8 +68,8 @@ const setAdminCompat = (user: User, token: string, subject?: string) => {
             assignedGrades: ['prekinder', 'kinder', '1basico', '2basico', '3basico', '4basico', '5basico', '6basico', '7basico', '8basico', '1medio', '2medio', '3medio', '4medio'],
             isAdmin: true,
         }));
-        localStorage.setItem('professor_token', token);
-        localStorage.setItem('professor_user', JSON.stringify({
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN), token);
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER), JSON.stringify({
             email: user.email,
             firstName: user.firstName,
             lastName: user.lastName,
@@ -93,17 +94,17 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 // Firebase user is signed in — get fresh idToken and fetch profile from BFF
                 try {
                     const idToken = await firebaseUser.getIdToken();
-                    localStorage.setItem('auth_token', idToken);
+                    localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
                     // Check if we already have cached user data
-                    const cached = localStorage.getItem('authenticated_user');
+                    const cached = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                     if (cached) {
                         try {
                             setUser(JSON.parse(cached));
                             setIsLoading(false);
                             return;
                         } catch {
-                            localStorage.removeItem('authenticated_user');
+                            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                         }
                     }
 
@@ -111,20 +112,20 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                     const response = await api.get('/v1/auth/check');
                     if (response.data?.success && response.data?.user) {
                         const userData = buildUserFromBff(response.data.user);
-                        localStorage.setItem('authenticated_user', JSON.stringify(userData));
+                        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(userData));
                         setAdminCompat(userData, idToken, response.data.user?.subject);
                         setUser(userData);
                     }
                 } catch {
                     // BFF call failed — clear state
-                    localStorage.removeItem('auth_token');
-                    localStorage.removeItem('authenticated_user');
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                     setUser(null);
                 }
             } else {
                 // No Firebase user — clear everything
-                localStorage.removeItem('auth_token');
-                localStorage.removeItem('authenticated_user');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                 setUser(null);
             }
             setIsLoading(false);
@@ -141,7 +142,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             if (response.success && u) {
                 const userData = buildUserFromBff(u);
                 setAdminCompat(userData, response.token ?? '', u?.subject);
-                localStorage.setItem('authenticated_user', JSON.stringify(userData));
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(userData));
                 setUser(userData);
             } else {
                 throw new Error(response.message || 'Error en la autenticación');
@@ -170,7 +171,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 const newUser = buildUserFromBff(u);
                 newUser.phone = userData.phone;
                 newUser.rut = userData.rut;
-                localStorage.setItem('authenticated_user', JSON.stringify(newUser));
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(newUser));
                 setUser(newUser);
             } else {
                 throw new Error(response.message || 'Error al crear la cuenta');
@@ -184,13 +185,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
     const logout = () => {
         authService.logout();
-        localStorage.removeItem('currentProfessor');
-        localStorage.removeItem('professor_token');
-        localStorage.removeItem('professor_user');
-        localStorage.removeItem('apoderado_token');
-        localStorage.removeItem('apoderado_user');
-        localStorage.removeItem('auth_token');
-        localStorage.removeItem('authenticated_user');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
         setUser(null);
         window.location.href = '/#/apoderado/login';
     };

--- a/microfrontends/apps/mf-guardian/pages/ApoderadoLogin.tsx
+++ b/microfrontends/apps/mf-guardian/pages/ApoderadoLogin.tsx
@@ -103,7 +103,7 @@ const ApoderadoLogin: React.FC = () => {
             await register(registerData, 'apoderado');
             // Para usuarios nuevos registrados, redirigir al formulario de postulación
             // no al dashboard directamente
-            window.location.href = microfrontendUrls.admissions;
+            window.location.href = microfrontendUrls.admissions + '?justRegistered=true';
         } catch (err: any) {
             const msg = err.message || 'Error al crear la cuenta. Intente nuevamente.';
             setError(msg);

--- a/microfrontends/apps/mf-guardian/pages/FamilyDashboard.tsx
+++ b/microfrontends/apps/mf-guardian/pages/FamilyDashboard.tsx
@@ -39,7 +39,7 @@ import { applicationService, Application } from '../services/applicationService'
 import { useAuth } from '../context/AuthContext';
 import useUserProfile from '../hooks/useUserProfile';
 import applicationWorkflowService, { type ApplicationDraft } from '../services/applicationWorkflowService';
-import documentGatewayService from '../services/documentGatewayService';
+import { documentService } from '../services/documentService';
 import FamilyInterviews from '../components/family/FamilyInterviews';
 import FamilyCalendar from '../components/family/FamilyCalendar';
 import ComplementaryApplicationForm from './ComplementaryApplicationForm';
@@ -85,23 +85,24 @@ const FamilyDashboard: React.FC = () => {
   const [loadingDocuments, setLoadingDocuments] = useState(false);
 
   // Function to download/view document
-  const handleViewDocument = (documentId: number, documentName: string) => {
-    // Try to get token from different possible storage keys
-    const token = localStorage.getItem('apoderado_token') ||
-                  localStorage.getItem('auth_token') ||
-                  localStorage.getItem('professor_token');
+  const handleViewDocument = async (documentId: number, documentName: string) => {
+    const viewer = window.open('', '_blank');
 
-    if (!token) {
-      alert('No se encontró el token de autenticación. Por favor, inicia sesión nuevamente.');
-      return;
+    try {
+      const blob = await documentService.viewDocument(documentId);
+      const url = window.URL.createObjectURL(blob);
+
+      if (viewer) {
+        viewer.location.href = url;
+      } else {
+        window.open(url, '_blank');
+      }
+
+      window.setTimeout(() => window.URL.revokeObjectURL(url), 60_000);
+    } catch (error: any) {
+      viewer?.close();
+      alert(error.message || `No se pudo abrir el documento ${documentName || ''}`.trim());
     }
-
-    // Use environment variable for API URL
-    const baseUrl = import.meta.env.VITE_API_BASE_URL || '';
-    const downloadUrl = `${baseUrl}/v1/documents/${documentId}/download?token=${encodeURIComponent(token)}`;
-
-    // Open in new tab for viewing (browser will handle display based on content type)
-    window.open(downloadUrl, '_blank');
   };
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/microfrontends/apps/mf-guardian/services/api.ts
+++ b/microfrontends/apps/mf-guardian/services/api.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { csrfService } from './csrfService';
 import { getApiBaseUrl } from '../config/api.config';
 import { auth } from '../src/lib/firebase';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 // Configuración base de axios - Using nginx gateway for microservices
 // NO baseURL here - will be set in request interceptor for runtime detection
@@ -61,11 +62,11 @@ api.interceptors.request.use(
                     const idToken = await currentUser.getIdToken();
                     config.headers.Authorization = `Bearer ${idToken}`;
                 } catch {
-                    const token = localStorage.getItem('auth_token');
+                    const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
                     if (token) config.headers.Authorization = `Bearer ${token}`;
                 }
             } else {
-                const token = localStorage.getItem('auth_token') || localStorage.getItem('professor_token');
+                const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN)) || localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
                 if (token) config.headers.Authorization = `Bearer ${token}`;
             }
         }
@@ -126,16 +127,16 @@ api.interceptors.response.use(
                 console.warn('JWT token expired or invalid - cleaning session');
 
                 // Limpiar token de usuario regular
-                localStorage.removeItem('auth_token');
-                localStorage.removeItem('authenticated_user');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
 
                 // Limpiar token de profesor
-                localStorage.removeItem('professor_token');
-                localStorage.removeItem('professor_user');
-                localStorage.removeItem('currentProfessor');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
 
                 // Solo redirigir si no estamos ya en una página de login o si no es una ruta pública
-                const currentPath = window.location.hash || window.location.pathname;
+                const currentPath = window.location.pathname;
                 const isLoginPage = currentPath.includes('/login') || currentPath === '/';
                 const requestUrl = error.config?.url || '';
                 const isPublicRoute = requestUrl.includes('/public/') ||
@@ -146,7 +147,11 @@ api.interceptors.response.use(
                     console.warn('Redirecting to login due to expired token');
                     // Usar setTimeout para evitar problemas con el contexto de React
                     setTimeout(() => {
-                        window.location.href = '/#/apoderado/login';
+                        if (currentPath.includes('/admin') || currentPath.includes('/profesor')) {
+                            window.location.href = '/admin/login';
+                        } else {
+                            window.location.href = '/login';
+                        }
                     }, 100);
                 }
             }

--- a/microfrontends/apps/mf-guardian/services/authService.ts
+++ b/microfrontends/apps/mf-guardian/services/authService.ts
@@ -5,6 +5,7 @@ import {
     signOut,
 } from 'firebase/auth';
 import { auth } from '../src/lib/firebase';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 export interface LoginRequest {
     email: string;
@@ -64,7 +65,7 @@ class AuthService {
             const data = response.data;
 
             // 3. Store the Firebase idToken for immediate use until interceptor takes over
-            localStorage.setItem('auth_token', idToken);
+            localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
             return {
                 success: true,
@@ -104,7 +105,7 @@ class AuthService {
             });
             const data = response.data;
 
-            localStorage.setItem('auth_token', idToken);
+            localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
             return {
                 success: true,
@@ -141,8 +142,8 @@ class AuthService {
         } catch (e) {
             // Ignore Firebase signOut errors
         }
-        localStorage.removeItem('auth_token');
-        localStorage.removeItem('authenticated_user');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
     }
 }
 

--- a/microfrontends/apps/mf-guardian/services/http.ts
+++ b/microfrontends/apps/mf-guardian/services/http.ts
@@ -7,6 +7,7 @@ import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosError } f
 import { oidcService } from './oidcService';
 import { getApiBaseUrl } from '../config/api.config';
 import { csrfService } from './csrfService';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 // Tipos
 interface RetryConfig {
@@ -154,12 +155,12 @@ class HttpClient {
   private async getAccessToken(): Promise<string | null> {
     try {
       // Primero intentar obtener el token de usuario regular (apoderado)
-      let token = localStorage.getItem('auth_token');
+      let token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
       console.log('http.ts - auth_token:', token ? `${token.substring(0, 20)}...` : 'NOT FOUND');
 
       // Si no hay token de usuario regular, intentar con token de profesor
       if (!token) {
-        token = localStorage.getItem('professor_token');
+        token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
         console.log('http.ts - professor_token:', token ? `${token.substring(0, 20)}...` : 'NOT FOUND');
       }
 
@@ -257,8 +258,8 @@ class HttpClient {
       console.warn('Session invalidated - User logged in from another device');
 
       // Clear ALL tokens
-      localStorage.removeItem('auth_token');
-      localStorage.removeItem('professor_token');
+      localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+      localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
       sessionStorage.clear();
 
       // Show alert to user
@@ -294,7 +295,7 @@ class HttpClient {
     const currentPath = window.location.pathname + window.location.search;
     sessionStorage.setItem('redirectAfterLogin', currentPath);
     
-    window.location.href = '/#/apoderado/login';
+    window.location.href = '/login';
   }
 
   private createHttpError(error: AxiosError, correlationId?: string): HttpError {

--- a/microfrontends/apps/mf-guardian/services/professorAuthService.ts
+++ b/microfrontends/apps/mf-guardian/services/professorAuthService.ts
@@ -1,4 +1,5 @@
 import api from './api';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 // RSA encryption removed - credentials sent over HTTPS only
 // import encryptionService from './encryptionService';
 
@@ -45,9 +46,9 @@ class ProfessorAuthService {
 
             // Guardar token en localStorage
             if (data.token) {
-                localStorage.setItem('professor_token', data.token);
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN), data.token);
                 const u = data.user;
-                localStorage.setItem('professor_user', JSON.stringify({
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER), JSON.stringify({
                     email: u?.email || data.email,
                     firstName: u?.firstName || data.firstName,
                     lastName: u?.lastName || data.lastName,
@@ -75,7 +76,7 @@ class ProfessorAuthService {
     
     async getCurrentProfessor(): Promise<ProfessorUser | null> {
         try {
-            const token = localStorage.getItem('professor_token');
+            const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
             if (!token) {
                 return null;
             }
@@ -100,19 +101,19 @@ class ProfessorAuthService {
     }
     
     isAuthenticated(): boolean {
-        const token = localStorage.getItem('professor_token');
+        const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
         return !!token;
     }
     
     getStoredProfessor() {
-        const stored = localStorage.getItem('professor_user');
+        const stored = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
         return stored ? JSON.parse(stored) : null;
     }
     
     logout() {
-        localStorage.removeItem('professor_token');
-        localStorage.removeItem('professor_user');
-        localStorage.removeItem('currentProfessor');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
     }
     
     // Método para verificar si el usuario es un profesor válido

--- a/microfrontends/apps/mf-guardian/utils/microfrontendUrls.ts
+++ b/microfrontends/apps/mf-guardian/utils/microfrontendUrls.ts
@@ -1,3 +1,5 @@
+import { resolveEnvironmentDomain } from '../../../packages/backend-sdk/src/index';
+
 const isBrowser = typeof window !== 'undefined';
 const host = isBrowser ? window.location.hostname : 'localhost';
 const protocol = isBrowser ? window.location.protocol : 'http:';
@@ -24,21 +26,6 @@ const subdomains: Partial<Record<keyof typeof localPorts, string>> = {
   coordinator: 'coordinadores',
 };
 
-const defaultBaseDomain = 'admitia.dedyn.io';
-
-const getEnvironmentDomain = () => {
-  const baseDomain = ((import.meta as any).env?.VITE_MF_BASE_DOMAIN || defaultBaseDomain)
-    .replace(/^https?:\/\//, '')
-    .replace(/\/$/, '');
-  const environment = ((import.meta as any).env?.VITE_MF_ENV || '').trim().toLowerCase();
-
-  if (!environment || environment === 'production' || environment === 'prod') {
-    return baseDomain;
-  }
-
-  return `${environment}.${baseDomain}`;
-};
-
 const buildUrl = (app: keyof typeof localPorts, hashPath: string) => {
   const envUrl = (import.meta as any).env?.[`VITE_MF_${app.toUpperCase()}_URL`];
   if (envUrl) return `${envUrl.replace(/\/$/, '')}/#${hashPath}`;
@@ -49,7 +36,7 @@ const buildUrl = (app: keyof typeof localPorts, hashPath: string) => {
 
   const subdomain = subdomains[app];
   if (subdomain) {
-    return `https://${subdomain}.${getEnvironmentDomain()}/#${hashPath}`;
+    return `https://${subdomain}.${resolveEnvironmentDomain((import.meta as any).env)}/#${hashPath}`;
   }
 
   return `${protocol}//${host}/#${hashPath}`;

--- a/microfrontends/apps/mf-interviews/components/admin/ApplicationDecisionModal.tsx
+++ b/microfrontends/apps/mf-interviews/components/admin/ApplicationDecisionModal.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import Modal from '../ui/Modal';
-import axios from 'axios';
-import { getApiBaseUrl } from '../../config/api.config';
+import api from '../../services/api';
 
 interface ApplicationDecisionModalProps {
   isOpen: boolean;
@@ -31,18 +30,9 @@ const ApplicationDecisionModal: React.FC<ApplicationDecisionModalProps> = ({
 
     setLoading(true);
     try {
-      const token = localStorage.getItem('auth_token');
-      await axios.post(
-        `${getApiBaseUrl()}/v1/applications/${application.id}/final-decision`,
-        {
-          decision,
-          note
-        },
-        {
-          headers: {
-            'Authorization': `Bearer ${token}`
-          }
-        }
+      await api.post(
+        `/v1/applications/${application.id}/final-decision`,
+        { decision, note }
       );
 
       setShowConfirmation(true);

--- a/microfrontends/apps/mf-interviews/components/auth/ProtectedCoordinatorRoute.tsx
+++ b/microfrontends/apps/mf-interviews/components/auth/ProtectedCoordinatorRoute.tsx
@@ -5,6 +5,7 @@
 
 import React, { ReactNode } from 'react';
 import { Navigate } from 'react-router-dom';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 interface ProtectedCoordinatorRouteProps {
   children: ReactNode;
@@ -12,14 +13,14 @@ interface ProtectedCoordinatorRouteProps {
 
 const ProtectedCoordinatorRoute: React.FC<ProtectedCoordinatorRouteProps> = ({ children }) => {
   // Verificar autenticación - revisar múltiples posibles tokens
-  const authToken = localStorage.getItem('auth_token');
+  const authToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
   const adminToken = localStorage.getItem('admin_token');
-  const professorToken = localStorage.getItem('professor_token');
+  const professorToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
 
   // Verificar múltiples ubicaciones de usuario en localStorage
-  const userStr = localStorage.getItem('authenticated_user') ||
+  const userStr = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER)) ||
                   localStorage.getItem('user') ||
-                  localStorage.getItem('professor_user');
+                  localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
 
   // Si hay un token de autenticación
   const isAuthenticated = !!(authToken || adminToken || professorToken);

--- a/microfrontends/apps/mf-interviews/components/layout/Header.tsx
+++ b/microfrontends/apps/mf-interviews/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import Button from '../ui/Button';
 import { microfrontendUrls } from '../../utils/microfrontendUrls';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 const Header: React.FC = () => {
     const navigate = useNavigate();
@@ -15,10 +16,10 @@ const Header: React.FC = () => {
     useEffect(() => {
         const checkAuthStatus = () => {
             // Verificar múltiples fuentes de autenticación
-            const currentProfessor = localStorage.getItem('currentProfessor');
-            const authToken = localStorage.getItem('auth_token');
-            const professorToken = localStorage.getItem('professor_token');
-            const apoderadoToken = localStorage.getItem('apoderado_token');
+            const currentProfessor = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
+            const authToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+            const professorToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+            const apoderadoToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
 
             // Verificar si hay profesor autenticado
             const hasProfessorAuth = !!(professorToken && currentProfessor);
@@ -66,10 +67,10 @@ const Header: React.FC = () => {
             e.preventDefault(); // Prevenir navegación predeterminada
 
             // Limpiar TODOS los tokens y datos de autenticación
-            localStorage.removeItem('auth_token');
-            localStorage.removeItem('professor_token');
-            localStorage.removeItem('apoderado_token');
-            localStorage.removeItem('currentProfessor');
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
             localStorage.removeItem('currentUser');
             localStorage.removeItem('currentApoderado');
 

--- a/microfrontends/apps/mf-interviews/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-interviews/context/AuthContext.tsx
@@ -3,6 +3,7 @@ import { onAuthStateChanged } from 'firebase/auth';
 import { auth, hasFirebaseConfig } from '../src/lib/firebase';
 import { authService } from '../services/authService';
 import api from '../services/api';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 interface User {
     id: string;
@@ -57,7 +58,7 @@ const buildUserFromBff = (u: any): User => ({
 
 const setAdminCompat = (user: User, token: string, subject?: string) => {
     if (user.role === 'ADMIN') {
-        localStorage.setItem('currentProfessor', JSON.stringify({
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR), JSON.stringify({
             id: user.id,
             firstName: user.firstName,
             lastName: user.lastName,
@@ -67,8 +68,8 @@ const setAdminCompat = (user: User, token: string, subject?: string) => {
             assignedGrades: ['prekinder', 'kinder', '1basico', '2basico', '3basico', '4basico', '5basico', '6basico', '7basico', '8basico', '1medio', '2medio', '3medio', '4medio'],
             isAdmin: true,
         }));
-        localStorage.setItem('professor_token', token);
-        localStorage.setItem('professor_user', JSON.stringify({
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN), token);
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER), JSON.stringify({
             email: user.email,
             firstName: user.firstName,
             lastName: user.lastName,
@@ -93,17 +94,17 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 // Firebase user is signed in — get fresh idToken and fetch profile from BFF
                 try {
                     const idToken = await firebaseUser.getIdToken();
-                    localStorage.setItem('auth_token', idToken);
+                    localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
                     // Check if we already have cached user data
-                    const cached = localStorage.getItem('authenticated_user');
+                    const cached = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                     if (cached) {
                         try {
                             setUser(JSON.parse(cached));
                             setIsLoading(false);
                             return;
                         } catch {
-                            localStorage.removeItem('authenticated_user');
+                            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                         }
                     }
 
@@ -111,20 +112,20 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                     const response = await api.get('/v1/auth/check');
                     if (response.data?.success && response.data?.user) {
                         const userData = buildUserFromBff(response.data.user);
-                        localStorage.setItem('authenticated_user', JSON.stringify(userData));
+                        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(userData));
                         setAdminCompat(userData, idToken, response.data.user?.subject);
                         setUser(userData);
                     }
                 } catch {
                     // BFF call failed — clear state
-                    localStorage.removeItem('auth_token');
-                    localStorage.removeItem('authenticated_user');
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                     setUser(null);
                 }
             } else {
                 // No Firebase user — clear everything
-                localStorage.removeItem('auth_token');
-                localStorage.removeItem('authenticated_user');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                 setUser(null);
             }
             setIsLoading(false);
@@ -141,7 +142,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             if (response.success && u) {
                 const userData = buildUserFromBff(u);
                 setAdminCompat(userData, response.token ?? '', u?.subject);
-                localStorage.setItem('authenticated_user', JSON.stringify(userData));
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(userData));
                 setUser(userData);
             } else {
                 throw new Error(response.message || 'Error en la autenticación');
@@ -170,7 +171,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 const newUser = buildUserFromBff(u);
                 newUser.phone = userData.phone;
                 newUser.rut = userData.rut;
-                localStorage.setItem('authenticated_user', JSON.stringify(newUser));
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(newUser));
                 setUser(newUser);
             } else {
                 throw new Error(response.message || 'Error al crear la cuenta');
@@ -184,13 +185,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
     const logout = () => {
         authService.logout();
-        localStorage.removeItem('currentProfessor');
-        localStorage.removeItem('professor_token');
-        localStorage.removeItem('professor_user');
-        localStorage.removeItem('apoderado_token');
-        localStorage.removeItem('apoderado_user');
-        localStorage.removeItem('auth_token');
-        localStorage.removeItem('authenticated_user');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
         setUser(null);
         window.location.href = '/apoderado-login';
     };

--- a/microfrontends/apps/mf-interviews/services/api.ts
+++ b/microfrontends/apps/mf-interviews/services/api.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { csrfService } from './csrfService';
 import { getApiBaseUrl } from '../config/api.config';
 import { auth } from '../src/lib/firebase';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 // Configuración base de axios - Using nginx gateway for microservices
 // NO baseURL here - will be set in request interceptor for runtime detection
@@ -61,11 +62,11 @@ api.interceptors.request.use(
                     const idToken = await currentUser.getIdToken();
                     config.headers.Authorization = `Bearer ${idToken}`;
                 } catch {
-                    const token = localStorage.getItem('auth_token');
+                    const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
                     if (token) config.headers.Authorization = `Bearer ${token}`;
                 }
             } else {
-                const token = localStorage.getItem('auth_token') || localStorage.getItem('professor_token');
+                const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN)) || localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
                 if (token) config.headers.Authorization = `Bearer ${token}`;
             }
         }
@@ -126,13 +127,13 @@ api.interceptors.response.use(
                 console.warn('JWT token expired or invalid - cleaning session');
 
                 // Limpiar token de usuario regular
-                localStorage.removeItem('auth_token');
-                localStorage.removeItem('authenticated_user');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
 
                 // Limpiar token de profesor
-                localStorage.removeItem('professor_token');
-                localStorage.removeItem('professor_user');
-                localStorage.removeItem('currentProfessor');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
 
                 // Solo redirigir si no estamos ya en una página de login o si no es una ruta pública
                 const currentPath = window.location.pathname;

--- a/microfrontends/apps/mf-interviews/services/authService.ts
+++ b/microfrontends/apps/mf-interviews/services/authService.ts
@@ -5,6 +5,7 @@ import {
     signOut,
 } from 'firebase/auth';
 import { auth } from '../src/lib/firebase';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 export interface LoginRequest {
     email: string;
@@ -64,7 +65,7 @@ class AuthService {
             const data = response.data;
 
             // 3. Store the Firebase idToken for immediate use until interceptor takes over
-            localStorage.setItem('auth_token', idToken);
+            localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
             return {
                 success: true,
@@ -104,7 +105,7 @@ class AuthService {
             });
             const data = response.data;
 
-            localStorage.setItem('auth_token', idToken);
+            localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
             return {
                 success: true,
@@ -141,8 +142,8 @@ class AuthService {
         } catch (e) {
             // Ignore Firebase signOut errors
         }
-        localStorage.removeItem('auth_token');
-        localStorage.removeItem('authenticated_user');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
     }
 }
 

--- a/microfrontends/apps/mf-interviews/services/http.ts
+++ b/microfrontends/apps/mf-interviews/services/http.ts
@@ -7,6 +7,7 @@ import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosError } f
 import { oidcService } from './oidcService';
 import { getApiBaseUrl } from '../config/api.config';
 import { csrfService } from './csrfService';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 // Tipos
 interface RetryConfig {
@@ -154,12 +155,12 @@ class HttpClient {
   private async getAccessToken(): Promise<string | null> {
     try {
       // Primero intentar obtener el token de usuario regular (apoderado)
-      let token = localStorage.getItem('auth_token');
+      let token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
       console.log('http.ts - auth_token:', token ? `${token.substring(0, 20)}...` : 'NOT FOUND');
 
       // Si no hay token de usuario regular, intentar con token de profesor
       if (!token) {
-        token = localStorage.getItem('professor_token');
+        token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
         console.log('http.ts - professor_token:', token ? `${token.substring(0, 20)}...` : 'NOT FOUND');
       }
 
@@ -257,8 +258,8 @@ class HttpClient {
       console.warn('Session invalidated - User logged in from another device');
 
       // Clear ALL tokens
-      localStorage.removeItem('auth_token');
-      localStorage.removeItem('professor_token');
+      localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+      localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
       sessionStorage.clear();
 
       // Show alert to user

--- a/microfrontends/apps/mf-interviews/services/professorAuthService.ts
+++ b/microfrontends/apps/mf-interviews/services/professorAuthService.ts
@@ -1,4 +1,5 @@
 import api from './api';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 // RSA encryption removed - credentials sent over HTTPS only
 // import encryptionService from './encryptionService';
 
@@ -45,9 +46,9 @@ class ProfessorAuthService {
 
             // Guardar token en localStorage
             if (data.token) {
-                localStorage.setItem('professor_token', data.token);
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN), data.token);
                 const u = data.user;
-                localStorage.setItem('professor_user', JSON.stringify({
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER), JSON.stringify({
                     email: u?.email || data.email,
                     firstName: u?.firstName || data.firstName,
                     lastName: u?.lastName || data.lastName,
@@ -75,7 +76,7 @@ class ProfessorAuthService {
     
     async getCurrentProfessor(): Promise<ProfessorUser | null> {
         try {
-            const token = localStorage.getItem('professor_token');
+            const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
             if (!token) {
                 return null;
             }
@@ -100,19 +101,19 @@ class ProfessorAuthService {
     }
     
     isAuthenticated(): boolean {
-        const token = localStorage.getItem('professor_token');
+        const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
         return !!token;
     }
     
     getStoredProfessor() {
-        const stored = localStorage.getItem('professor_user');
+        const stored = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
         return stored ? JSON.parse(stored) : null;
     }
     
     logout() {
-        localStorage.removeItem('professor_token');
-        localStorage.removeItem('professor_user');
-        localStorage.removeItem('currentProfessor');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
     }
     
     // Método para verificar si el usuario es un profesor válido

--- a/microfrontends/apps/mf-interviews/utils/microfrontendUrls.ts
+++ b/microfrontends/apps/mf-interviews/utils/microfrontendUrls.ts
@@ -1,3 +1,5 @@
+import { resolveEnvironmentDomain } from '../../../packages/backend-sdk/src/index';
+
 const isBrowser = typeof window !== 'undefined';
 const host = isBrowser ? window.location.hostname : 'localhost';
 const protocol = isBrowser ? window.location.protocol : 'http:';
@@ -24,21 +26,6 @@ const subdomains: Partial<Record<keyof typeof localPorts, string>> = {
   coordinator: 'coordinadores',
 };
 
-const defaultBaseDomain = 'admitia.dedyn.io';
-
-const getEnvironmentDomain = () => {
-  const baseDomain = ((import.meta as any).env?.VITE_MF_BASE_DOMAIN || defaultBaseDomain)
-    .replace(/^https?:\/\//, '')
-    .replace(/\/$/, '');
-  const environment = ((import.meta as any).env?.VITE_MF_ENV || '').trim().toLowerCase();
-
-  if (!environment || environment === 'production' || environment === 'prod') {
-    return baseDomain;
-  }
-
-  return `${environment}.${baseDomain}`;
-};
-
 const buildUrl = (app: keyof typeof localPorts, hashPath: string) => {
   const envUrl = (import.meta as any).env?.[`VITE_MF_${app.toUpperCase()}_URL`];
   if (envUrl) return `${envUrl.replace(/\/$/, '')}/#${hashPath}`;
@@ -49,7 +36,7 @@ const buildUrl = (app: keyof typeof localPorts, hashPath: string) => {
 
   const subdomain = subdomains[app];
   if (subdomain) {
-    return `https://${subdomain}.${getEnvironmentDomain()}/#${hashPath}`;
+    return `https://${subdomain}.${resolveEnvironmentDomain((import.meta as any).env)}/#${hashPath}`;
   }
 
   return `${protocol}//${host}/#${hashPath}`;

--- a/microfrontends/apps/mf-reports/components/admin/ApplicationDecisionModal.tsx
+++ b/microfrontends/apps/mf-reports/components/admin/ApplicationDecisionModal.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import Modal from '../ui/Modal';
-import axios from 'axios';
-import { getApiBaseUrl } from '../../config/api.config';
+import api from '../../services/api';
 
 interface ApplicationDecisionModalProps {
   isOpen: boolean;
@@ -31,18 +30,9 @@ const ApplicationDecisionModal: React.FC<ApplicationDecisionModalProps> = ({
 
     setLoading(true);
     try {
-      const token = localStorage.getItem('auth_token');
-      await axios.post(
-        `${getApiBaseUrl()}/v1/applications/${application.id}/final-decision`,
-        {
-          decision,
-          note
-        },
-        {
-          headers: {
-            'Authorization': `Bearer ${token}`
-          }
-        }
+      await api.post(
+        `/v1/applications/${application.id}/final-decision`,
+        { decision, note }
       );
 
       setShowConfirmation(true);

--- a/microfrontends/apps/mf-reports/components/auth/ProtectedCoordinatorRoute.tsx
+++ b/microfrontends/apps/mf-reports/components/auth/ProtectedCoordinatorRoute.tsx
@@ -5,6 +5,7 @@
 
 import React, { ReactNode } from 'react';
 import { Navigate } from 'react-router-dom';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 interface ProtectedCoordinatorRouteProps {
   children: ReactNode;
@@ -12,14 +13,14 @@ interface ProtectedCoordinatorRouteProps {
 
 const ProtectedCoordinatorRoute: React.FC<ProtectedCoordinatorRouteProps> = ({ children }) => {
   // Verificar autenticación - revisar múltiples posibles tokens
-  const authToken = localStorage.getItem('auth_token');
+  const authToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
   const adminToken = localStorage.getItem('admin_token');
-  const professorToken = localStorage.getItem('professor_token');
+  const professorToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
 
   // Verificar múltiples ubicaciones de usuario en localStorage
-  const userStr = localStorage.getItem('authenticated_user') ||
+  const userStr = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER)) ||
                   localStorage.getItem('user') ||
-                  localStorage.getItem('professor_user');
+                  localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
 
   // Si hay un token de autenticación
   const isAuthenticated = !!(authToken || adminToken || professorToken);

--- a/microfrontends/apps/mf-reports/components/layout/Header.tsx
+++ b/microfrontends/apps/mf-reports/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import Button from '../ui/Button';
 import { microfrontendUrls } from '../../utils/microfrontendUrls';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 const Header: React.FC = () => {
     const navigate = useNavigate();
@@ -15,10 +16,10 @@ const Header: React.FC = () => {
     useEffect(() => {
         const checkAuthStatus = () => {
             // Verificar múltiples fuentes de autenticación
-            const currentProfessor = localStorage.getItem('currentProfessor');
-            const authToken = localStorage.getItem('auth_token');
-            const professorToken = localStorage.getItem('professor_token');
-            const apoderadoToken = localStorage.getItem('apoderado_token');
+            const currentProfessor = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
+            const authToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+            const professorToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+            const apoderadoToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
 
             // Verificar si hay profesor autenticado
             const hasProfessorAuth = !!(professorToken && currentProfessor);
@@ -66,10 +67,10 @@ const Header: React.FC = () => {
             e.preventDefault(); // Prevenir navegación predeterminada
 
             // Limpiar TODOS los tokens y datos de autenticación
-            localStorage.removeItem('auth_token');
-            localStorage.removeItem('professor_token');
-            localStorage.removeItem('apoderado_token');
-            localStorage.removeItem('currentProfessor');
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
             localStorage.removeItem('currentUser');
             localStorage.removeItem('currentApoderado');
 

--- a/microfrontends/apps/mf-reports/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-reports/context/AuthContext.tsx
@@ -3,6 +3,7 @@ import { onAuthStateChanged } from 'firebase/auth';
 import { auth, hasFirebaseConfig } from '../src/lib/firebase';
 import { authService } from '../services/authService';
 import api from '../services/api';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 interface User {
     id: string;
@@ -57,7 +58,7 @@ const buildUserFromBff = (u: any): User => ({
 
 const setAdminCompat = (user: User, token: string, subject?: string) => {
     if (user.role === 'ADMIN') {
-        localStorage.setItem('currentProfessor', JSON.stringify({
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR), JSON.stringify({
             id: user.id,
             firstName: user.firstName,
             lastName: user.lastName,
@@ -67,8 +68,8 @@ const setAdminCompat = (user: User, token: string, subject?: string) => {
             assignedGrades: ['prekinder', 'kinder', '1basico', '2basico', '3basico', '4basico', '5basico', '6basico', '7basico', '8basico', '1medio', '2medio', '3medio', '4medio'],
             isAdmin: true,
         }));
-        localStorage.setItem('professor_token', token);
-        localStorage.setItem('professor_user', JSON.stringify({
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN), token);
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER), JSON.stringify({
             email: user.email,
             firstName: user.firstName,
             lastName: user.lastName,
@@ -93,17 +94,17 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 // Firebase user is signed in — get fresh idToken and fetch profile from BFF
                 try {
                     const idToken = await firebaseUser.getIdToken();
-                    localStorage.setItem('auth_token', idToken);
+                    localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
                     // Check if we already have cached user data
-                    const cached = localStorage.getItem('authenticated_user');
+                    const cached = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                     if (cached) {
                         try {
                             setUser(JSON.parse(cached));
                             setIsLoading(false);
                             return;
                         } catch {
-                            localStorage.removeItem('authenticated_user');
+                            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                         }
                     }
 
@@ -111,20 +112,20 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                     const response = await api.get('/v1/auth/check');
                     if (response.data?.success && response.data?.user) {
                         const userData = buildUserFromBff(response.data.user);
-                        localStorage.setItem('authenticated_user', JSON.stringify(userData));
+                        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(userData));
                         setAdminCompat(userData, idToken, response.data.user?.subject);
                         setUser(userData);
                     }
                 } catch {
                     // BFF call failed — clear state
-                    localStorage.removeItem('auth_token');
-                    localStorage.removeItem('authenticated_user');
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                     setUser(null);
                 }
             } else {
                 // No Firebase user — clear everything
-                localStorage.removeItem('auth_token');
-                localStorage.removeItem('authenticated_user');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                 setUser(null);
             }
             setIsLoading(false);
@@ -141,7 +142,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             if (response.success && u) {
                 const userData = buildUserFromBff(u);
                 setAdminCompat(userData, response.token ?? '', u?.subject);
-                localStorage.setItem('authenticated_user', JSON.stringify(userData));
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(userData));
                 setUser(userData);
             } else {
                 throw new Error(response.message || 'Error en la autenticación');
@@ -170,7 +171,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 const newUser = buildUserFromBff(u);
                 newUser.phone = userData.phone;
                 newUser.rut = userData.rut;
-                localStorage.setItem('authenticated_user', JSON.stringify(newUser));
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(newUser));
                 setUser(newUser);
             } else {
                 throw new Error(response.message || 'Error al crear la cuenta');
@@ -184,13 +185,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
     const logout = () => {
         authService.logout();
-        localStorage.removeItem('currentProfessor');
-        localStorage.removeItem('professor_token');
-        localStorage.removeItem('professor_user');
-        localStorage.removeItem('apoderado_token');
-        localStorage.removeItem('apoderado_user');
-        localStorage.removeItem('auth_token');
-        localStorage.removeItem('authenticated_user');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
         setUser(null);
         window.location.href = '/apoderado-login';
     };

--- a/microfrontends/apps/mf-reports/services/api.ts
+++ b/microfrontends/apps/mf-reports/services/api.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { csrfService } from './csrfService';
 import { getApiBaseUrl } from '../config/api.config';
 import { auth } from '../src/lib/firebase';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 // Configuración base de axios - Using nginx gateway for microservices
 // NO baseURL here - will be set in request interceptor for runtime detection
@@ -61,11 +62,11 @@ api.interceptors.request.use(
                     const idToken = await currentUser.getIdToken();
                     config.headers.Authorization = `Bearer ${idToken}`;
                 } catch {
-                    const token = localStorage.getItem('auth_token');
+                    const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
                     if (token) config.headers.Authorization = `Bearer ${token}`;
                 }
             } else {
-                const token = localStorage.getItem('auth_token') || localStorage.getItem('professor_token');
+                const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN)) || localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
                 if (token) config.headers.Authorization = `Bearer ${token}`;
             }
         }
@@ -126,13 +127,13 @@ api.interceptors.response.use(
                 console.warn('JWT token expired or invalid - cleaning session');
 
                 // Limpiar token de usuario regular
-                localStorage.removeItem('auth_token');
-                localStorage.removeItem('authenticated_user');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
 
                 // Limpiar token de profesor
-                localStorage.removeItem('professor_token');
-                localStorage.removeItem('professor_user');
-                localStorage.removeItem('currentProfessor');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
 
                 // Solo redirigir si no estamos ya en una página de login o si no es una ruta pública
                 const currentPath = window.location.pathname;

--- a/microfrontends/apps/mf-reports/services/authService.ts
+++ b/microfrontends/apps/mf-reports/services/authService.ts
@@ -5,6 +5,7 @@ import {
     signOut,
 } from 'firebase/auth';
 import { auth } from '../src/lib/firebase';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 export interface LoginRequest {
     email: string;
@@ -64,7 +65,7 @@ class AuthService {
             const data = response.data;
 
             // 3. Store the Firebase idToken for immediate use until interceptor takes over
-            localStorage.setItem('auth_token', idToken);
+            localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
             return {
                 success: true,
@@ -104,7 +105,7 @@ class AuthService {
             });
             const data = response.data;
 
-            localStorage.setItem('auth_token', idToken);
+            localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
             return {
                 success: true,
@@ -141,8 +142,8 @@ class AuthService {
         } catch (e) {
             // Ignore Firebase signOut errors
         }
-        localStorage.removeItem('auth_token');
-        localStorage.removeItem('authenticated_user');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
     }
 }
 

--- a/microfrontends/apps/mf-reports/services/http.ts
+++ b/microfrontends/apps/mf-reports/services/http.ts
@@ -7,6 +7,7 @@ import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosError } f
 import { oidcService } from './oidcService';
 import { getApiBaseUrl } from '../config/api.config';
 import { csrfService } from './csrfService';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 // Tipos
 interface RetryConfig {
@@ -154,12 +155,12 @@ class HttpClient {
   private async getAccessToken(): Promise<string | null> {
     try {
       // Primero intentar obtener el token de usuario regular (apoderado)
-      let token = localStorage.getItem('auth_token');
+      let token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
       console.log('http.ts - auth_token:', token ? `${token.substring(0, 20)}...` : 'NOT FOUND');
 
       // Si no hay token de usuario regular, intentar con token de profesor
       if (!token) {
-        token = localStorage.getItem('professor_token');
+        token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
         console.log('http.ts - professor_token:', token ? `${token.substring(0, 20)}...` : 'NOT FOUND');
       }
 
@@ -257,8 +258,8 @@ class HttpClient {
       console.warn('Session invalidated - User logged in from another device');
 
       // Clear ALL tokens
-      localStorage.removeItem('auth_token');
-      localStorage.removeItem('professor_token');
+      localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+      localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
       sessionStorage.clear();
 
       // Show alert to user

--- a/microfrontends/apps/mf-reports/services/professorAuthService.ts
+++ b/microfrontends/apps/mf-reports/services/professorAuthService.ts
@@ -1,4 +1,5 @@
 import api from './api';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 // RSA encryption removed - credentials sent over HTTPS only
 // import encryptionService from './encryptionService';
 
@@ -45,9 +46,9 @@ class ProfessorAuthService {
 
             // Guardar token en localStorage
             if (data.token) {
-                localStorage.setItem('professor_token', data.token);
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN), data.token);
                 const u = data.user;
-                localStorage.setItem('professor_user', JSON.stringify({
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER), JSON.stringify({
                     email: u?.email || data.email,
                     firstName: u?.firstName || data.firstName,
                     lastName: u?.lastName || data.lastName,
@@ -75,7 +76,7 @@ class ProfessorAuthService {
     
     async getCurrentProfessor(): Promise<ProfessorUser | null> {
         try {
-            const token = localStorage.getItem('professor_token');
+            const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
             if (!token) {
                 return null;
             }
@@ -100,19 +101,19 @@ class ProfessorAuthService {
     }
     
     isAuthenticated(): boolean {
-        const token = localStorage.getItem('professor_token');
+        const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
         return !!token;
     }
     
     getStoredProfessor() {
-        const stored = localStorage.getItem('professor_user');
+        const stored = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
         return stored ? JSON.parse(stored) : null;
     }
     
     logout() {
-        localStorage.removeItem('professor_token');
-        localStorage.removeItem('professor_user');
-        localStorage.removeItem('currentProfessor');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
     }
     
     // Método para verificar si el usuario es un profesor válido

--- a/microfrontends/apps/mf-reports/utils/microfrontendUrls.ts
+++ b/microfrontends/apps/mf-reports/utils/microfrontendUrls.ts
@@ -1,3 +1,5 @@
+import { resolveEnvironmentDomain } from '../../../packages/backend-sdk/src/index';
+
 const isBrowser = typeof window !== 'undefined';
 const host = isBrowser ? window.location.hostname : 'localhost';
 const protocol = isBrowser ? window.location.protocol : 'http:';
@@ -24,21 +26,6 @@ const subdomains: Partial<Record<keyof typeof localPorts, string>> = {
   coordinator: 'coordinadores',
 };
 
-const defaultBaseDomain = 'admitia.dedyn.io';
-
-const getEnvironmentDomain = () => {
-  const baseDomain = ((import.meta as any).env?.VITE_MF_BASE_DOMAIN || defaultBaseDomain)
-    .replace(/^https?:\/\//, '')
-    .replace(/\/$/, '');
-  const environment = ((import.meta as any).env?.VITE_MF_ENV || '').trim().toLowerCase();
-
-  if (!environment || environment === 'production' || environment === 'prod') {
-    return baseDomain;
-  }
-
-  return `${environment}.${baseDomain}`;
-};
-
 const buildUrl = (app: keyof typeof localPorts, hashPath: string) => {
   const envUrl = (import.meta as any).env?.[`VITE_MF_${app.toUpperCase()}_URL`];
   if (envUrl) return `${envUrl.replace(/\/$/, '')}/#${hashPath}`;
@@ -49,7 +36,7 @@ const buildUrl = (app: keyof typeof localPorts, hashPath: string) => {
 
   const subdomain = subdomains[app];
   if (subdomain) {
-    return `https://${subdomain}.${getEnvironmentDomain()}/#${hashPath}`;
+    return `https://${subdomain}.${resolveEnvironmentDomain((import.meta as any).env)}/#${hashPath}`;
   }
 
   return `${protocol}//${host}/#${hashPath}`;

--- a/microfrontends/apps/mf-student/components/admin/ApplicationDecisionModal.tsx
+++ b/microfrontends/apps/mf-student/components/admin/ApplicationDecisionModal.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import Modal from '../ui/Modal';
-import axios from 'axios';
-import { getApiBaseUrl } from '../../config/api.config';
+import api from '../../services/api';
 
 interface ApplicationDecisionModalProps {
   isOpen: boolean;
@@ -31,18 +30,9 @@ const ApplicationDecisionModal: React.FC<ApplicationDecisionModalProps> = ({
 
     setLoading(true);
     try {
-      const token = localStorage.getItem('auth_token');
-      await axios.post(
-        `${getApiBaseUrl()}/v1/applications/${application.id}/final-decision`,
-        {
-          decision,
-          note
-        },
-        {
-          headers: {
-            'Authorization': `Bearer ${token}`
-          }
-        }
+      await api.post(
+        `/v1/applications/${application.id}/final-decision`,
+        { decision, note }
       );
 
       setShowConfirmation(true);

--- a/microfrontends/apps/mf-student/components/auth/ProtectedCoordinatorRoute.tsx
+++ b/microfrontends/apps/mf-student/components/auth/ProtectedCoordinatorRoute.tsx
@@ -5,6 +5,7 @@
 
 import React, { ReactNode } from 'react';
 import { Navigate } from 'react-router-dom';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 interface ProtectedCoordinatorRouteProps {
   children: ReactNode;
@@ -12,14 +13,14 @@ interface ProtectedCoordinatorRouteProps {
 
 const ProtectedCoordinatorRoute: React.FC<ProtectedCoordinatorRouteProps> = ({ children }) => {
   // Verificar autenticación - revisar múltiples posibles tokens
-  const authToken = localStorage.getItem('auth_token');
+  const authToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
   const adminToken = localStorage.getItem('admin_token');
-  const professorToken = localStorage.getItem('professor_token');
+  const professorToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
 
   // Verificar múltiples ubicaciones de usuario en localStorage
-  const userStr = localStorage.getItem('authenticated_user') ||
+  const userStr = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER)) ||
                   localStorage.getItem('user') ||
-                  localStorage.getItem('professor_user');
+                  localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
 
   // Si hay un token de autenticación
   const isAuthenticated = !!(authToken || adminToken || professorToken);

--- a/microfrontends/apps/mf-student/components/layout/Header.tsx
+++ b/microfrontends/apps/mf-student/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import Button from '../ui/Button';
 import { microfrontendUrls } from '../../utils/microfrontendUrls';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 const Header: React.FC = () => {
     const navigate = useNavigate();
@@ -15,10 +16,10 @@ const Header: React.FC = () => {
     useEffect(() => {
         const checkAuthStatus = () => {
             // Verificar múltiples fuentes de autenticación
-            const currentProfessor = localStorage.getItem('currentProfessor');
-            const authToken = localStorage.getItem('auth_token');
-            const professorToken = localStorage.getItem('professor_token');
-            const apoderadoToken = localStorage.getItem('apoderado_token');
+            const currentProfessor = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
+            const authToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+            const professorToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+            const apoderadoToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
 
             // Verificar si hay profesor autenticado
             const hasProfessorAuth = !!(professorToken && currentProfessor);
@@ -66,10 +67,10 @@ const Header: React.FC = () => {
             e.preventDefault(); // Prevenir navegación predeterminada
 
             // Limpiar TODOS los tokens y datos de autenticación
-            localStorage.removeItem('auth_token');
-            localStorage.removeItem('professor_token');
-            localStorage.removeItem('apoderado_token');
-            localStorage.removeItem('currentProfessor');
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
+            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
             localStorage.removeItem('currentUser');
             localStorage.removeItem('currentApoderado');
 

--- a/microfrontends/apps/mf-student/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-student/context/AuthContext.tsx
@@ -3,6 +3,7 @@ import { onAuthStateChanged } from 'firebase/auth';
 import { auth, hasFirebaseConfig } from '../src/lib/firebase';
 import { authService } from '../services/authService';
 import api from '../services/api';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 interface User {
     id: string;
@@ -57,7 +58,7 @@ const buildUserFromBff = (u: any): User => ({
 
 const setAdminCompat = (user: User, token: string, subject?: string) => {
     if (user.role === 'ADMIN') {
-        localStorage.setItem('currentProfessor', JSON.stringify({
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR), JSON.stringify({
             id: user.id,
             firstName: user.firstName,
             lastName: user.lastName,
@@ -67,8 +68,8 @@ const setAdminCompat = (user: User, token: string, subject?: string) => {
             assignedGrades: ['prekinder', 'kinder', '1basico', '2basico', '3basico', '4basico', '5basico', '6basico', '7basico', '8basico', '1medio', '2medio', '3medio', '4medio'],
             isAdmin: true,
         }));
-        localStorage.setItem('professor_token', token);
-        localStorage.setItem('professor_user', JSON.stringify({
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN), token);
+        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER), JSON.stringify({
             email: user.email,
             firstName: user.firstName,
             lastName: user.lastName,
@@ -93,17 +94,17 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 // Firebase user is signed in — get fresh idToken and fetch profile from BFF
                 try {
                     const idToken = await firebaseUser.getIdToken();
-                    localStorage.setItem('auth_token', idToken);
+                    localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
                     // Check if we already have cached user data
-                    const cached = localStorage.getItem('authenticated_user');
+                    const cached = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                     if (cached) {
                         try {
                             setUser(JSON.parse(cached));
                             setIsLoading(false);
                             return;
                         } catch {
-                            localStorage.removeItem('authenticated_user');
+                            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                         }
                     }
 
@@ -111,20 +112,20 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                     const response = await api.get('/v1/auth/check');
                     if (response.data?.success && response.data?.user) {
                         const userData = buildUserFromBff(response.data.user);
-                        localStorage.setItem('authenticated_user', JSON.stringify(userData));
+                        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(userData));
                         setAdminCompat(userData, idToken, response.data.user?.subject);
                         setUser(userData);
                     }
                 } catch {
                     // BFF call failed — clear state
-                    localStorage.removeItem('auth_token');
-                    localStorage.removeItem('authenticated_user');
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                     setUser(null);
                 }
             } else {
                 // No Firebase user — clear everything
-                localStorage.removeItem('auth_token');
-                localStorage.removeItem('authenticated_user');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                 setUser(null);
             }
             setIsLoading(false);
@@ -141,7 +142,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             if (response.success && u) {
                 const userData = buildUserFromBff(u);
                 setAdminCompat(userData, response.token ?? '', u?.subject);
-                localStorage.setItem('authenticated_user', JSON.stringify(userData));
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(userData));
                 setUser(userData);
             } else {
                 throw new Error(response.message || 'Error en la autenticación');
@@ -170,7 +171,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 const newUser = buildUserFromBff(u);
                 newUser.phone = userData.phone;
                 newUser.rut = userData.rut;
-                localStorage.setItem('authenticated_user', JSON.stringify(newUser));
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(newUser));
                 setUser(newUser);
             } else {
                 throw new Error(response.message || 'Error al crear la cuenta');
@@ -184,13 +185,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
     const logout = () => {
         authService.logout();
-        localStorage.removeItem('currentProfessor');
-        localStorage.removeItem('professor_token');
-        localStorage.removeItem('professor_user');
-        localStorage.removeItem('apoderado_token');
-        localStorage.removeItem('apoderado_user');
-        localStorage.removeItem('auth_token');
-        localStorage.removeItem('authenticated_user');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
         setUser(null);
         window.location.href = '/#/examenes';
     };

--- a/microfrontends/apps/mf-student/services/api.ts
+++ b/microfrontends/apps/mf-student/services/api.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { csrfService } from './csrfService';
 import { getApiBaseUrl } from '../config/api.config';
 import { auth } from '../src/lib/firebase';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 // Configuración base de axios - Using nginx gateway for microservices
 // NO baseURL here - will be set in request interceptor for runtime detection
@@ -61,11 +62,11 @@ api.interceptors.request.use(
                     const idToken = await currentUser.getIdToken();
                     config.headers.Authorization = `Bearer ${idToken}`;
                 } catch {
-                    const token = localStorage.getItem('auth_token');
+                    const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
                     if (token) config.headers.Authorization = `Bearer ${token}`;
                 }
             } else {
-                const token = localStorage.getItem('auth_token') || localStorage.getItem('professor_token');
+                const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN)) || localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
                 if (token) config.headers.Authorization = `Bearer ${token}`;
             }
         }
@@ -126,16 +127,16 @@ api.interceptors.response.use(
                 console.warn('JWT token expired or invalid - cleaning session');
 
                 // Limpiar token de usuario regular
-                localStorage.removeItem('auth_token');
-                localStorage.removeItem('authenticated_user');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
 
                 // Limpiar token de profesor
-                localStorage.removeItem('professor_token');
-                localStorage.removeItem('professor_user');
-                localStorage.removeItem('currentProfessor');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
 
                 // Solo redirigir si no estamos ya en una página de login o si no es una ruta pública
-                const currentPath = window.location.hash || window.location.pathname;
+                const currentPath = window.location.pathname;
                 const isLoginPage = currentPath.includes('/login') || currentPath === '/';
                 const requestUrl = error.config?.url || '';
                 const isPublicRoute = requestUrl.includes('/public/') ||
@@ -146,7 +147,11 @@ api.interceptors.response.use(
                     console.warn('Redirecting to login due to expired token');
                     // Usar setTimeout para evitar problemas con el contexto de React
                     setTimeout(() => {
-                        window.location.href = '/#/examenes';
+                        if (currentPath.includes('/admin') || currentPath.includes('/profesor')) {
+                            window.location.href = '/admin/login';
+                        } else {
+                            window.location.href = '/login';
+                        }
                     }, 100);
                 }
             }

--- a/microfrontends/apps/mf-student/services/authService.ts
+++ b/microfrontends/apps/mf-student/services/authService.ts
@@ -5,6 +5,7 @@ import {
     signOut,
 } from 'firebase/auth';
 import { auth } from '../src/lib/firebase';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 export interface LoginRequest {
     email: string;
@@ -64,7 +65,7 @@ class AuthService {
             const data = response.data;
 
             // 3. Store the Firebase idToken for immediate use until interceptor takes over
-            localStorage.setItem('auth_token', idToken);
+            localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
             return {
                 success: true,
@@ -104,7 +105,7 @@ class AuthService {
             });
             const data = response.data;
 
-            localStorage.setItem('auth_token', idToken);
+            localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), idToken);
 
             return {
                 success: true,
@@ -141,8 +142,8 @@ class AuthService {
         } catch (e) {
             // Ignore Firebase signOut errors
         }
-        localStorage.removeItem('auth_token');
-        localStorage.removeItem('authenticated_user');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
     }
 }
 

--- a/microfrontends/apps/mf-student/services/http.ts
+++ b/microfrontends/apps/mf-student/services/http.ts
@@ -7,6 +7,7 @@ import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosError } f
 import { oidcService } from './oidcService';
 import { getApiBaseUrl } from '../config/api.config';
 import { csrfService } from './csrfService';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 // Tipos
 interface RetryConfig {
@@ -58,6 +59,7 @@ class HttpClient {
         'Accept': 'application/json',
       },
     });
+
     this.setupInterceptors();
   }
 
@@ -153,12 +155,12 @@ class HttpClient {
   private async getAccessToken(): Promise<string | null> {
     try {
       // Primero intentar obtener el token de usuario regular (apoderado)
-      let token = localStorage.getItem('auth_token');
+      let token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
       console.log('http.ts - auth_token:', token ? `${token.substring(0, 20)}...` : 'NOT FOUND');
 
       // Si no hay token de usuario regular, intentar con token de profesor
       if (!token) {
-        token = localStorage.getItem('professor_token');
+        token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
         console.log('http.ts - professor_token:', token ? `${token.substring(0, 20)}...` : 'NOT FOUND');
       }
 
@@ -256,8 +258,8 @@ class HttpClient {
       console.warn('Session invalidated - User logged in from another device');
 
       // Clear ALL tokens
-      localStorage.removeItem('auth_token');
-      localStorage.removeItem('professor_token');
+      localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+      localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
       sessionStorage.clear();
 
       // Show alert to user
@@ -293,7 +295,7 @@ class HttpClient {
     const currentPath = window.location.pathname + window.location.search;
     sessionStorage.setItem('redirectAfterLogin', currentPath);
     
-    window.location.href = '/#/examenes';
+    window.location.href = '/login';
   }
 
   private createHttpError(error: AxiosError, correlationId?: string): HttpError {

--- a/microfrontends/apps/mf-student/services/http.ts
+++ b/microfrontends/apps/mf-student/services/http.ts
@@ -58,7 +58,6 @@ class HttpClient {
         'Accept': 'application/json',
       },
     });
-
     this.setupInterceptors();
   }
 

--- a/microfrontends/apps/mf-student/services/professorAuthService.ts
+++ b/microfrontends/apps/mf-student/services/professorAuthService.ts
@@ -1,4 +1,5 @@
 import api from './api';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 // RSA encryption removed - credentials sent over HTTPS only
 // import encryptionService from './encryptionService';
 
@@ -45,9 +46,9 @@ class ProfessorAuthService {
 
             // Guardar token en localStorage
             if (data.token) {
-                localStorage.setItem('professor_token', data.token);
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN), data.token);
                 const u = data.user;
-                localStorage.setItem('professor_user', JSON.stringify({
+                localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER), JSON.stringify({
                     email: u?.email || data.email,
                     firstName: u?.firstName || data.firstName,
                     lastName: u?.lastName || data.lastName,
@@ -75,7 +76,7 @@ class ProfessorAuthService {
     
     async getCurrentProfessor(): Promise<ProfessorUser | null> {
         try {
-            const token = localStorage.getItem('professor_token');
+            const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
             if (!token) {
                 return null;
             }
@@ -100,19 +101,19 @@ class ProfessorAuthService {
     }
     
     isAuthenticated(): boolean {
-        const token = localStorage.getItem('professor_token');
+        const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
         return !!token;
     }
     
     getStoredProfessor() {
-        const stored = localStorage.getItem('professor_user');
+        const stored = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
         return stored ? JSON.parse(stored) : null;
     }
     
     logout() {
-        localStorage.removeItem('professor_token');
-        localStorage.removeItem('professor_user');
-        localStorage.removeItem('currentProfessor');
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER));
+        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
     }
     
     // Método para verificar si el usuario es un profesor válido

--- a/microfrontends/apps/mf-student/utils/microfrontendUrls.ts
+++ b/microfrontends/apps/mf-student/utils/microfrontendUrls.ts
@@ -1,3 +1,5 @@
+import { resolveEnvironmentDomain } from '../../../packages/backend-sdk/src/index';
+
 const isBrowser = typeof window !== 'undefined';
 const host = isBrowser ? window.location.hostname : 'localhost';
 const protocol = isBrowser ? window.location.protocol : 'http:';
@@ -24,21 +26,6 @@ const subdomains: Partial<Record<keyof typeof localPorts, string>> = {
   coordinator: 'coordinadores',
 };
 
-const defaultBaseDomain = 'admitia.dedyn.io';
-
-const getEnvironmentDomain = () => {
-  const baseDomain = ((import.meta as any).env?.VITE_MF_BASE_DOMAIN || defaultBaseDomain)
-    .replace(/^https?:\/\//, '')
-    .replace(/\/$/, '');
-  const environment = ((import.meta as any).env?.VITE_MF_ENV || '').trim().toLowerCase();
-
-  if (!environment || environment === 'production' || environment === 'prod') {
-    return baseDomain;
-  }
-
-  return `${environment}.${baseDomain}`;
-};
-
 const buildUrl = (app: keyof typeof localPorts, hashPath: string) => {
   const envUrl = (import.meta as any).env?.[`VITE_MF_${app.toUpperCase()}_URL`];
   if (envUrl) return `${envUrl.replace(/\/$/, '')}/#${hashPath}`;
@@ -49,7 +36,7 @@ const buildUrl = (app: keyof typeof localPorts, hashPath: string) => {
 
   const subdomain = subdomains[app];
   if (subdomain) {
-    return `https://${subdomain}.${getEnvironmentDomain()}/#${hashPath}`;
+    return `https://${subdomain}.${resolveEnvironmentDomain((import.meta as any).env)}/#${hashPath}`;
   }
 
   return `${protocol}//${host}/#${hashPath}`;

--- a/microfrontends/apps/shell/src/manifest.ts
+++ b/microfrontends/apps/shell/src/manifest.ts
@@ -1,5 +1,5 @@
 import type { ShellManifest } from '../../../packages/contracts/src/index';
-import { resolveBackendEndpoints } from '../../../packages/backend-sdk/src/index';
+import { resolveBackendEndpoints, resolveEnvironmentDomain } from '../../../packages/backend-sdk/src/index';
 
 const backend = resolveBackendEndpoints(import.meta.env as Record<string, string | undefined>);
 
@@ -16,21 +16,6 @@ const subdomains: Record<string, string | undefined> = {
   coordinator: 'coordinadores',
 };
 
-const defaultBaseDomain = 'admitia.dedyn.io';
-
-const getEnvironmentDomain = () => {
-  const baseDomain = ((import.meta as any).env?.VITE_MF_BASE_DOMAIN || defaultBaseDomain)
-    .replace(/^https?:\/\//, '')
-    .replace(/\/$/, '');
-  const environment = ((import.meta as any).env?.VITE_MF_ENV || '').trim().toLowerCase();
-
-  if (!environment || environment === 'production' || environment === 'prod') {
-    return baseDomain;
-  }
-
-  return `${environment}.${baseDomain}`;
-};
-
 const getMfUrl = (name: string, localPort: number, localPath: string, prodPath: string) => {
   const individualUrl = (import.meta as any).env?.[`VITE_MF_${name.toUpperCase()}_URL`];
   if (individualUrl) return `${individualUrl.replace(/\/$/, '')}/#${prodPath}`;
@@ -41,7 +26,7 @@ const getMfUrl = (name: string, localPort: number, localPath: string, prodPath: 
 
   const subdomain = subdomains[name];
   if (subdomain) {
-    return `https://${subdomain}.${getEnvironmentDomain()}/#${prodPath}`;
+    return `https://${subdomain}.${resolveEnvironmentDomain((import.meta as any).env)}/#${prodPath}`;
   }
 
   return `${window.location.origin}/#${prodPath}`;

--- a/microfrontends/packages/backend-sdk/src/index.ts
+++ b/microfrontends/packages/backend-sdk/src/index.ts
@@ -21,6 +21,89 @@ const roleMap: Record<string, UserRole> = {
   TEACHER_ENGLISH: 'TEACHER_ENGLISH',
 };
 
+const BASE_DOMAIN = 'admitia.dedyn.io';
+
+const KNOWN_ENVS = ['dev', 'sta', 'staging', 'qa', 'uat', 'test'];
+
+/**
+ * Infers the deployment environment from the current hostname at runtime.
+ * Pattern: <mf-subdomain>.<env>.<BASE_DOMAIN>  → returns env segment
+ * Pattern: <mf-subdomain>.<BASE_DOMAIN>          → returns 'production'
+ * Localhost / unknown                            → returns 'development'
+ */
+export function resolveEnvironmentFromHost(hostname?: string): string {
+  const host = hostname ?? (typeof window !== 'undefined' ? window.location.hostname : 'localhost');
+
+  if (host === 'localhost' || host === '127.0.0.1') {
+    return 'development';
+  }
+
+  if (!host.endsWith(BASE_DOMAIN)) {
+    return 'production';
+  }
+
+  const withoutBase = host.slice(0, host.length - BASE_DOMAIN.length - 1);
+  const parts = withoutBase.split('.');
+
+  if (parts.length >= 2) {
+    const envSegment = parts[parts.length - 1].toLowerCase();
+    if (KNOWN_ENVS.includes(envSegment)) {
+      return envSegment;
+    }
+  }
+
+  return 'production';
+}
+
+/**
+ * Returns a localStorage key prefixed with the current environment so that
+ * tokens from different environments never collide.
+ * dev   → "auth_token__dev"
+ * sta   → "auth_token__sta"
+ * prod  → "auth_token__production"
+ * local → "auth_token__development"
+ */
+export function getStorageKey(baseKey: string, hostname?: string): string {
+  const env = resolveEnvironmentFromHost(hostname);
+  return `${baseKey}__${env}`;
+}
+
+/**
+ * Returns the environment-aware MF base domain.
+ * Prefers VITE_MF_BASE_DOMAIN / VITE_MF_ENV when available (build-time),
+ * then falls back to runtime hostname inference.
+ */
+export function resolveEnvironmentDomain(env?: Record<string, string | undefined>): string {
+  const baseDomain = (env?.VITE_MF_BASE_DOMAIN || BASE_DOMAIN)
+    .replace(/^https?:\/\//, '')
+    .replace(/\/$/, '');
+
+  if (env?.VITE_MF_ENV) {
+    const mfEnv = env.VITE_MF_ENV.trim().toLowerCase();
+    if (!mfEnv || mfEnv === 'production' || mfEnv === 'prod') {
+      return baseDomain;
+    }
+    return `${mfEnv}.${baseDomain}`;
+  }
+
+  const runtimeEnv = resolveEnvironmentFromHost();
+  if (runtimeEnv === 'production' || runtimeEnv === 'development') {
+    return baseDomain;
+  }
+  return `${runtimeEnv}.${baseDomain}`;
+}
+
+export const BASE_STORAGE_KEYS = {
+  AUTH_TOKEN: 'auth_token',
+  PROFESSOR_TOKEN: 'professor_token',
+  APODERADO_TOKEN: 'apoderado_token',
+  AUTHENTICATED_USER: 'authenticated_user',
+  PROFESSOR_USER: 'professor_user',
+  CURRENT_PROFESSOR: 'currentProfessor',
+  APODERADO_USER: 'apoderado_user',
+} as const;
+
+/** @deprecated Use getStorageKey(BASE_STORAGE_KEYS.X) instead */
 export const AUTH_STORAGE_KEYS = [
   'auth_token',
   'professor_token',
@@ -37,7 +120,16 @@ export function resolveBackendEndpoints(env: Record<string, string | undefined> 
 }
 
 export function resolveAccessToken(storage: Pick<Storage, 'getItem'> = window.localStorage): string | null {
-  for (const key of AUTH_STORAGE_KEYS) {
+  const keys = [
+    getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN),
+    getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN),
+    getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN),
+    BASE_STORAGE_KEYS.AUTH_TOKEN,
+    BASE_STORAGE_KEYS.PROFESSOR_TOKEN,
+    BASE_STORAGE_KEYS.APODERADO_TOKEN,
+  ];
+
+  for (const key of keys) {
     const token = storage.getItem(key);
     if (token) {
       return token;
@@ -49,8 +141,10 @@ export function resolveAccessToken(storage: Pick<Storage, 'getItem'> = window.lo
 
 export function resolveSession(storage: Pick<Storage, 'getItem'> = window.localStorage): AuthSession | null {
   const raw =
-    storage.getItem('authenticated_user') ||
-    storage.getItem('professor_user') ||
+    storage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER)) ||
+    storage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER)) ||
+    storage.getItem(BASE_STORAGE_KEYS.AUTHENTICATED_USER) ||
+    storage.getItem(BASE_STORAGE_KEYS.PROFESSOR_USER) ||
     storage.getItem('user');
 
   if (!raw) {
@@ -65,7 +159,7 @@ export function resolveSession(storage: Pick<Storage, 'getItem'> = window.localS
       firstName: parsed.firstName ?? '',
       lastName: parsed.lastName ?? '',
       role: roleMap[String(parsed.role ?? '')] ?? roleFallback,
-      token: resolveAccessToken(storage),
+      token: resolveAccessToken(storage) ?? undefined,
     };
   } catch {
     return null;


### PR DESCRIPTION
## Descripción

Se corrigieron cuatro problemas críticos en los flujos de autenticación que afectaban a usuarios nuevos, administradores y sesiones persistentes entre microfrontends.

## Cambios realizados

### 1. Registro de usuarios → Formulario de postulación
**Archivo:** `microfrontends/apps/mf-guardian/pages/ApoderadoLogin.tsx`
- Se añade parámetro `?justRegistered=true` al redirigir después del registro
- El usuario accede directamente al formulario sin necesidad de login nuevamente

### 2. Verificación rápida de token
**Archivo:** `microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx`
- Nuevo useEffect que detecta el parámetro `?justRegistered=true`
- Valida el token de autenticación en máximo 200ms
- El formulario de postulación se carga inmediatamente si el token es válido

### 3. Redirección correcta de administrador
**Archivo:** `microfrontends/apps/mf-evaluations/pages/AdminLoginPage.tsx`
- Se importa `microfrontendUrls` para obtener la URL correcta del panel administrativo
- El login de administrador redirige a `http://localhost:5206` (mf-admin)
- Evita el bucle de redirección a la ruta inexistente `/admin`

### 4. Persistencia de sesión entre aplicaciones
**Archivo:** `microfrontends/apps/mf-admin/context/AuthContext.tsx`
- Nuevo useEffect que restaura la sesión desde localStorage antes del check de Firebase
- Valida el token mediante `/v1/auth/check` en máximo 200ms
- Mantiene la sesión del usuario al navegar entre diferentes microfrontends
