### PR TITLE
fix: corregir redirección a profesor en login de admin

### DIFF
--- a/microfrontends/apps/mf-admin/pages/AdminLogin.tsx
+++ b/microfrontends/apps/mf-admin/pages/AdminLogin.tsx
@@ -6,6 +6,7 @@ import Input from '../components/ui/Input';
 import { useAuth } from '../context/AuthContext';
 import { useNotifications } from '../context/AppContext';
 import { microfrontendUrls } from '../utils/microfrontendUrls';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 const AdminLogin: React.FC = () => {
     const navigate = useNavigate();
@@ -34,10 +35,10 @@ const AdminLogin: React.FC = () => {
         try {
             await login(email, password, 'ADMIN');
 
-            const storedUser = JSON.parse(localStorage.getItem('authenticated_user') || 'null');
+            const storedUser = JSON.parse(localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER)) || 'null');
             if (!storedUser || storedUser.role !== 'ADMIN') {
-                localStorage.removeItem('auth_token');
-                localStorage.removeItem('authenticated_user');
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
 
                 if (storedUser?.role === 'APODERADO') {
                     window.location.href = microfrontendUrls.guardianDashboard;


### PR DESCRIPTION
## Descripción

Se corrigió un bug donde los usuarios admin se redirigían al portal de profesor en lugar del panel de administración después de hacer login.

## Problema

Al hacer login en `admin.dev.admitia.dedyn.io`:
- El backend retornaba correctamente el rol ADMIN
- Pero el frontend buscaba los datos del usuario en localStorage con una clave incorrecta
- No encontraba los datos y asumía que no era admin
- Redirigía al usuario al portal de profesor

## Solución

Se actualizó `AdminLogin.tsx` para usar `getStorageKey()` al leer del localStorage, igual que hace `AuthContext` al guardar.

Ahora la lectura y escritura en localStorage están sincronizadas.

## Cambios

- `microfrontends/apps/mf-admin/pages/AdminLogin.tsx`: Uso correcto de `getStorageKey()` para localStorage

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>