### PR TITLE
Rediseño pagina de inicio y examenes

### DIFF
--- a/microfrontends/apps/mf-admissions/components/layout/Header.tsx
+++ b/microfrontends/apps/mf-admissions/components/layout/Header.tsx
@@ -1,12 +1,14 @@
 
 import React, { useState, useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import Button from '../ui/Button';
 import { microfrontendUrls } from '../../utils/microfrontendUrls';
 import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 const Header: React.FC = () => {
     const navigate = useNavigate();
+    const location = useLocation();
+    const isHomePage = location.pathname === '/';
     const [isAdmin, setIsAdmin] = useState(false);
     const [isProfessorLoggedIn, setIsProfessorLoggedIn] = useState(false);
     const [isAnyUserLoggedIn, setIsAnyUserLoggedIn] = useState(false);
@@ -123,7 +125,19 @@ const Header: React.FC = () => {
                 </nav>
 
                 <div className="flex items-center gap-2 sm:gap-4">
-                    {!isAnyUserLoggedIn && (
+                    {!isAnyUserLoggedIn && isHomePage && (
+                        <div className="hidden sm:flex items-center gap-3">
+                            <a href={microfrontendUrls.guardianLogin} className="text-gris-piedra hover:text-azul-monte-tabor font-semibold transition-colors duration-200">
+                                Iniciar sesión
+                            </a>
+                            <a href={microfrontendUrls.admissions}>
+                                <Button variant="primary" size="sm" className="!text-blanco-pureza">
+                                    Postular
+                                </Button>
+                            </a>
+                        </div>
+                    )}
+                    {!isAnyUserLoggedIn && !isHomePage && (
                         <a href={microfrontendUrls.admissions} className="hidden sm:block">
                             <Button variant="primary" size="sm">
                                 Iniciar Postulación
@@ -193,7 +207,21 @@ const Header: React.FC = () => {
                                 Admin
                             </a>
                         )}
-                        {!isAnyUserLoggedIn && (
+                        {!isAnyUserLoggedIn && isHomePage && (
+                            <div className="pt-2 pb-1 flex flex-col gap-2">
+                                <a href={microfrontendUrls.guardianLogin} onClick={() => setIsMobileMenuOpen(false)}>
+                                    <Button variant="outline" className="w-full">
+                                        Iniciar sesión
+                                    </Button>
+                                </a>
+                                <a href={microfrontendUrls.admissions} onClick={() => setIsMobileMenuOpen(false)}>
+                                    <Button variant="primary" className="w-full !text-blanco-pureza">
+                                        Postular
+                                    </Button>
+                                </a>
+                            </div>
+                        )}
+                        {!isAnyUserLoggedIn && !isHomePage && (
                             <div className="pt-2 pb-1">
                                 <a href={microfrontendUrls.admissions} onClick={() => setIsMobileMenuOpen(false)}>
                                     <Button variant="primary" className="w-full">

--- a/microfrontends/apps/mf-admissions/pages/HomePage.tsx
+++ b/microfrontends/apps/mf-admissions/pages/HomePage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import Button from '../components/ui/Button';
 import Card from '../components/ui/Card';
-import { FileText, Users, CheckCircle, Clock, Calendar, Calculator, BookOpen, Globe } from 'lucide-react';
+import { FileText, Users, CheckCircle, Calculator, BookOpen, Globe } from 'lucide-react';
 import { microfrontendUrls } from '../utils/microfrontendUrls';
 
 const HomePage: React.FC = () => {
@@ -13,30 +13,42 @@ const HomePage: React.FC = () => {
     ];
 
     const admissionTimeline = [
-        { date: '1 de Agosto', event: 'Inicio del Proceso de Postulación', current: true },
-        { date: '30 de Septiembre', event: 'Cierre de Postulaciones', current: false },
-        { date: '1 al 15 de Octubre', event: 'Periodo de Entrevistas', current: false },
-        { date: '1 de Noviembre', event: 'Publicación de Resultados', current: false },
+        {
+            date: 'AGOSTO 2025',
+            event: 'Apertura de Postulaciones',
+            description: 'Inicio del periodo oficial para la recepción de documentos y solicitudes en línea.',
+            current: true,
+            status: 'active',
+        },
+        {
+            date: 'SEPTIEMBRE - OCTUBRE 2025',
+            event: 'Exámenes y Entrevistas',
+            description: 'Periodo de evaluaciones académicas y encuentros personales con las familias postulantes.',
+            current: false,
+            status: 'upcoming',
+        },
+        {
+            date: 'NOVIEMBRE 2025',
+            event: 'Publicación de Resultados',
+            description: 'Comunicación oficial de las admisiones y formalización de la matrícula para el ciclo 2026.',
+            current: false,
+            status: 'future',
+        },
     ];
 
     return (
         <div className="bg-blanco-pureza">
             {/* Hero Section */}
-            <section className="relative text-blanco-pureza py-20 sm:py-32 text-center bg-cover bg-center" style={{ backgroundImage: `url('/images/colegio.png')`}}>
+            <section className="relative text-blanco-pureza py-[7.5rem] sm:py-48 text-center bg-cover bg-center" style={{ backgroundImage: `url('/images/colegio.png')`}}>
                 {/* Overlay azul con opacidad 85% */}
-                <div className="absolute inset-0 bg-azul-monte-tabor" style={{ opacity: 0.85 }}></div>
+                <div className="absolute inset-0 bg-azul-monte-tabor" style={{ opacity: 0.85, filter: 'brightness(0.75)' }}></div>
                 <div className="relative container mx-auto px-4 sm:px-6">
-                    <h1 className="text-3xl sm:text-5xl md:text-6xl font-black font-serif mb-4 animate-fade-in-down">Formando Líderes con Espíritu de Servicio</h1>
-                    <p className="text-base sm:text-xl text-gray-200 mb-8 max-w-3xl mx-auto">Únase a una comunidad educativa comprometida con la excelencia académica y la formación católica.</p>
-                    <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center items-center">
-                        <a href={microfrontendUrls.guardianLogin}>
-                            <Button size="lg" variant="primary">
-                                Postular Aquí
-                            </Button>
-                        </a>
-                        <a href={microfrontendUrls.guardianLogin}>
-                            <Button size="lg" variant="secondary">
-                                Portal Apoderados
+                    <h1 className="text-3xl sm:text-5xl md:text-6xl font-black font-serif mb-4 animate-fade-in-down">Formando líderes con espíritu de servicio</h1>
+                    <p className="text-base sm:text-xl text-gray-200 mb-8 max-w-3xl mx-auto">Únanse a una comunidad educativa comprometida con la excelencia académica y formación católica</p>
+                    <div className="flex justify-center">
+                        <a href={microfrontendUrls.admissions}>
+                            <Button size="lg" variant="primary" className="!text-blanco-pureza">
+                                Iniciar postulación
                             </Button>
                         </a>
                     </div>
@@ -45,50 +57,50 @@ const HomePage: React.FC = () => {
 
             {/* Steps Section */}
             <section className="py-12 sm:py-20 bg-gray-50">
-                <div className="container mx-auto px-4 sm:px-6 text-center">
-                    <h2 className="text-2xl sm:text-4xl font-bold text-azul-monte-tabor mb-4 font-serif">Proceso de Admisión</h2>
-                    <p className="text-gris-piedra mb-12 max-w-2xl mx-auto">Un camino claro y guiado para formar parte de nuestra comunidad educativa.</p>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 sm:gap-10">
+                <div className="container mx-auto px-4 sm:px-6">
+                    <h2 className="text-2xl sm:text-4xl font-bold text-azul-monte-tabor mb-4 font-serif text-center">Proceso de Admisión</h2>
+                    <p className="text-gris-piedra mb-12 max-w-2xl mx-auto text-center">Un camino claro y guiado para formar parte de nuestra comunidad educativa.</p>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-6">
                         {admissionSteps.map((step, index) => (
-                            <Card key={index} className="text-center p-8">
-                                <div className="flex justify-center mb-6">{step.icon}</div>
-                                <h3 className="text-xl font-bold text-azul-monte-tabor mb-2">{step.title}</h3>
-                                <p className="text-gris-piedra">{step.description}</p>
-                            </Card>
+                            <div key={index} className="bg-blanco-pureza p-8 rounded-2xl border border-gray-200 text-center">
+                                <div className="flex justify-center mb-4">{step.icon}</div>
+                                <h3 className="text-lg font-bold text-azul-monte-tabor mb-3">{step.title}</h3>
+                                <p className="text-gris-piedra text-sm">{step.description}</p>
+                            </div>
                         ))}
                     </div>
                 </div>
             </section>
 
             {/* Exam Portal Section */}
-            <section className="py-12 sm:py-20 bg-azul-monte-tabor text-blanco-pureza">
+            <section className="py-12 sm:py-20 bg-gray-100">
                 <div className="container mx-auto px-4 sm:px-6 text-center">
-                    <h2 className="text-2xl sm:text-4xl font-bold mb-4 font-serif">Portal de Exámenes de Admisión</h2>
-                    <p className="text-gray-200 mb-8 max-w-3xl mx-auto text-base sm:text-lg">
-                        Una vez completada tu postulación, podrás acceder al portal de exámenes para programar 
+                    <h2 className="text-2xl sm:text-4xl font-bold text-azul-monte-tabor mb-4 font-serif">Portal de Exámenes de Admisión</h2>
+                    <p className="text-gris-piedra mb-8 max-w-3xl mx-auto text-base sm:text-lg">
+                        Una vez completada tu postulación, podrás acceder al portal de exámenes para programar
                         y rendir las evaluaciones de Matemática, Lenguaje e Inglés.
                     </p>
-                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6 mb-8">
-                        <div className="bg-blanco-pureza bg-opacity-10 p-6 rounded-lg">
-                            <div className="flex justify-center mb-3">
-                                <Calculator className="w-12 h-12 text-dorado-nazaret" />
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6 mb-8 text-center">
+                        <div className="bg-blanco-pureza p-8 rounded-2xl border border-gray-200">
+                            <div className="flex justify-center mb-4">
+                                <Calculator className="w-10 h-10 text-dorado-nazaret" />
                             </div>
-                            <h3 className="font-bold text-dorado-nazaret mb-2">Matemática</h3>
-                            <p className="text-gray-200 text-sm">Evaluación adaptada según tu nivel educativo</p>
+                            <h3 className="font-bold text-azul-monte-tabor text-lg mb-3">Matemática</h3>
+                            <p className="text-gris-piedra text-sm">Evaluación adaptada según tu nivel educativo</p>
                         </div>
-                        <div className="bg-blanco-pureza bg-opacity-10 p-6 rounded-lg">
-                            <div className="flex justify-center mb-3">
-                                <BookOpen className="w-12 h-12 text-dorado-nazaret" />
+                        <div className="bg-blanco-pureza p-8 rounded-2xl border border-gray-200">
+                            <div className="flex justify-center mb-4">
+                                <BookOpen className="w-10 h-10 text-dorado-nazaret" />
                             </div>
-                            <h3 className="font-bold text-dorado-nazaret mb-2">Lenguaje</h3>
-                            <p className="text-gray-200 text-sm">Comprensión lectora y expresión escrita</p>
+                            <h3 className="font-bold text-azul-monte-tabor text-lg mb-3">Lenguaje</h3>
+                            <p className="text-gris-piedra text-sm">Comprensión lectora y expresión escrita</p>
                         </div>
-                        <div className="bg-blanco-pureza bg-opacity-10 p-6 rounded-lg">
-                            <div className="flex justify-center mb-3">
-                                <Globe className="w-12 h-12 text-dorado-nazaret" />
+                        <div className="bg-blanco-pureza p-8 rounded-2xl border border-gray-200">
+                            <div className="flex justify-center mb-4">
+                                <Globe className="w-10 h-10 text-dorado-nazaret" />
                             </div>
-                            <h3 className="font-bold text-dorado-nazaret mb-2">Inglés</h3>
-                            <p className="text-gray-200 text-sm">Gramática, vocabulario y comprensión</p>
+                            <h3 className="font-bold text-azul-monte-tabor text-lg mb-3">Inglés</h3>
+                            <p className="text-gris-piedra text-sm">Gramática, vocabulario y comprensión</p>
                         </div>
                     </div>
                     <a href={microfrontendUrls.studentExams}>
@@ -100,37 +112,52 @@ const HomePage: React.FC = () => {
             </section>
 
             {/* Timeline Section */}
-            <section className="py-12 sm:py-20">
+            <section className="py-12 sm:py-20 bg-gray-50">
                 <div className="container mx-auto px-4 sm:px-6">
-                    <h2 className="text-2xl sm:text-4xl font-bold text-azul-monte-tabor text-center mb-8 sm:mb-12 font-serif">Calendario de Admisión 2025</h2>
+                    <div className="text-center mb-12 sm:mb-16">
+                        <h2 className="text-2xl sm:text-4xl font-bold text-azul-monte-tabor mb-3 font-serif">Calendario de Admisión 2025</h2>
+                        <p className="text-dorado-nazaret font-medium">Fechas clave e hitos importantes para tu postulación</p>
+                    </div>
                     {/* Desktop: alternating timeline */}
                     <div className="hidden sm:block relative max-w-3xl mx-auto">
-                        <div className="absolute left-1/2 h-full w-1 bg-azul-monte-tabor rounded-full transform -translate-x-1/2"></div>
+                        <div className="absolute left-1/2 h-full w-0.5 bg-gray-300 transform -translate-x-1/2"></div>
                         {admissionTimeline.map((item, index) => (
-                            <div key={index} className={`flex items-center w-full mb-8 ${index % 2 === 0 ? 'justify-start' : 'justify-end'}`}>
-                                <div className={`w-5/12 ${index % 2 === 0 ? 'text-right pr-8' : 'text-left pl-8'}`}>
-                                    <p className="font-bold text-dorado-nazaret">{item.date}</p>
-                                    <p className="text-gris-piedra">{item.event}</p>
+                            <div key={index} className="flex items-center w-full mb-16">
+                                <div className="flex-1 pr-10 text-right">
+                                    {index % 2 === 0 ? (
+                                        <>
+                                            <p className={`text-xs font-bold uppercase tracking-wider mb-1 ${item.status === 'future' ? 'text-gray-400' : 'text-dorado-nazaret'}`}>{item.date}</p>
+                                            <p className={`font-bold text-base ${item.status === 'future' ? 'text-gray-400' : 'text-azul-monte-tabor'}`}>{item.event}</p>
+                                        </>
+                                    ) : (
+                                        <p className="text-gris-piedra text-sm">{item.description}</p>
+                                    )}
                                 </div>
-                                <div className="relative">
-                                    <div className={`w-8 h-8 rounded-full flex items-center justify-center z-10 ${item.current ? 'bg-dorado-nazaret ring-8 ring-amber-200' : 'bg-azul-monte-tabor'}`}>
-                                        <Clock className="w-5 h-5 text-blanco-pureza" />
-                                    </div>
+                                <div className="flex-shrink-0 z-10 w-3">
+                                    <div className={`w-3 h-3 rounded-full ${item.current ? 'bg-dorado-nazaret' : item.status === 'future' ? 'bg-gray-300' : 'bg-azul-monte-tabor'}`}></div>
                                 </div>
-                                <div className="w-5/12"></div>
+                                <div className="flex-1 pl-10 text-left">
+                                    {index % 2 === 0 ? (
+                                        <p className="text-gris-piedra text-sm">{item.description}</p>
+                                    ) : (
+                                        <>
+                                            <p className={`text-xs font-bold uppercase tracking-wider mb-1 ${item.status === 'future' ? 'text-gray-400' : 'text-dorado-nazaret'}`}>{item.date}</p>
+                                            <p className={`font-bold text-base ${item.status === 'future' ? 'text-gray-400' : 'text-azul-monte-tabor'}`}>{item.event}</p>
+                                        </>
+                                    )}
+                                </div>
                             </div>
                         ))}
                     </div>
                     {/* Mobile: vertical list */}
                     <div className="sm:hidden space-y-4 max-w-sm mx-auto">
                         {admissionTimeline.map((item, index) => (
-                            <div key={index} className={`flex items-start gap-4 p-4 rounded-lg border-l-4 ${item.current ? 'border-dorado-nazaret bg-amber-50' : 'border-azul-monte-tabor bg-gray-50'}`}>
-                                <div className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${item.current ? 'bg-dorado-nazaret' : 'bg-azul-monte-tabor'}`}>
-                                    <Clock className="w-4 h-4 text-blanco-pureza" />
-                                </div>
+                            <div key={index} className={`flex items-start gap-4 p-4 rounded-lg border-l-4 ${item.current ? 'border-dorado-nazaret bg-amber-50' : item.status === 'future' ? 'border-gray-300 bg-gray-100' : 'border-azul-monte-tabor bg-blanco-pureza'}`}>
+                                <div className={`w-3 h-3 rounded-full mt-1 flex-shrink-0 ${item.current ? 'bg-dorado-nazaret' : item.status === 'future' ? 'bg-gray-300' : 'bg-azul-monte-tabor'}`}></div>
                                 <div>
-                                    <p className="font-bold text-dorado-nazaret text-sm">{item.date}</p>
-                                    <p className="text-gris-piedra text-sm">{item.event}</p>
+                                    <p className={`text-xs font-bold uppercase tracking-wider mb-1 ${item.status === 'future' ? 'text-gray-400' : 'text-dorado-nazaret'}`}>{item.date}</p>
+                                    <p className={`font-bold text-sm mb-1 ${item.status === 'future' ? 'text-gray-400' : 'text-azul-monte-tabor'}`}>{item.event}</p>
+                                    <p className="text-gris-piedra text-sm">{item.description}</p>
                                 </div>
                             </div>
                         ))}
@@ -139,17 +166,17 @@ const HomePage: React.FC = () => {
             </section>
 
             {/* Sección de Contacto */}
-            <section className="py-12 sm:py-16 bg-azul-monte-tabor text-blanco-pureza">
+            <section className="py-12 sm:py-16 bg-blanco-pureza border-t border-gray-200">
                 <div className="container mx-auto px-4 sm:px-6 text-center">
-                    <h2 className="text-3xl font-bold mb-8">¿Tienes Preguntas?</h2>
-                    <p className="text-xl mb-8">
+                    <h2 className="text-2xl sm:text-3xl font-bold text-azul-monte-tabor mb-4 font-serif">¿Tienes Preguntas?</h2>
+                    <p className="text-gris-piedra text-lg mb-8 max-w-2xl mx-auto">
                         Nuestro equipo está aquí para ayudarte en todo el proceso de admisión
                     </p>
                     <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                        <Button variant="outline" size="lg" className="text-blanco-pureza border-blanco-pureza hover:bg-blanco-pureza hover:text-azul-monte-tabor">
+                        <Button variant="outline" size="lg">
                             Contactar Admisión
                         </Button>
-                        <Button variant="primary" size="lg">
+                        <Button variant="secondary" size="lg">
                             Agendar Visita
                         </Button>
                     </div>

--- a/microfrontends/apps/mf-student/components/layout/Header.tsx
+++ b/microfrontends/apps/mf-student/components/layout/Header.tsx
@@ -124,11 +124,16 @@ const Header: React.FC = () => {
 
                 <div className="flex items-center gap-2 sm:gap-4">
                     {!isAnyUserLoggedIn && (
-                        <a href={microfrontendUrls.admissions} className="hidden sm:block">
-                            <Button variant="primary" size="sm">
-                                Iniciar Postulación
-                            </Button>
-                        </a>
+                        <div className="hidden sm:flex items-center gap-3">
+                            <a href={microfrontendUrls.guardianLogin} className="text-gris-piedra hover:text-azul-monte-tabor font-semibold transition-colors duration-200">
+                                Iniciar sesión
+                            </a>
+                            <a href={microfrontendUrls.admissions}>
+                                <Button variant="primary" size="sm" className="!text-blanco-pureza">
+                                    Postular
+                                </Button>
+                            </a>
+                        </div>
                     )}
                     {/* Hamburger button */}
                     <button
@@ -194,10 +199,15 @@ const Header: React.FC = () => {
                             </a>
                         )}
                         {!isAnyUserLoggedIn && (
-                            <div className="pt-2 pb-1">
+                            <div className="pt-2 pb-1 flex flex-col gap-2">
+                                <a href={microfrontendUrls.guardianLogin} onClick={() => setIsMobileMenuOpen(false)}>
+                                    <Button variant="outline" className="w-full">
+                                        Iniciar sesión
+                                    </Button>
+                                </a>
                                 <a href={microfrontendUrls.admissions} onClick={() => setIsMobileMenuOpen(false)}>
-                                    <Button variant="primary" className="w-full">
-                                        Iniciar Postulación
+                                    <Button variant="primary" className="w-full !text-blanco-pureza">
+                                        Postular
                                     </Button>
                                 </a>
                             </div>

--- a/microfrontends/apps/mf-student/pages/ExamPortal.tsx
+++ b/microfrontends/apps/mf-student/pages/ExamPortal.tsx
@@ -141,53 +141,68 @@ const ExamPortal: React.FC = () => {
                 </div>
 
                 {/* Process Timeline */}
-                <Card className="p-4 sm:p-8">
-                    <h2 className="text-xl sm:text-2xl font-bold text-azul-monte-tabor text-center mb-6 sm:mb-8">
-                        Proceso de Exámenes
-                    </h2>
+                <div className="py-8 sm:py-12">
+                    <div className="text-center mb-12">
+                        <h2 className="text-xl sm:text-2xl font-bold text-azul-monte-tabor mb-3 font-serif">
+                            Proceso de Exámenes
+                        </h2>
+                        <p className="text-dorado-nazaret font-medium">Sigue estos pasos para completar tu proceso de evaluación</p>
+                    </div>
                     {/* Desktop: alternating timeline */}
-                    <div className="hidden sm:block relative max-w-4xl mx-auto">
-                        <div className="absolute left-1/2 h-full w-1 bg-azul-monte-tabor rounded-full transform -translate-x-1/2"></div>
+                    <div className="hidden sm:block relative max-w-3xl mx-auto">
+                        <div className="absolute left-1/2 h-full w-0.5 bg-gray-300 transform -translate-x-1/2"></div>
                         {[
                             { step: 1, title: "Preparación", description: "Revisa los temas y requisitos para cada asignatura", date: "Previo al examen" },
                             { step: 2, title: "Confirmación de Horarios", description: "Confirma tu asistencia a los horarios asignados", date: "Fecha fija" },
                             { step: 3, title: "Rendir Exámenes", description: "Presenta los exámenes - 31 preguntas en 80 minutos", date: "Fecha programada" },
                             { step: 4, title: "Resultados", description: "Consulta tus resultados en el portal (puntaje mínimo 60%)", date: "Posterior al examen" }
                         ].map((item, index) => (
-                            <div key={item.step} className={`flex items-center w-full mb-8 ${index % 2 === 0 ? 'justify-start' : 'justify-end'}`}>
-                                <div className={`w-5/12 ${index % 2 === 0 ? 'text-right pr-8' : 'text-left pl-8'}`}>
-                                    <div className={`${index % 2 === 0 ? 'text-right' : 'text-left'}`}>
-                                        <h3 className="font-bold text-azul-monte-tabor mb-1">Paso {item.step}: {item.title}</h3>
-                                        <p className="text-gris-piedra text-sm mb-1">{item.description}</p>
-                                        <p className="text-dorado-nazaret font-semibold text-sm">{item.date}</p>
-                                    </div>
+                            <div key={item.step} className="flex items-center w-full mb-16">
+                                <div className="flex-1 pr-10 text-right">
+                                    {index % 2 === 0 ? (
+                                        <>
+                                            <p className="text-xs font-bold uppercase tracking-wider mb-1 text-dorado-nazaret">{item.date}</p>
+                                            <p className="font-bold text-base text-azul-monte-tabor">Paso {item.step}: {item.title}</p>
+                                        </>
+                                    ) : (
+                                        <p className="text-gris-piedra text-sm">{item.description}</p>
+                                    )}
                                 </div>
-                                <div className="relative">
-                                    <div className="w-8 h-8 rounded-full bg-dorado-nazaret flex items-center justify-center z-10 text-azul-monte-tabor font-bold text-sm">{item.step}</div>
+                                <div className="flex-shrink-0 z-10 w-6">
+                                    <div className="w-6 h-6 rounded-full bg-dorado-nazaret flex items-center justify-center text-azul-monte-tabor font-bold text-xs">{item.step}</div>
                                 </div>
-                                <div className="w-5/12"></div>
+                                <div className="flex-1 pl-10 text-left">
+                                    {index % 2 === 0 ? (
+                                        <p className="text-gris-piedra text-sm">{item.description}</p>
+                                    ) : (
+                                        <>
+                                            <p className="text-xs font-bold uppercase tracking-wider mb-1 text-dorado-nazaret">{item.date}</p>
+                                            <p className="font-bold text-base text-azul-monte-tabor">Paso {item.step}: {item.title}</p>
+                                        </>
+                                    )}
+                                </div>
                             </div>
                         ))}
                     </div>
                     {/* Mobile: vertical steps */}
-                    <div className="sm:hidden space-y-3">
+                    <div className="sm:hidden space-y-4 max-w-sm mx-auto">
                         {[
                             { step: 1, title: "Preparación", description: "Revisa los temas y requisitos para cada asignatura", date: "Previo al examen" },
                             { step: 2, title: "Confirmación de Horarios", description: "Confirma tu asistencia a los horarios asignados", date: "Fecha fija" },
                             { step: 3, title: "Rendir Exámenes", description: "Presenta los exámenes - 31 preguntas en 80 minutos", date: "Fecha programada" },
                             { step: 4, title: "Resultados", description: "Consulta tus resultados en el portal (puntaje mínimo 60%)", date: "Posterior al examen" }
                         ].map((item) => (
-                            <div key={item.step} className="flex items-start gap-4 p-4 bg-gray-50 rounded-lg">
-                                <div className="w-8 h-8 rounded-full bg-dorado-nazaret flex items-center justify-center flex-shrink-0 text-azul-monte-tabor font-bold text-sm">{item.step}</div>
+                            <div key={item.step} className="flex items-start gap-4 p-4 rounded-lg border-l-4 border-dorado-nazaret bg-amber-50">
+                                <div className="w-6 h-6 rounded-full bg-dorado-nazaret flex items-center justify-center flex-shrink-0 text-azul-monte-tabor font-bold text-xs mt-0.5">{item.step}</div>
                                 <div>
-                                    <h3 className="font-bold text-azul-monte-tabor text-sm">{item.title}</h3>
-                                    <p className="text-gris-piedra text-xs mt-1">{item.description}</p>
-                                    <p className="text-dorado-nazaret font-semibold text-xs mt-1">{item.date}</p>
+                                    <p className="text-xs font-bold uppercase tracking-wider mb-1 text-dorado-nazaret">{item.date}</p>
+                                    <p className="font-bold text-sm text-azul-monte-tabor mb-1">Paso {item.step}: {item.title}</p>
+                                    <p className="text-gris-piedra text-sm">{item.description}</p>
                                 </div>
                             </div>
                         ))}
                     </div>
-                </Card>
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
Rediseño de página de inicio y portal de exámenes

Cambios realizados en mf-admissions y mf-student:

Página de inicio (mf-admissions):

Hero: un solo botón "Iniciar postulación" con texto blanco, overlay azul oscurecido y sección extendida
Sección "Proceso de Admisión": tarjetas con borde, esquinas redondeadas e iconos centrados
Sección "Portal de Exámenes": fondo gris claro, textos en azul y gris, tarjetas con borde
Calendario: timeline alternado con línea central delgada, puntos de colores y subtítulo dorado
Sección "¿Tienes Preguntas?": fondo blanco con borde superior, estilo consistente con el resto
Navbar (mf-admissions):

En home se muestran dos botones: "Iniciar sesión" y "Postular"
En otras páginas se mantiene el botón "Iniciar Postulación" original
Portal de Exámenes (mf-student):

Sección "Proceso de Exámenes": timeline alternado igual al calendario de admisión
Navbar: mismos botones "Iniciar sesión" y "Postular"