### PR TITLE
feat: reorganize application form to 9 steps with improved auth flow

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,15 +1,1 @@
-# ============================================
-# Admitia Frontend - Development Environment
-# ============================================
 
-# NGINX Gateway (staging on Railway)
-VITE_API_BASE_URL=https://admitia-nginx-staging.up.railway.app
-
-# Firebase Authentication
-VITE_FIREBASE_API_KEY=AIzaSyDA51UgWgiQcVQaYix3talbmuO1cHjFkK0
-VITE_FIREBASE_AUTH_DOMAIN=admitia-55514.firebaseapp.com
-VITE_FIREBASE_PROJECT_ID=admitia-55514
-VITE_FIREBASE_STORAGE_BUCKET=admitia-55514.firebasestorage.app
-VITE_FIREBASE_MESSAGING_SENDER_ID=812821234932
-VITE_FIREBASE_APP_ID=1:812821234932:web:d764d0507bffa6692c4aa1
-VITE_FIREBASE_MEASUREMENT_ID=G-NQ2JG2DTSM

--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,15 @@
+# ============================================
+# Admitia Frontend - Development Environment
+# ============================================
 
+# NGINX Gateway (staging on Railway)
+VITE_API_BASE_URL=https://admitia-nginx-staging.up.railway.app
+
+# Firebase Authentication
+VITE_FIREBASE_API_KEY=AIzaSyDA51UgWgiQcVQaYix3talbmuO1cHjFkK0
+VITE_FIREBASE_AUTH_DOMAIN=admitia-55514.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=admitia-55514
+VITE_FIREBASE_STORAGE_BUCKET=admitia-55514.firebasestorage.app
+VITE_FIREBASE_MESSAGING_SENDER_ID=812821234932
+VITE_FIREBASE_APP_ID=1:812821234932:web:d764d0507bffa6692c4aa1
+VITE_FIREBASE_MEASUREMENT_ID=G-NQ2JG2DTSM

--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,4 @@ docker-compose.override.yml
 security-report.*
 vulnerability-report.*
 .vercel
+.gstack/

--- a/microfrontends/apps/mf-admin/App.tsx
+++ b/microfrontends/apps/mf-admin/App.tsx
@@ -4,6 +4,7 @@ import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import HomePage from './pages/HomePage';
 import AdminLogin from './pages/AdminLogin';
 import ProfessorLoginPage from './pages/ProfessorLoginPage';
+import ApoderadoLogin from './pages/ApoderadoLogin';
 import AdminDashboard from './pages/AdminDashboard';
 import ProtectedAdminRoute from './components/auth/ProtectedAdminRoute';
 import { AppProvider } from './context/AppContext';
@@ -23,7 +24,7 @@ const LoadingFallback = () => (
 function App() {
   const legacyRedirects = createLegacyRedirectRoutes();
   const location = useLocation();
-  const isLoginPage = location.pathname === '/login' || location.pathname === '/admin/login' || location.pathname === '/profesor';
+  const isLoginPage = location.pathname === '/login' || location.pathname === '/admin/login' || location.pathname === '/profesor' || location.pathname === '/apoderado/login';
 
   return (
     <ErrorBoundary>
@@ -39,6 +40,7 @@ function App() {
         <Route path="/login" element={<AdminLogin />} />
         <Route path="/admin/login" element={<AdminLogin />} />
         <Route path="/profesor" element={<ProfessorLoginPage />} />
+        <Route path="/apoderado/login" element={<ApoderadoLogin />} />
         <Route path="/admin" element={<ProtectedAdminRoute><AdminDashboard /></ProtectedAdminRoute>} />
         {legacyRedirects}
         <Route path="*" element={<Navigate to="/login" replace />} />

--- a/microfrontends/apps/mf-admin/App.tsx
+++ b/microfrontends/apps/mf-admin/App.tsx
@@ -24,14 +24,20 @@ const LoadingFallback = () => (
 function App() {
   const legacyRedirects = createLegacyRedirectRoutes();
   const location = useLocation();
-  const isLoginPage = location.pathname === '/login' || location.pathname === '/admin/login' || location.pathname === '/profesor' || location.pathname === '/apoderado/login';
+  const hideHeader = location.pathname === '/login'
+    || location.pathname === '/admin/login'
+    || location.pathname === '/profesor'
+    || location.pathname === '/apoderado/login'
+    || location.pathname === '/admin'
+    || location.pathname.startsWith('/admin/')
+    || location.pathname === '/familia';
 
   return (
     <ErrorBoundary>
       <AuthProvider>
         <AppProvider>
           <div className="flex min-h-screen flex-col bg-blanco-pureza text-gray-800 font-sans">
-            {!isLoginPage && <Header />}
+            {!hideHeader && <Header />}
             <main className="flex-grow overflow-x-hidden">
               <Suspense fallback={<LoadingFallback />}>
                 <Routes>

--- a/microfrontends/apps/mf-admin/components/admin/AnalyticsView.tsx
+++ b/microfrontends/apps/mf-admin/components/admin/AnalyticsView.tsx
@@ -6,7 +6,8 @@
 import React, { useState, useEffect } from 'react';
 import { FiTrendingUp, FiUsers, FiAward, FiClock } from 'react-icons/fi';
 import Card from '../ui/Card';
-import { BarChart, Bar, LineChart, Line, RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { dashboardClient } from '../../src/api/dashboard.client';
 
 export const AnalyticsView: React.FC = () => {
@@ -54,7 +55,34 @@ export const AnalyticsView: React.FC = () => {
         );
     }
 
-    const COLORS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899'];
+    const evaluatorPerformanceOption: EChartsOption = {
+        color: ['#10B981', '#F59E0B'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: evaluatorData.map(item => item.name) },
+        yAxis: { type: 'value' },
+        series: [
+            { name: 'Completadas', type: 'bar', data: evaluatorData.map(item => item.completed) },
+            { name: 'Pendientes', type: 'bar', data: evaluatorData.map(item => item.pending) }
+        ]
+    };
+
+    const radarData = evaluatorData.slice(0, 6);
+    const evaluatorWorkloadOption: EChartsOption = {
+        color: ['#3B82F6'],
+        tooltip: {},
+        radar: {
+            indicator: radarData.map(item => ({ name: item.name, max: Math.max(...radarData.map(e => e.total || 0), 1) })),
+            splitArea: { areaStyle: { color: ['rgba(59, 130, 246, 0.04)', 'rgba(59, 130, 246, 0.1)'] } }
+        },
+        series: [{
+            name: 'Evaluaciones',
+            type: 'radar',
+            areaStyle: { opacity: 0.35 },
+            data: [{ name: 'Evaluaciones', value: radarData.map(item => item.total || 0) }]
+        }]
+    };
 
     return (
         <div className="space-y-6">
@@ -136,31 +164,13 @@ export const AnalyticsView: React.FC = () => {
                 {/* Evaluator Performance */}
                 <Card className="p-6">
                     <h3 className="text-lg font-semibold text-gray-900 mb-4">Rendimiento de Evaluadores</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <BarChart data={evaluatorData}>
-                            <CartesianGrid strokeDasharray="3 3" />
-                            <XAxis dataKey="name" />
-                            <YAxis />
-                            <Tooltip />
-                            <Legend />
-                            <Bar dataKey="completed" fill="#10B981" name="Completadas" />
-                            <Bar dataKey="pending" fill="#F59E0B" name="Pendientes" />
-                        </BarChart>
-                    </ResponsiveContainer>
+                    <EChart option={evaluatorPerformanceOption} height={300} />
                 </Card>
 
                 {/* Evaluator Workload Radar */}
                 <Card className="p-6">
                     <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución de Carga de Trabajo</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <RadarChart data={evaluatorData.slice(0, 6)}>
-                            <PolarGrid />
-                            <PolarAngleAxis dataKey="name" />
-                            <PolarRadiusAxis />
-                            <Radar name="Evaluaciones" dataKey="total" stroke="#3B82F6" fill="#3B82F6" fillOpacity={0.6} />
-                            <Tooltip />
-                        </RadarChart>
-                    </ResponsiveContainer>
+                    <EChart option={evaluatorWorkloadOption} height={300} />
                 </Card>
             </div>
 

--- a/microfrontends/apps/mf-admin/components/admin/ApplicantMetricsView.tsx
+++ b/microfrontends/apps/mf-admin/components/admin/ApplicantMetricsView.tsx
@@ -5,7 +5,8 @@ import Badge from '../ui/Badge';
 import Button from '../ui/Button';
 import { dashboardClient } from '../../src/api/dashboard.client';
 import type { ApplicantMetric, ApplicantMetricsFilters } from '../../src/api/dashboard.types';
-import { PieChart, Pie, BarChart, Bar, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, LabelList } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 
 // Version: 2025-11-11 - Added overallOpinionScore display
 export const ApplicantMetricsView: React.FC = () => {
@@ -178,6 +179,48 @@ export const ApplicantMetricsView: React.FC = () => {
   };
 
   const { performanceData, avgData } = getChartData();
+
+  const performanceDistributionOption: EChartsOption = {
+    color: performanceData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    legend: { bottom: 0 },
+    series: [{
+      type: 'pie',
+      radius: ['42%', '70%'],
+      center: ['50%', '44%'],
+      itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+      label: { formatter: '{d}%' },
+      data: performanceData.map(item => ({ name: item.name, value: item.value }))
+    }]
+  };
+
+  const examAverageOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', valueFormatter: value => `${value}%` },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 24, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: avgData.map(item => item.name) },
+    yAxis: { type: 'value', min: 0, max: 100 },
+    series: [{
+      name: 'Promedio (%)',
+      type: 'bar',
+      data: avgData.map(item => item.promedio),
+      barMaxWidth: 48,
+      label: { show: true, position: 'top', formatter: '{c}%' }
+    }]
+  };
+
+  const subjectDistributionOption: EChartsOption = {
+    color: subjectDistribution.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [{
+      type: 'pie',
+      radius: ['42%', '72%'],
+      itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+      label: { formatter: '{b}: {d}%' },
+      data: subjectDistribution.map(item => ({ name: item.name, value: item.value }))
+    }]
+  };
 
   const uniqueGrades = [...new Set(applicants.map(a => a.gradeApplied))].sort();
   const uniqueStatuses = [...new Set(applicants.map(a => a.applicationStatus))];
@@ -420,56 +463,17 @@ export const ApplicantMetricsView: React.FC = () => {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <Card className="p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución de Rendimiento</h3>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie
-                data={performanceData}
-                cx="50%"
-                cy="50%"
-                labelLine={false}
-                label={({ percent }: { percent?: number }) => `${Math.round((percent || 0) * 100)}%`}
-                outerRadius={80}
-                fill="#8884d8"
-                dataKey="value"
-              >
-                {performanceData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
-                ))}
-              </Pie>
-              <Tooltip />
-              <Legend
-                verticalAlign="bottom"
-                height={36}
-                formatter={(value, entry: any) => entry.payload.name}
-              />
-            </PieChart>
-          </ResponsiveContainer>
+          <EChart option={performanceDistributionOption} height={300} />
         </Card>
 
         <Card className="p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Promedio por Examen</h3>
           <p className="text-sm text-gray-500 mb-2">Haz clic en una barra para ver la distribución detallada</p>
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={avgData} onClick={(data) => {
-              if (data && data.activeLabel) {
-                handleSubjectClick(data.activeLabel);
-              }
-            }}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
-              <YAxis domain={[0, 100]} />
-              <Tooltip />
-              <Legend />
-              <Bar
-                dataKey="promedio"
-                fill="#3B82F6"
-                name="Promedio (%)"
-                cursor="pointer"
-              >
-                <LabelList dataKey="promedio" position="top" formatter={(value: number) => `${value}%`} />
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+          <EChart
+            option={examAverageOption}
+            height={300}
+            onEvents={{ click: params => params.name && handleSubjectClick(String(params.name)) }}
+          />
         </Card>
       </div>
 
@@ -680,27 +684,7 @@ export const ApplicantMetricsView: React.FC = () => {
               </div>
 
               <div className="mb-6">
-                <ResponsiveContainer width="100%" height={350}>
-                  <PieChart>
-                    <Pie
-                      data={subjectDistribution}
-                      cx="50%"
-                      cy="50%"
-                      labelLine={false}
-                      label={({ name, percent }: { name: string, percent?: number }) =>
-                        `${name}: ${Math.round((percent || 0) * 100)}%`
-                      }
-                      outerRadius={120}
-                      fill="#8884d8"
-                      dataKey="value"
-                    >
-                      {subjectDistribution.map((entry, index) => (
-                        <Cell key={`cell-${index}`} fill={entry.color} />
-                      ))}
-                    </Pie>
-                    <Tooltip />
-                  </PieChart>
-                </ResponsiveContainer>
+                <EChart option={subjectDistributionOption} height={350} />
               </div>
 
               <div className="border-t pt-4">

--- a/microfrontends/apps/mf-admin/components/admin/ReportsView.tsx
+++ b/microfrontends/apps/mf-admin/components/admin/ReportsView.tsx
@@ -7,7 +7,8 @@ import React, { useState, useEffect } from 'react';
 import { FiDownload, FiFilter, FiCalendar, FiBarChart2, FiPieChart, FiTrendingUp } from 'react-icons/fi';
 import Card from '../ui/Card';
 import Button from '../ui/Button';
-import { BarChart, Bar, PieChart, Pie, LineChart, Line, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { dashboardClient } from '../../src/api/dashboard.client';
 
 interface ReportFilters {
@@ -85,6 +86,64 @@ export const ReportsView: React.FC = () => {
     };
 
     const COLORS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899'];
+
+    const statusBarOption: EChartsOption = {
+        color: ['#3B82F6'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: statusData.map(item => item.name) },
+        yAxis: { type: 'value' },
+        series: [{ name: 'Cantidad', type: 'bar', data: statusData.map(item => item.value), barMaxWidth: 44 }]
+    };
+
+    const statusPieOption: EChartsOption = {
+        color: COLORS,
+        tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+        series: [{
+            type: 'pie',
+            radius: ['42%', '70%'],
+            itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+            label: { formatter: '{b}: {c}' },
+            data: statusData.map(item => ({ name: item.name, value: item.value }))
+        }]
+    };
+
+    const gradeBarOption: EChartsOption = {
+        color: ['#10B981'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: gradeData.map(item => item.grade) },
+        yAxis: { type: 'value' },
+        series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 44 }]
+    };
+
+    const gradePieOption: EChartsOption = {
+        color: COLORS,
+        tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+        series: [{
+            type: 'pie',
+            radius: ['42%', '70%'],
+            itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+            label: { formatter: '{b}: {c}' },
+            data: gradeData.map(item => ({ name: item.grade, value: item.count }))
+        }]
+    };
+
+    const temporalOption: EChartsOption = {
+        color: ['#3B82F6', '#10B981', '#EF4444'],
+        tooltip: { trigger: 'axis' },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 24, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: temporalData.map(item => item.month) },
+        yAxis: { type: 'value' },
+        series: [
+            { name: 'Postulaciones', type: 'line', smooth: true, data: temporalData.map(item => item.applications) },
+            { name: 'Aprobadas', type: 'line', smooth: true, data: temporalData.map(item => item.approved) },
+            { name: 'Rechazadas', type: 'line', smooth: true, data: temporalData.map(item => item.rejected) }
+        ]
+    };
 
     if (loading) {
         return (
@@ -196,38 +255,11 @@ export const ReportsView: React.FC = () => {
                     <>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución por Estado (Barras)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <BarChart data={statusData}>
-                                    <CartesianGrid strokeDasharray="3 3" />
-                                    <XAxis dataKey="name" />
-                                    <YAxis />
-                                    <Tooltip />
-                                    <Legend />
-                                    <Bar dataKey="value" fill="#3B82F6" />
-                                </BarChart>
-                            </ResponsiveContainer>
+                            <EChart option={statusBarOption} height={300} />
                         </Card>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución por Estado (Pastel)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <PieChart>
-                                    <Pie
-                                        data={statusData}
-                                        cx="50%"
-                                        cy="50%"
-                                        labelLine={false}
-                                        label={(entry) => `${entry.name}: ${entry.value}`}
-                                        outerRadius={80}
-                                        fill="#8884d8"
-                                        dataKey="value"
-                                    >
-                                        {statusData.map((entry, index) => (
-                                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                        ))}
-                                    </Pie>
-                                    <Tooltip />
-                                </PieChart>
-                            </ResponsiveContainer>
+                            <EChart option={statusPieOption} height={300} />
                         </Card>
                     </>
                 )}
@@ -236,38 +268,11 @@ export const ReportsView: React.FC = () => {
                     <>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Postulaciones por Grado (Barras)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <BarChart data={gradeData}>
-                                    <CartesianGrid strokeDasharray="3 3" />
-                                    <XAxis dataKey="grade" />
-                                    <YAxis />
-                                    <Tooltip />
-                                    <Legend />
-                                    <Bar dataKey="count" fill="#10B981" />
-                                </BarChart>
-                            </ResponsiveContainer>
+                            <EChart option={gradeBarOption} height={300} />
                         </Card>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Postulaciones por Grado (Pastel)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <PieChart>
-                                    <Pie
-                                        data={gradeData}
-                                        cx="50%"
-                                        cy="50%"
-                                        labelLine={false}
-                                        label={(entry) => `${entry.grade}: ${entry.count}`}
-                                        outerRadius={80}
-                                        fill="#8884d8"
-                                        dataKey="count"
-                                    >
-                                        {gradeData.map((entry, index) => (
-                                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                        ))}
-                                    </Pie>
-                                    <Tooltip />
-                                </PieChart>
-                            </ResponsiveContainer>
+                            <EChart option={gradePieOption} height={300} />
                         </Card>
                     </>
                 )}
@@ -275,18 +280,7 @@ export const ReportsView: React.FC = () => {
                 {selectedReport === 'temporal' && (
                     <Card className="p-6 lg:col-span-2">
                         <h3 className="text-lg font-semibold text-gray-900 mb-4">Tendencias Temporales de Postulaciones</h3>
-                        <ResponsiveContainer width="100%" height={400}>
-                            <LineChart data={temporalData}>
-                                <CartesianGrid strokeDasharray="3 3" />
-                                <XAxis dataKey="month" />
-                                <YAxis />
-                                <Tooltip />
-                                <Legend />
-                                <Line type="monotone" dataKey="applications" stroke="#3B82F6" strokeWidth={2} name="Postulaciones" />
-                                <Line type="monotone" dataKey="approved" stroke="#10B981" strokeWidth={2} name="Aprobadas" />
-                                <Line type="monotone" dataKey="rejected" stroke="#EF4444" strokeWidth={2} name="Rechazadas" />
-                            </LineChart>
-                        </ResponsiveContainer>
+                        <EChart option={temporalOption} height={400} />
                     </Card>
                 )}
             </div>

--- a/microfrontends/apps/mf-admin/components/charts/EChart.tsx
+++ b/microfrontends/apps/mf-admin/components/charts/EChart.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactECharts from 'echarts-for-react';
+import type { EChartsOption } from 'echarts';
+
+interface EChartProps {
+  option: EChartsOption;
+  height?: number;
+  onEvents?: Record<string, (params: any) => void>;
+}
+
+const EChart: React.FC<EChartProps> = ({ option, height = 300, onEvents }) => (
+  <ReactECharts
+    option={option}
+    notMerge
+    lazyUpdate
+    onEvents={onEvents}
+    style={{ width: '100%', height }}
+  />
+);
+
+export default EChart;

--- a/microfrontends/apps/mf-admin/components/charts/EChartCard.tsx
+++ b/microfrontends/apps/mf-admin/components/charts/EChartCard.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import ReactECharts from 'echarts-for-react';
+import type { EChartsOption } from 'echarts';
+
+interface EChartCardProps {
+  title: string;
+  subtitle?: string;
+  option: EChartsOption;
+  loading?: boolean;
+  empty?: boolean;
+  emptyText?: string;
+  height?: number;
+  onEvents?: Record<string, (params: any) => void>;
+  footer?: React.ReactNode;
+}
+
+const loadingOption = {
+  text: 'Cargando datos...',
+  color: '#2563eb',
+  textColor: '#334155',
+  maskColor: 'rgba(255, 255, 255, 0.72)',
+  zlevel: 0,
+};
+
+const EChartCard: React.FC<EChartCardProps> = ({
+  title,
+  subtitle,
+  option,
+  loading = false,
+  empty = false,
+  emptyText = 'Sin datos para mostrar',
+  height = 320,
+  onEvents,
+  footer,
+}) => {
+  return (
+    <div className="group rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-xl">
+      <div className="mb-4">
+        <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
+        {subtitle && <p className="mt-1 text-sm text-slate-500">{subtitle}</p>}
+      </div>
+
+      {empty ? (
+        <div
+          className="flex items-center justify-center rounded-xl border border-dashed border-slate-200 bg-slate-50 text-sm text-slate-500"
+          style={{ height }}
+        >
+          {emptyText}
+        </div>
+      ) : (
+        <ReactECharts
+          option={option}
+          showLoading={loading}
+          loadingOption={loadingOption}
+          notMerge
+          lazyUpdate
+          onEvents={onEvents}
+          style={{ height, width: '100%' }}
+        />
+      )}
+
+      {footer && <div className="mt-4">{footer}</div>}
+    </div>
+  );
+};
+
+export default EChartCard;

--- a/microfrontends/apps/mf-admin/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-admin/components/interviews/InterviewForm.tsx
@@ -1080,7 +1080,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : (
                   <div className="p-4 bg-gray-50 border border-gray-200 rounded-md">
                     <p className="text-sm text-gray-600 text-center">
-                      👆 Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
+                      Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
                     </p>
                   </div>
                 )}

--- a/microfrontends/apps/mf-admin/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-admin/components/interviews/InterviewForm.tsx
@@ -133,21 +133,18 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
 
         console.log('Array de entrevistadores:', dataArray);
 
-        // El backend ya devuelve el formato correcto con firstName, lastName, role, scheduleCount
+        // El backend puede devolver array directo o envuelto, y nombres separados o name.
         const mappedInterviewers: BackendInterviewer[] = dataArray.map((item: any) => ({
-          id: item.id,
-          name: `${item.firstName} ${item.lastName}`,
-          role: item.role,
-          subject: item.subject,
+          id: Number(item.id),
+          name: item.name || `${item.firstName || ''} ${item.lastName || ''}`.trim() || item.email,
+          role: item.role || '',
+          subject: item.subject || '',
           educationalLevel: item.educationalLevel,
-          scheduleCount: item.scheduleCount || 0
-        }));
+          scheduleCount: Number(item.scheduleCount || 0)
+        })).filter((item) => item.id && item.name);
 
-        // Filtrar solo entrevistadores con horarios configurados
-        const interviewersWithSchedules = mappedInterviewers.filter(i => i.scheduleCount > 0);
-
-        console.log(`Entrevistadores con horarios: ${interviewersWithSchedules.length}/${mappedInterviewers.length}`);
-        setInterviewers(interviewersWithSchedules);
+        console.log(`Entrevistadores cargados: ${mappedInterviewers.length}`);
+        setInterviewers(mappedInterviewers);
       } catch (error: any) {
         console.error('Error cargando entrevistadores:', error);
 
@@ -263,7 +260,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
     // Validación de parámetros requeridos
     if (!formData.interviewerId || !formData.scheduledDate) {
       console.log('[loadAvailableTimeSlots] Faltan parámetros requeridos - abortando');
-      setAvailableTimeSlots(INTERVIEW_CONFIG.DEFAULT_TIME_SLOTS);
+      setAvailableTimeSlots([]);
       return;
     }
 
@@ -350,7 +347,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
 
       // Solo actualizar estado si no fue cancelada
       if (!currentController.signal.aborted) {
-        setAvailableTimeSlots(INTERVIEW_CONFIG.DEFAULT_TIME_SLOTS);
+        setAvailableTimeSlots([]);
       }
     } finally {
       // Solo limpiar loading state si esta es la llamada más reciente
@@ -936,9 +933,8 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                     <option
                       key={interviewer.id}
                       value={interviewer.id}
-                      disabled={interviewer.scheduleCount === 0}
                     >
-                      {interviewer.name} - {interviewer.role} {interviewer.scheduleCount === 0 ? '(Sin horarios)' : `(${interviewer.scheduleCount} horarios)`}
+                      {interviewer.name} - {interviewer.role} {interviewer.scheduleCount > 0 ? `(${interviewer.scheduleCount} horarios)` : ''}
                     </option>
                   ))
                 )}
@@ -969,7 +965,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : interviewersError ? (
                   <option disabled>{interviewersError}</option>
                 ) : interviewers.length === 0 ? (
-                  <option disabled>No hay entrevistadores con horarios configurados</option>
+                  <option disabled>No hay entrevistadores disponibles</option>
                 ) : (
                   (() => {
                     const filteredInterviewers = interviewers.filter(interviewer => {
@@ -988,9 +984,8 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                       <option
                         key={interviewer.id}
                         value={interviewer.id}
-                        disabled={interviewer.scheduleCount === 0}
                       >
-                        {interviewer.name} - {interviewer.role} {interviewer.scheduleCount === 0 ? '(Sin horarios)' : `(${interviewer.scheduleCount} horarios)`}
+                        {interviewer.name} - {interviewer.role} {interviewer.scheduleCount > 0 ? `(${interviewer.scheduleCount} horarios)` : ''}
                       </option>
                     ));
                   })()

--- a/microfrontends/apps/mf-admin/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-admin/components/interviews/InterviewForm.tsx
@@ -1080,7 +1080,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : (
                   <div className="p-4 bg-gray-50 border border-gray-200 rounded-md">
                     <p className="text-sm text-gray-600 text-center">
-                      Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
+                      👆 Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
                     </p>
                   </div>
                 )}

--- a/microfrontends/apps/mf-admin/components/layout/Footer.tsx
+++ b/microfrontends/apps/mf-admin/components/layout/Footer.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Facebook, Instagram, Linkedin } from 'lucide-react';
+import { microfrontendUrls } from '../../utils/microfrontendUrls';
 
 const Footer: React.FC = () => {
     const [showModal, setShowModal] = useState(false);
@@ -63,8 +64,14 @@ const Footer: React.FC = () => {
                         </div>
                     </div>
                 </div>
-                <div className="border-t border-blue-800 mt-10 pt-6 text-center text-sm text-gray-400">
+                <div className="border-t border-blue-800 mt-10 pt-6 flex flex-col sm:flex-row items-center justify-between gap-2 text-sm text-gray-400">
                     <p>&copy; {new Date().getFullYear()} Colegio Monte Tabor y Nazaret. Todos los derechos reservados.</p>
+                    <a
+                        href={microfrontendUrls.adminLogin}
+                        className="text-gray-400 hover:text-dorado-nazaret transition-colors text-xs underline underline-offset-2"
+                    >
+                        Acceso personal MTN
+                    </a>
                 </div>
             </div>
             {/* Modal de contacto */}

--- a/microfrontends/apps/mf-admin/components/layout/Header.tsx
+++ b/microfrontends/apps/mf-admin/components/layout/Header.tsx
@@ -3,11 +3,12 @@ import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import Button from '../ui/Button';
 import { microfrontendUrls } from '../../utils/microfrontendUrls';
-import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
+import { getStorageKey, BASE_STORAGE_KEYS, clearAllSessions } from '../../../../packages/backend-sdk/src/index';
 
 const Header: React.FC = () => {
     const navigate = useNavigate();
     const [isAdmin, setIsAdmin] = useState(false);
+    const [isAdminLoggedIn, setIsAdminLoggedIn] = useState(false);
     const [isProfessorLoggedIn, setIsProfessorLoggedIn] = useState(false);
     const [isAnyUserLoggedIn, setIsAnyUserLoggedIn] = useState(false);
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -30,16 +31,17 @@ const Header: React.FC = () => {
             setIsAnyUserLoggedIn(hasAnyAuth);
 
             // Solo mostrar admin si hay un token válido Y datos de profesor admin
+            let adminActive = false;
             if ((authToken || professorToken) && currentProfessor) {
                 try {
                     const professorData = JSON.parse(currentProfessor);
-                    setIsAdmin(professorData.isAdmin === true);
+                    adminActive = professorData.isAdmin === true;
                 } catch (error) {
-                    setIsAdmin(false);
+                    adminActive = false;
                 }
-            } else {
-                setIsAdmin(false);
             }
+            setIsAdmin(adminActive);
+            setIsAdminLoggedIn(adminActive);
         };
 
         checkAuthStatus();
@@ -66,13 +68,7 @@ const Header: React.FC = () => {
         if (isAnyUserLoggedIn) {
             e.preventDefault(); // Prevenir navegación predeterminada
 
-            // Limpiar TODOS los tokens y datos de autenticación
-            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
-            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
-            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_TOKEN));
-            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR));
-            localStorage.removeItem('currentUser');
-            localStorage.removeItem('currentApoderado');
+            clearAllSessions();
 
             // Actualizar estados locales
             setIsAdmin(false);
@@ -90,6 +86,16 @@ const Header: React.FC = () => {
 
     const navigateTo = (url: string) => {
         window.location.href = url;
+    };
+
+    const clearAndGoAdmin = (e: React.MouseEvent) => {
+        e.preventDefault();
+        clearAllSessions();
+        setIsAdmin(false);
+        setIsAdminLoggedIn(false);
+        setIsProfessorLoggedIn(false);
+        setIsAnyUserLoggedIn(false);
+        window.location.href = microfrontendUrls.adminLogin;
     };
 
     return (
@@ -111,6 +117,9 @@ const Header: React.FC = () => {
                     <a href={microfrontendUrls.guardianLogin} className="text-gris-piedra hover:text-azul-monte-tabor font-semibold transition-colors duration-200">Portal Familia</a>
                     {!isProfessorLoggedIn && (
                         <a href={microfrontendUrls.professorLogin} className="text-gris-piedra hover:text-azul-monte-tabor font-semibold transition-colors duration-200">Profesores</a>
+                    )}
+                    {!isAdminLoggedIn && (
+                        <a href={microfrontendUrls.adminLogin} onClick={clearAndGoAdmin} className="text-gris-piedra hover:text-azul-monte-tabor font-semibold transition-colors duration-200">Administradores</a>
                     )}
                     {isAdmin && (
                         <a
@@ -182,6 +191,15 @@ const Header: React.FC = () => {
                                 className="px-4 py-3 rounded-lg font-semibold transition-colors text-gris-piedra hover:bg-gray-50"
                             >
                                 Profesores
+                            </a>
+                        )}
+                        {!isAdminLoggedIn && (
+                            <a
+                                href={microfrontendUrls.adminLogin}
+                                onClick={(e) => { clearAndGoAdmin(e); setIsMobileMenuOpen(false); }}
+                                className="px-4 py-3 rounded-lg font-semibold transition-colors text-gris-piedra hover:bg-gray-50"
+                            >
+                                Administradores
                             </a>
                         )}
                         {isAdmin && (

--- a/microfrontends/apps/mf-admin/components/modals/CoordinatorDashboardModal.tsx
+++ b/microfrontends/apps/mf-admin/components/modals/CoordinatorDashboardModal.tsx
@@ -7,7 +7,8 @@ import React, { useState, useEffect } from 'react';
 import { FiX, FiRefreshCw } from 'react-icons/fi';
 import { dashboardClient } from '../../src/api/dashboard.client';
 import type { DetailedAdminStats, Alert } from '../../src/api/dashboard.types';
-import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 
 interface CoordinatorDashboardModalProps {
   isOpen: boolean;
@@ -115,6 +116,32 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
   const acceptanceRate = stats && stats.totalApplications > 0
     ? ((stats.statusBreakdown.approved / stats.totalApplications) * 100).toFixed(1)
     : '0.0';
+
+  const statusChartOption: EChartsOption = {
+    color: statusData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [
+      {
+        type: 'pie',
+        radius: ['42%', '70%'],
+        center: ['50%', '50%'],
+        avoidLabelOverlap: true,
+        itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+        label: { formatter: '{b}: {d}%' },
+        data: statusData.map(item => ({ name: item.name, value: item.value }))
+      }
+    ]
+  };
+
+  const gradeChartOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: gradeData.map(item => item.grade), axisTick: { alignWithLabel: true } },
+    yAxis: { type: 'value' },
+    series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 42 }]
+  };
 
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
@@ -348,25 +375,7 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
                   {/* Status Distribution Pie Chart */}
                   <div className="bg-white border border-gray-200 shadow-sm rounded-lg p-6">
                     <h3 className="text-lg font-medium text-gray-900 mb-4">Distribución por Estado</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                      <PieChart>
-                        <Pie
-                          data={statusData}
-                          cx="50%"
-                          cy="50%"
-                          labelLine={false}
-                          label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
-                          outerRadius={80}
-                          fill="#8884d8"
-                          dataKey="value"
-                        >
-                          {statusData.map((entry, index) => (
-                            <Cell key={`cell-${index}`} fill={entry.color} />
-                          ))}
-                        </Pie>
-                        <Tooltip />
-                      </PieChart>
-                    </ResponsiveContainer>
+                    <EChart option={statusChartOption} height={300} />
                     <div className="mt-4 grid grid-cols-2 gap-2 text-sm">
                       {statusData.map((item, index) => (
                         <div key={index} className="flex items-center">
@@ -383,16 +392,7 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
                   {/* Grade Distribution Bar Chart */}
                   <div className="bg-white border border-gray-200 shadow-sm rounded-lg p-6">
                     <h3 className="text-lg font-medium text-gray-900 mb-4">Distribución por Nivel</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                      <BarChart data={gradeData}>
-                        <CartesianGrid strokeDasharray="3 3" />
-                        <XAxis dataKey="grade" />
-                        <YAxis />
-                        <Tooltip />
-                        <Legend />
-                        <Bar dataKey="count" fill="#3B82F6" name="Postulaciones" />
-                      </BarChart>
-                    </ResponsiveContainer>
+                    <EChart option={gradeChartOption} height={300} />
                   </div>
                 </div>
 

--- a/microfrontends/apps/mf-admin/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-admin/context/AuthContext.tsx
@@ -83,9 +83,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     const [isLoading, setIsLoading] = useState(true);
 
     // Fallback: Restore session from localStorage if available (for non-Firebase auth methods)
+    const [sessionRestoredFromStorage, setSessionRestoredFromStorage] = React.useState(false);
+
     useEffect(() => {
-        if (user !== null) {
-            // User already loaded, skip
+        if (user !== null || sessionRestoredFromStorage) {
+            // User already loaded or restoration was attempted, skip
             return;
         }
 
@@ -132,8 +134,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
         // Try storage restore FIRST, regardless of Firebase config
         // This ensures non-Firebase sessions (like from professorAuthService) work immediately
-        if (tryRestoreFromStorage()) {
-            console.log('[AuthContext] Successfully restored from localStorage');
+        const restored = tryRestoreFromStorage();
+        setSessionRestoredFromStorage(true);
+
+        if (restored) {
+            console.log('[AuthContext] Successfully restored from storage');
             return;
         }
 
@@ -148,6 +153,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     // Listen to Firebase auth state changes for automatic session restore
     useEffect(() => {
         if (!auth || !hasFirebaseConfig) {
+            return;
+        }
+
+        // Skip Firebase listener if session was already restored from storage (cookies/localStorage)
+        if (sessionRestoredFromStorage && user !== null) {
+            console.log('[AuthContext] Session already restored from storage, skipping Firebase listener');
+            setIsLoading(false);
             return;
         }
 

--- a/microfrontends/apps/mf-admin/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-admin/context/AuthContext.tsx
@@ -108,11 +108,15 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             return false;
         };
 
-        // Only try storage restore if Firebase is not available
+        // Try storage restore FIRST, regardless of Firebase config
+        // This ensures non-Firebase sessions (like from professorAuthService) work immediately
+        if (tryRestoreFromStorage()) {
+            return;
+        }
+
+        // Only continue to Firebase check if storage restore failed
         if (!auth || !hasFirebaseConfig) {
-            if (!tryRestoreFromStorage()) {
-                setIsLoading(false);
-            }
+            setIsLoading(false);
             return;
         }
     }, []);

--- a/microfrontends/apps/mf-admin/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-admin/context/AuthContext.tsx
@@ -83,11 +83,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     const [isLoading, setIsLoading] = useState(true);
 
     // Fallback: Restore session from localStorage if available (for non-Firebase auth methods)
-    const [sessionRestoredFromStorage, setSessionRestoredFromStorage] = React.useState(false);
-
     useEffect(() => {
-        if (user !== null || sessionRestoredFromStorage) {
-            // User already loaded or restoration was attempted, skip
+        if (user !== null) {
+            // User already loaded, skip
             return;
         }
 
@@ -135,7 +133,6 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         // Try storage restore FIRST, regardless of Firebase config
         // This ensures non-Firebase sessions (like from professorAuthService) work immediately
         const restored = tryRestoreFromStorage();
-        setSessionRestoredFromStorage(true);
 
         if (restored) {
             console.log('[AuthContext] Successfully restored from storage');
@@ -152,14 +149,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
     // Listen to Firebase auth state changes for automatic session restore
     useEffect(() => {
-        if (!auth || !hasFirebaseConfig) {
+        // Skip Firebase entirely if user already authenticated from storage
+        if (user !== null) {
+            console.log('[AuthContext] User already authenticated, skipping Firebase listener');
             return;
         }
 
-        // Skip Firebase listener if session was already restored from storage (cookies/localStorage)
-        if (sessionRestoredFromStorage && user !== null) {
-            console.log('[AuthContext] Session already restored from storage, skipping Firebase listener');
-            setIsLoading(false);
+        if (!auth || !hasFirebaseConfig) {
             return;
         }
 
@@ -211,7 +207,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             setIsLoading(false);
         });
         return () => unsubscribe();
-    }, []);
+    }, [user]);
 
     const login = async (email: string, password: string, _role: string) => {
         setIsLoading(true);

--- a/microfrontends/apps/mf-admin/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-admin/context/AuthContext.tsx
@@ -185,10 +185,16 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                     setUser(null);
                 }
             } else {
-                // No Firebase user — clear everything
-                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
-                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
-                setUser(null);
+                // No Firebase user — but don't clear if user is already authenticated from another source
+                // (e.g., from cookies set by non-Firebase auth like professorAuthService)
+                if (!user) {
+                    console.log('[AuthContext] No Firebase user and no local user, clearing auth state');
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
+                    setUser(null);
+                } else {
+                    console.log('[AuthContext] No Firebase user, but user authenticated from other source. Keeping session.');
+                }
             }
             setIsLoading(false);
         });

--- a/microfrontends/apps/mf-admin/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-admin/context/AuthContext.tsx
@@ -92,6 +92,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         const tryRestoreFromStorage = () => {
             try {
                 console.log('[AuthContext] Attempting to restore from storage');
+                console.log('[AuthContext] Available cookies:', document.cookie);
 
                 // Try localStorage first (environment-aware key)
                 let cached =
@@ -109,6 +110,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                     if (cookieValue) {
                         cached = decodeURIComponent(cookieValue);
                         console.log('[AuthContext] Found user in cookies');
+                    } else {
+                        console.log('[AuthContext] No auth_user cookie found. Available:', document.cookie);
                     }
                 }
 

--- a/microfrontends/apps/mf-admin/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-admin/context/AuthContext.tsx
@@ -3,7 +3,7 @@ import { onAuthStateChanged } from 'firebase/auth';
 import { auth, hasFirebaseConfig } from '../src/lib/firebase';
 import { authService } from '../services/authService';
 import api from '../services/api';
-import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
+import { getStorageKey, BASE_STORAGE_KEYS, clearAllSessions } from '../../../packages/backend-sdk/src/index';
 import { microfrontendUrls } from '../utils/microfrontendUrls';
 
 interface User {
@@ -222,6 +222,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     const login = async (email: string, password: string, _role: string) => {
         setIsLoading(true);
         try {
+            clearAllSessions();
+
             const response = await authService.login({ email, password });
 
             const u = response.user;

--- a/microfrontends/apps/mf-admin/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-admin/context/AuthContext.tsx
@@ -82,10 +82,44 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     const [user, setUser] = useState<User | null>(null);
     const [isLoading, setIsLoading] = useState(true);
 
+    // Fallback: Restore session from localStorage if available (for non-Firebase auth methods)
+    useEffect(() => {
+        if (user !== null) {
+            // User already loaded, skip
+            return;
+        }
+
+        const tryRestoreFromStorage = () => {
+            try {
+                // Try to restore from localStorage with environment-aware key
+                const cached =
+                    localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER)) ||
+                    localStorage.getItem(BASE_STORAGE_KEYS.AUTHENTICATED_USER);
+
+                if (cached) {
+                    const userData = JSON.parse(cached);
+                    setUser(userData);
+                    setIsLoading(false);
+                    return true;
+                }
+            } catch (error) {
+                // Fallback failed, continue to Firebase check
+            }
+            return false;
+        };
+
+        // Only try storage restore if Firebase is not available
+        if (!auth || !hasFirebaseConfig) {
+            if (!tryRestoreFromStorage()) {
+                setIsLoading(false);
+            }
+            return;
+        }
+    }, []);
+
     // Listen to Firebase auth state changes for automatic session restore
     useEffect(() => {
         if (!auth || !hasFirebaseConfig) {
-            setIsLoading(false);
             return;
         }
 

--- a/microfrontends/apps/mf-admin/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-admin/context/AuthContext.tsx
@@ -4,6 +4,7 @@ import { auth, hasFirebaseConfig } from '../src/lib/firebase';
 import { authService } from '../services/authService';
 import api from '../services/api';
 import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
+import { microfrontendUrls } from '../utils/microfrontendUrls';
 
 interface User {
     id: string;
@@ -268,8 +269,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.APODERADO_USER));
         localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
         localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
+        // Also clear cookies for cross-port sessions
+        document.cookie = 'auth_user=; path=/; expires=Thu, 01 Jan 1970 00:00:00 UTC;';
+        document.cookie = 'auth_token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 UTC;';
         setUser(null);
-        window.location.href = '/#/login';
+        window.location.href = microfrontendUrls.home;
     };
 
     const value: AuthContextType = {

--- a/microfrontends/apps/mf-admin/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-admin/context/AuthContext.tsx
@@ -91,18 +91,22 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
         const tryRestoreFromStorage = () => {
             try {
+                console.log('[AuthContext] Attempting to restore from localStorage');
                 // Try to restore from localStorage with environment-aware key
                 const cached =
                     localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER)) ||
                     localStorage.getItem(BASE_STORAGE_KEYS.AUTHENTICATED_USER);
 
+                console.log('[AuthContext] Cached user data:', cached ? 'found' : 'not found');
                 if (cached) {
                     const userData = JSON.parse(cached);
+                    console.log('[AuthContext] Restoring user from localStorage:', userData);
                     setUser(userData);
                     setIsLoading(false);
                     return true;
                 }
             } catch (error) {
+                console.log('[AuthContext] Fallback restoration failed:', error);
                 // Fallback failed, continue to Firebase check
             }
             return false;
@@ -111,11 +115,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         // Try storage restore FIRST, regardless of Firebase config
         // This ensures non-Firebase sessions (like from professorAuthService) work immediately
         if (tryRestoreFromStorage()) {
+            console.log('[AuthContext] Successfully restored from localStorage');
             return;
         }
 
         // Only continue to Firebase check if storage restore failed
         if (!auth || !hasFirebaseConfig) {
+            console.log('[AuthContext] No Firebase config, not waiting for Firebase auth');
             setIsLoading(false);
             return;
         }

--- a/microfrontends/apps/mf-admin/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-admin/context/AuthContext.tsx
@@ -119,6 +119,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 console.log('[AuthContext] Cached user data:', cached ? 'found' : 'not found');
                 if (cached) {
                     const userData = JSON.parse(cached);
+                    if (userData?.role !== 'ADMIN') {
+                        console.log('[AuthContext] Cached user is not ADMIN, clearing session');
+                        localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
+                        localStorage.removeItem(BASE_STORAGE_KEYS.AUTHENTICATED_USER);
+                        document.cookie = 'auth_user=; path=/; expires=Thu, 01 Jan 1970 00:00:00 UTC;';
+                        return false;
+                    }
                     console.log('[AuthContext] Restoring user from storage:', userData);
                     setUser(userData);
                     setIsLoading(false);
@@ -171,9 +178,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                     const cached = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                     if (cached) {
                         try {
-                            setUser(JSON.parse(cached));
-                            setIsLoading(false);
-                            return;
+                            const cachedUser = JSON.parse(cached);
+                            if (cachedUser?.role !== 'ADMIN') {
+                                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
+                            } else {
+                                setUser(cachedUser);
+                                setIsLoading(false);
+                                return;
+                            }
                         } catch {
                             localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
                         }
@@ -183,9 +195,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                     const response = await api.get('/v1/auth/check');
                     if (response.data?.success && response.data?.user) {
                         const userData = buildUserFromBff(response.data.user);
-                        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(userData));
-                        setAdminCompat(userData, idToken, response.data.user?.subject);
-                        setUser(userData);
+                        if (userData.role === 'ADMIN') {
+                            localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(userData));
+                            setAdminCompat(userData, idToken, response.data.user?.subject);
+                            setUser(userData);
+                        } else {
+                            localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                        }
                     }
                 } catch {
                     // BFF call failed — clear state
@@ -194,16 +210,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                     setUser(null);
                 }
             } else {
-                // No Firebase user — but don't clear if user is already authenticated from another source
-                // (e.g., from cookies set by non-Firebase auth like professorAuthService)
-                if (!user) {
-                    console.log('[AuthContext] No Firebase user and no local user, clearing auth state');
-                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
-                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
-                    setUser(null);
-                } else {
-                    console.log('[AuthContext] No Firebase user, but user authenticated from other source. Keeping session.');
-                }
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER));
+                setUser(null);
             }
             setIsLoading(false);
         });
@@ -218,6 +227,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             const u = response.user;
             if (response.success && u) {
                 const userData = buildUserFromBff(u);
+
+                if (userData.role !== 'ADMIN') {
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                    throw new Error('Su cuenta no tiene acceso al panel de administración. Use el portal correspondiente a su rol.');
+                }
+
                 setAdminCompat(userData, response.token ?? '', u?.subject);
                 localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(userData));
                 setUser(userData);

--- a/microfrontends/apps/mf-admin/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-admin/context/AuthContext.tsx
@@ -91,16 +91,31 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
         const tryRestoreFromStorage = () => {
             try {
-                console.log('[AuthContext] Attempting to restore from localStorage');
-                // Try to restore from localStorage with environment-aware key
-                const cached =
+                console.log('[AuthContext] Attempting to restore from storage');
+
+                // Try localStorage first (environment-aware key)
+                let cached =
                     localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER)) ||
                     localStorage.getItem(BASE_STORAGE_KEYS.AUTHENTICATED_USER);
+
+                // If not found in localStorage, try cookies (for cross-origin redirects)
+                if (!cached) {
+                    console.log('[AuthContext] Not in localStorage, checking cookies...');
+                    const cookieValue = document.cookie
+                        .split('; ')
+                        .find(row => row.startsWith('auth_user='))
+                        ?.split('=')[1];
+
+                    if (cookieValue) {
+                        cached = decodeURIComponent(cookieValue);
+                        console.log('[AuthContext] Found user in cookies');
+                    }
+                }
 
                 console.log('[AuthContext] Cached user data:', cached ? 'found' : 'not found');
                 if (cached) {
                     const userData = JSON.parse(cached);
-                    console.log('[AuthContext] Restoring user from localStorage:', userData);
+                    console.log('[AuthContext] Restoring user from storage:', userData);
                     setUser(userData);
                     setIsLoading(false);
                     return true;

--- a/microfrontends/apps/mf-admin/package.json
+++ b/microfrontends/apps/mf-admin/package.json
@@ -14,6 +14,8 @@
     "axios": "^1.11.0",
     "axios-retry": "^4.5.0",
     "date-fns": "^4.1.0",
+    "echarts": "^6.0.0",
+    "echarts-for-react": "^3.0.6",
     "express": "^4.18.2",
     "firebase": "^12.12.1",
     "lucide-react": "^0.540.0",
@@ -23,7 +25,6 @@
     "react-dropzone": "^14.3.8",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.3",
-    "recharts": "^3.2.1",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {

--- a/microfrontends/apps/mf-admin/pages/AdminLogin.tsx
+++ b/microfrontends/apps/mf-admin/pages/AdminLogin.tsx
@@ -5,7 +5,7 @@ import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
 import { useAuth } from '../context/AuthContext';
 import { useNotifications } from '../context/AppContext';
-import { microfrontendUrls } from '../utils/microfrontendUrls';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 const AdminLogin: React.FC = () => {
     const navigate = useNavigate();
@@ -34,17 +34,15 @@ const AdminLogin: React.FC = () => {
         try {
             await login(email, password, 'ADMIN');
 
-            const storedUser = JSON.parse(localStorage.getItem('authenticated_user') || 'null');
+            const storedKey = getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER);
+            const storedUser = JSON.parse(localStorage.getItem(storedKey) || 'null');
+
             if (!storedUser || storedUser.role !== 'ADMIN') {
-                localStorage.removeItem('auth_token');
-                localStorage.removeItem('authenticated_user');
-
-                if (storedUser?.role === 'APODERADO') {
-                    window.location.href = microfrontendUrls.guardianDashboard;
-                    return;
-                }
-
-                window.location.href = microfrontendUrls.professorDashboard;
+                localStorage.removeItem(storedKey);
+                localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                const msg = 'Su cuenta no tiene acceso al panel de administración. Use el portal correspondiente a su rol.';
+                setError(msg);
+                addNotification({ type: 'error', title: 'Acceso denegado', message: msg });
                 return;
             }
 

--- a/microfrontends/apps/mf-admin/pages/ProfessorLoginPage.tsx
+++ b/microfrontends/apps/mf-admin/pages/ProfessorLoginPage.tsx
@@ -85,12 +85,17 @@ const ProfessorLoginPage: React.FC = () => {
                         localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(adminUser));
                         localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), response.token);
 
-                        // Also save to cookies for cross-origin access (port 5204 to 5206)
+                        // Also save to cookies for cross-port access (port 5204 to 5206)
                         // Use a 7-day expiration and path=/
                         const expirationDate = new Date();
                         expirationDate.setDate(expirationDate.getDate() + 7);
-                        document.cookie = `auth_user=${encodeURIComponent(JSON.stringify(adminUser))}; path=/; expires=${expirationDate.toUTCString()}`;
-                        document.cookie = `auth_token=${encodeURIComponent(response.token)}; path=/; expires=${expirationDate.toUTCString()}`;
+                        const userCookie = `auth_user=${encodeURIComponent(JSON.stringify(adminUser))}; path=/; expires=${expirationDate.toUTCString()}`;
+                        const tokenCookie = `auth_token=${encodeURIComponent(response.token)}; path=/; expires=${expirationDate.toUTCString()}`;
+
+                        console.log('[ProfessorLogin] Setting cookies for cross-port access');
+                        document.cookie = userCookie;
+                        document.cookie = tokenCookie;
+                        console.log('[ProfessorLogin] Cookies set. Current cookies:', document.cookie);
                     }
 
                     // Guardar información del profesor en localStorage para compatibilidad

--- a/microfrontends/apps/mf-admin/pages/ProfessorLoginPage.tsx
+++ b/microfrontends/apps/mf-admin/pages/ProfessorLoginPage.tsx
@@ -8,6 +8,7 @@ import { useNotifications } from '../context/AppContext';
 import { professorAuthService } from '../services/professorAuthService';
 import { useAuth } from '../context/AuthContext';
 import { microfrontendUrls } from '../utils/microfrontendUrls';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 const ProfessorLoginPage: React.FC = () => {
     const navigate = useNavigate();
@@ -69,7 +70,7 @@ const ProfessorLoginPage: React.FC = () => {
                 // Verificar que el rol sea de profesor
                 if (respRole && professorAuthService.isProfessorRole(respRole)) {
 
-                    // Si es admin, guardar datos en localStorage del AuthContext
+                    // Si es admin, guardar datos en localStorage del AuthContext con keys ambientales
                     if (respRole === 'ADMIN') {
                         console.log('Usuario admin detectado, guardando en AuthContext...');
                         const adminUser = {
@@ -79,8 +80,8 @@ const ProfessorLoginPage: React.FC = () => {
                             lastName: respLastName,
                             role: 'ADMIN',
                         };
-                        localStorage.setItem('authenticated_user', JSON.stringify(adminUser));
-                        localStorage.setItem('auth_token', response.token);
+                        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(adminUser));
+                        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), response.token);
                     }
 
                     // Guardar información del profesor en localStorage para compatibilidad

--- a/microfrontends/apps/mf-admin/pages/ProfessorLoginPage.tsx
+++ b/microfrontends/apps/mf-admin/pages/ProfessorLoginPage.tsx
@@ -68,13 +68,21 @@ const ProfessorLoginPage: React.FC = () => {
             if (response.success && response.token) {
                 // Verificar que el rol sea de profesor
                 if (respRole && professorAuthService.isProfessorRole(respRole)) {
-                    
-                    // Si es admin, registrar en AuthContext principal
+
+                    // Si es admin, guardar datos en localStorage del AuthContext
                     if (respRole === 'ADMIN') {
-                        console.log('Usuario admin detectado, registrando en AuthContext principal...');
-                        await loginWithAuth(data.email, data.password, 'ADMIN');
+                        console.log('Usuario admin detectado, guardando en AuthContext...');
+                        const adminUser = {
+                            id: String(respId),
+                            email: respEmail,
+                            firstName: respFirstName,
+                            lastName: respLastName,
+                            role: 'ADMIN',
+                        };
+                        localStorage.setItem('authenticated_user', JSON.stringify(adminUser));
+                        localStorage.setItem('auth_token', response.token);
                     }
-                    
+
                     // Guardar información del profesor en localStorage para compatibilidad
                     localStorage.setItem('currentProfessor', JSON.stringify({
                         id: respId,
@@ -94,11 +102,11 @@ const ProfessorLoginPage: React.FC = () => {
                     });
 
                     console.log('Login exitoso, redirigiendo al dashboard...');
-                    
+
                     // Redirigir según el rol del usuario
                     if (respRole === 'ADMIN') {
                         console.log('Usuario admin detectado, redirigiendo al panel de administración...');
-                        navigate('/admin', { replace: true });
+                        window.location.href = '/#/admin';
                     } else {
                         console.log('Usuario profesor detectado, redirigiendo al dashboard de profesor...');
                         window.location.href = microfrontendUrls.professorDashboard;

--- a/microfrontends/apps/mf-admin/pages/ProfessorLoginPage.tsx
+++ b/microfrontends/apps/mf-admin/pages/ProfessorLoginPage.tsx
@@ -6,7 +6,7 @@ import { useFormValidation } from '../hooks/useFormValidation';
 import { useNotifications } from '../context/AppContext';
 import { professorAuthService } from '../services/professorAuthService';
 import { microfrontendUrls } from '../utils/microfrontendUrls';
-import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
+import { getStorageKey, BASE_STORAGE_KEYS, clearAllSessions } from '../../../packages/backend-sdk/src/index';
 
 const ProfessorLoginPage: React.FC = () => {
     const { addNotification } = useNotifications();
@@ -46,7 +46,9 @@ const ProfessorLoginPage: React.FC = () => {
 
         try {
             console.log('Iniciando login para profesor:', data.email);
-            
+
+            clearAllSessions();
+
             // Usar el servicio de autenticación real
             const response = await professorAuthService.login({
                 email: data.email,

--- a/microfrontends/apps/mf-admin/pages/ProfessorLoginPage.tsx
+++ b/microfrontends/apps/mf-admin/pages/ProfessorLoginPage.tsx
@@ -1,19 +1,15 @@
 import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
 import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
 import { useFormValidation } from '../hooks/useFormValidation';
 import { useNotifications } from '../context/AppContext';
 import { professorAuthService } from '../services/professorAuthService';
-import { useAuth } from '../context/AuthContext';
 import { microfrontendUrls } from '../utils/microfrontendUrls';
 import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 const ProfessorLoginPage: React.FC = () => {
-    const navigate = useNavigate();
     const { addNotification } = useNotifications();
-    const { login: loginWithAuth } = useAuth();
     const [isLoggingIn, setIsLoggingIn] = useState(false);
     const [loginError, setLoginError] = useState<string | null>(null);
 
@@ -67,47 +63,19 @@ const ProfessorLoginPage: React.FC = () => {
             const respSubject   = u?.subject   || (response as any).subject   || null;
 
             if (response.success && response.token) {
-                // Verificar que el rol sea de profesor
+                // Verificar que el rol sea de profesor (ADMIN excluido: tiene su propio portal)
                 if (respRole && professorAuthService.isProfessorRole(respRole)) {
 
-                    // Si es admin, guardar datos para acceso cross-origin (localStorage + cookies)
-                    if (respRole === 'ADMIN') {
-                        console.log('Usuario admin detectado, guardando en AuthContext...');
-                        const adminUser = {
-                            id: String(respId),
-                            email: respEmail,
-                            firstName: respFirstName,
-                            lastName: respLastName,
-                            role: 'ADMIN',
-                        };
-
-                        // Save to localStorage with environment-aware key
-                        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(adminUser));
-                        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), response.token);
-
-                        // Also save to cookies for cross-port access (port 5204 to 5206)
-                        // Use a 7-day expiration and path=/
-                        const expirationDate = new Date();
-                        expirationDate.setDate(expirationDate.getDate() + 7);
-                        const userCookie = `auth_user=${encodeURIComponent(JSON.stringify(adminUser))}; path=/; expires=${expirationDate.toUTCString()}`;
-                        const tokenCookie = `auth_token=${encodeURIComponent(response.token)}; path=/; expires=${expirationDate.toUTCString()}`;
-
-                        console.log('[ProfessorLogin] Setting cookies for cross-port access');
-                        document.cookie = userCookie;
-                        document.cookie = tokenCookie;
-                        console.log('[ProfessorLogin] Cookies set. Current cookies:', document.cookie);
-                    }
-
-                    // Guardar información del profesor en localStorage para compatibilidad
-                    localStorage.setItem('currentProfessor', JSON.stringify({
+                    // Guardar información del profesor en localStorage con clave con prefijo de entorno
+                    localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR), JSON.stringify({
                         id: respId,
                         firstName: respFirstName,
                         lastName: respLastName,
                         email: respEmail,
+                        role: respRole,
                         subject: respSubject,
                         subjects: getSubjectsByRole(respRole),
                         assignedGrades: ['prekinder', 'kinder', '1basico', '2basico', '3basico', '4basico', '5basico', '6basico', '7basico', '8basico', '1medio', '2medio', '3medio', '4medio'],
-                        isAdmin: respRole === 'ADMIN'
                     }));
 
                     addNotification({
@@ -116,17 +84,7 @@ const ProfessorLoginPage: React.FC = () => {
                         message: `Hola ${respFirstName} ${respLastName}`
                     });
 
-                    console.log('Login exitoso, redirigiendo al dashboard...');
-
-                    // Redirigir según el rol del usuario
-                    if (respRole === 'ADMIN') {
-                        console.log('Usuario admin detectado, redirigiendo al panel de administración...');
-                        // Save auth data before redirecting across origins (localhost:5204 -> localhost:5206)
-                        window.location.href = microfrontendUrls.adminDashboard;
-                    } else {
-                        console.log('Usuario profesor detectado, redirigiendo al dashboard de profesor...');
-                        window.location.href = microfrontendUrls.professorDashboard;
-                    }
+                    window.location.href = microfrontendUrls.professorDashboard;
                     
                 } else {
                     const msg = 'Su cuenta no tiene acceso a este portal. Contacte al administrador.';
@@ -148,19 +106,9 @@ const ProfessorLoginPage: React.FC = () => {
         }
     };
 
-    const handleKeyPress = (e: React.KeyboardEvent) => {
-        if (e.key === 'Enter') {
-            handleLogin();
-        }
-    };
-
     // Función para obtener las asignaturas según el rol
     const getSubjectsByRole = (role: string): string[] => {
         switch (role) {
-            // Administración
-            case 'ADMIN':
-                return ['MATH', 'SPANISH', 'ENGLISH', 'SCIENCE', 'HISTORY', 'PSYCHOLOGY'];
-            
             // Profesores ciclo inicial (pueden evaluar todo en su ciclo)
             case 'TEACHER_EARLY_CYCLE':
                 return ['MATH', 'SPANISH'];

--- a/microfrontends/apps/mf-admin/pages/ProfessorLoginPage.tsx
+++ b/microfrontends/apps/mf-admin/pages/ProfessorLoginPage.tsx
@@ -70,7 +70,7 @@ const ProfessorLoginPage: React.FC = () => {
                 // Verificar que el rol sea de profesor
                 if (respRole && professorAuthService.isProfessorRole(respRole)) {
 
-                    // Si es admin, guardar datos en localStorage del AuthContext con keys ambientales
+                    // Si es admin, guardar datos para acceso cross-origin (localStorage + cookies)
                     if (respRole === 'ADMIN') {
                         console.log('Usuario admin detectado, guardando en AuthContext...');
                         const adminUser = {
@@ -80,8 +80,17 @@ const ProfessorLoginPage: React.FC = () => {
                             lastName: respLastName,
                             role: 'ADMIN',
                         };
+
+                        // Save to localStorage with environment-aware key
                         localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(adminUser));
                         localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), response.token);
+
+                        // Also save to cookies for cross-origin access (port 5204 to 5206)
+                        // Use a 7-day expiration and path=/
+                        const expirationDate = new Date();
+                        expirationDate.setDate(expirationDate.getDate() + 7);
+                        document.cookie = `auth_user=${encodeURIComponent(JSON.stringify(adminUser))}; path=/; expires=${expirationDate.toUTCString()}`;
+                        document.cookie = `auth_token=${encodeURIComponent(response.token)}; path=/; expires=${expirationDate.toUTCString()}`;
                     }
 
                     // Guardar información del profesor en localStorage para compatibilidad
@@ -107,7 +116,8 @@ const ProfessorLoginPage: React.FC = () => {
                     // Redirigir según el rol del usuario
                     if (respRole === 'ADMIN') {
                         console.log('Usuario admin detectado, redirigiendo al panel de administración...');
-                        window.location.href = '/#/admin';
+                        // Save auth data before redirecting across origins (localhost:5204 -> localhost:5206)
+                        window.location.href = microfrontendUrls.adminDashboard;
                     } else {
                         console.log('Usuario profesor detectado, redirigiendo al dashboard de profesor...');
                         window.location.href = microfrontendUrls.professorDashboard;

--- a/microfrontends/apps/mf-admin/services/interviewService.ts
+++ b/microfrontends/apps/mf-admin/services/interviewService.ts
@@ -796,14 +796,14 @@ class InterviewService {
       const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
       if (!dateRegex.test(date)) {
         console.error(`getAvailableTimeSlots: Formato de fecha inválido "${date}". Se esperaba YYYY-MM-DD`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Verificar que el año sea razonable
       const year = parseInt(date.split('-')[0]);
       if (year < 2020 || year > 2100) {
         console.error(`getAvailableTimeSlots: Año inválido ${year}. Debe estar entre 2020 y 2100`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Validar y usar duración por defecto si es inválida
@@ -825,8 +825,8 @@ class InterviewService {
 
       // Verificar si la respuesta es del placeholder (microservicio no implementado)
       if (response.data && typeof response.data === 'object' && 'error' in response.data) {
-        console.log('Available slots service no implementado, usando horarios por defecto');
-        return this.getDefaultTimeSlots();
+        console.log('Available slots service no implementado, devolviendo horarios vacíos');
+        return [];
       }
 
       // CASO 1: Backend devuelve estructura { success: true, data: { availableSlots: [...] } }
@@ -878,13 +878,12 @@ class InterviewService {
         }
       }
 
-      console.log('Estructura de respuesta inesperada para available slots, usando horarios por defecto');
+      console.log('Estructura de respuesta inesperada para available slots, devolviendo horarios vacíos');
       console.log('Data recibida:', response.data);
-      return this.getDefaultTimeSlots();
+      return [];
     } catch (error) {
       console.error('Error fetching available slots:', error);
-      // Fallback: horarios estándar si el backend no los tiene configurados
-      return this.getDefaultTimeSlots();
+      return [];
     }
   }
 
@@ -979,14 +978,14 @@ class InterviewService {
       const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
       if (!dateRegex.test(date)) {
         console.error(`getCommonTimeSlots: Formato de fecha inválido "${date}". Se esperaba YYYY-MM-DD`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Verificar que el año sea razonable
       const year = parseInt(date.split('-')[0]);
       if (year < 2020 || year > 2100) {
         console.error(`getCommonTimeSlots: Año inválido ${year}. Debe estar entre 2020 y 2100`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Obtener los horarios disponibles de ambos entrevistadores
@@ -1006,8 +1005,7 @@ class InterviewService {
       return commonSlots;
     } catch (error) {
       console.error('Error obteniendo horarios comunes:', error);
-      // Fallback: horarios por defecto
-      return this.getDefaultTimeSlots();
+      return [];
     }
   }
 

--- a/microfrontends/apps/mf-admin/services/professorAuthService.ts
+++ b/microfrontends/apps/mf-admin/services/professorAuthService.ts
@@ -39,7 +39,7 @@ class ProfessorAuthService {
 
             // Send credentials directly over HTTPS (no RSA encryption)
             console.log('[Professor Auth] Sending credentials over HTTPS');
-            const response = await api.post('/v1/auth/login', request);
+            const response = await api.post('/v1/auth/login', { ...request, portalType: 'STAFF' });
             const data = response.data;
 
             console.log('Login exitoso para profesor:', data);
@@ -64,8 +64,10 @@ class ProfessorAuthService {
             
             if (error.response?.status === 401) {
                 throw new Error('Credenciales inválidas');
+            } else if (error.response?.status === 403) {
+                throw new Error(error.response?.data?.error?.message || 'Su cuenta no tiene acceso al portal de profesores. Use el portal correspondiente a su rol.');
             } else if (error.response?.status === 400) {
-                throw new Error('Datos de login inválidos');
+                throw new Error(error.response?.data?.error?.message || 'Datos de login inválidos');
             } else if (error.response?.status === 500) {
                 throw new Error('Error del servidor');
             }
@@ -119,9 +121,6 @@ class ProfessorAuthService {
     // Método para verificar si el usuario es un profesor válido
     isProfessorRole(role: string): boolean {
         const professorRoles = [
-            // Administración
-            'ADMIN',
-
             // Roles del backend (actuales)
             'TEACHER',
             'COORDINATOR',

--- a/microfrontends/apps/mf-admin/src/components/charts/EChart.tsx
+++ b/microfrontends/apps/mf-admin/src/components/charts/EChart.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactECharts from 'echarts-for-react';
+import type { EChartsOption } from 'echarts';
+
+interface EChartProps {
+  option: EChartsOption;
+  height?: number;
+  onEvents?: Record<string, (params: any) => void>;
+}
+
+const EChart: React.FC<EChartProps> = ({ option, height = 300, onEvents }) => (
+  <ReactECharts
+    option={option}
+    notMerge
+    lazyUpdate
+    onEvents={onEvents}
+    style={{ width: '100%', height }}
+  />
+);
+
+export default EChart;

--- a/microfrontends/apps/mf-admin/src/components/coordinator/CoordinatorDashboard.tsx
+++ b/microfrontends/apps/mf-admin/src/components/coordinator/CoordinatorDashboard.tsx
@@ -9,7 +9,8 @@
 import React, { useState, useEffect } from 'react';
 import { dashboardClient } from '../../api/dashboard.client';
 import type { DetailedAdminStats, Alert } from '../../api/dashboard.types';
-import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { ApplicantMetricsModal } from '../../../components/modals/ApplicantMetricsModal';
 
 export const CoordinatorDashboard: React.FC = () => {
@@ -143,6 +144,32 @@ export const CoordinatorDashboard: React.FC = () => {
   const acceptanceRate = stats.totalApplications > 0
     ? ((stats.statusBreakdown.approved / stats.totalApplications) * 100).toFixed(1)
     : '0.0';
+
+  const statusChartOption: EChartsOption = {
+    color: statusData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [
+      {
+        type: 'pie',
+        radius: ['42%', '70%'],
+        center: ['50%', '50%'],
+        avoidLabelOverlap: true,
+        itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+        label: { formatter: '{b}: {d}%' },
+        data: statusData.map(item => ({ name: item.name, value: item.value }))
+      }
+    ]
+  };
+
+  const gradeChartOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: gradeData.map(item => item.grade), axisTick: { alignWithLabel: true } },
+    yAxis: { type: 'value' },
+    series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 42 }]
+  };
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -336,25 +363,7 @@ export const CoordinatorDashboard: React.FC = () => {
         {/* Status Distribution Pie Chart */}
         <div className="bg-white shadow rounded-lg p-6">
           <h2 className="text-lg font-medium text-gray-900 mb-4">Distribución por Estado</h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie
-                data={statusData}
-                cx="50%"
-                cy="50%"
-                labelLine={false}
-                label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
-                outerRadius={80}
-                fill="#8884d8"
-                dataKey="value"
-              >
-                {statusData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
-                ))}
-              </Pie>
-              <Tooltip />
-            </PieChart>
-          </ResponsiveContainer>
+          <EChart option={statusChartOption} height={300} />
           <div className="mt-4 grid grid-cols-2 gap-2 text-sm">
             {statusData.map((item, index) => (
               <div key={index} className="flex items-center">
@@ -371,16 +380,7 @@ export const CoordinatorDashboard: React.FC = () => {
         {/* Grade Distribution Bar Chart */}
         <div className="bg-white shadow rounded-lg p-6">
           <h2 className="text-lg font-medium text-gray-900 mb-4">Distribución por Nivel</h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={gradeData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="grade" />
-              <YAxis />
-              <Tooltip />
-              <Legend />
-              <Bar dataKey="count" fill="#3B82F6" name="Postulaciones" />
-            </BarChart>
-          </ResponsiveContainer>
+          <EChart option={gradeChartOption} height={300} />
         </div>
       </div>
 

--- a/microfrontends/apps/mf-admin/src/components/coordinator/TemporalTrendsView.tsx
+++ b/microfrontends/apps/mf-admin/src/components/coordinator/TemporalTrendsView.tsx
@@ -8,7 +8,8 @@
 import React, { useState, useEffect } from 'react';
 import { dashboardClient } from '../../api/dashboard.client';
 import type { TemporalTrend, DetailedAdminStats } from '../../api/dashboard.types';
-import { LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { format } from 'date-fns';
 
 export const TemporalTrendsView: React.FC = () => {
@@ -114,6 +115,52 @@ export const TemporalTrendsView: React.FC = () => {
     };
   }).filter(Boolean);
 
+  const monthlyTrendsOption: EChartsOption = {
+    color: ['#3B82F6', '#10B981', '#EF4444', '#F59E0B'],
+    tooltip: { trigger: 'axis' },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 48, top: 24, bottom: 80, containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: monthlyTrendsData.map(item => item.month),
+      axisLabel: { rotate: 45 }
+    },
+    yAxis: [
+      { type: 'value', name: 'Postulaciones' },
+      { type: 'value', name: '%' }
+    ],
+    series: [
+      { name: 'Total Postulaciones', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.total) },
+      { name: 'Aprobadas', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.approved) },
+      { name: 'Rechazadas', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.rejected) },
+      { name: 'Tasa de Crecimiento (%)', type: 'line', smooth: true, yAxisIndex: 1, lineStyle: { type: 'dashed' }, data: monthlyTrendsData.map(item => item.growthRate) }
+    ]
+  };
+
+  const comparisonOption: EChartsOption = {
+    color: ['#3B82F6', '#10B981', '#EF4444'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: comparisonData.map((item: any) => item.year) },
+    yAxis: { type: 'value' },
+    series: [
+      { name: 'Total', type: 'bar', data: comparisonData.map((item: any) => item.total) },
+      { name: 'Aprobadas', type: 'bar', data: comparisonData.map((item: any) => item.approved) },
+      { name: 'Rechazadas', type: 'bar', data: comparisonData.map((item: any) => item.rejected) }
+    ]
+  };
+
+  const acceptanceRateOption: EChartsOption = {
+    color: ['#10B981'],
+    tooltip: { trigger: 'axis', valueFormatter: value => `${Number(value).toFixed(1)}%` },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: comparisonData.map((item: any) => item.year) },
+    yAxis: { type: 'value', min: 0, max: 100 },
+    series: [{ name: 'Tasa de Aceptación (%)', type: 'bar', data: comparisonData.map((item: any) => item.acceptanceRate), barMaxWidth: 48 }]
+  };
+
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       {/* Header */}
@@ -147,50 +194,7 @@ export const TemporalTrendsView: React.FC = () => {
       {/* Monthly Trends Chart */}
       <div className="bg-white shadow rounded-lg p-6 mb-6">
         <h2 className="text-lg font-medium text-gray-900 mb-4">Tendencia Mensual (Últimos 12 meses)</h2>
-        <ResponsiveContainer width="100%" height={400}>
-          <LineChart data={monthlyTrendsData}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="month" angle={-45} textAnchor="end" height={80} />
-            <YAxis yAxisId="left" />
-            <YAxis yAxisId="right" orientation="right" />
-            <Tooltip />
-            <Legend />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="total"
-              stroke="#3B82F6"
-              strokeWidth={2}
-              name="Total Postulaciones"
-              dot={{ r: 4 }}
-            />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="approved"
-              stroke="#10B981"
-              strokeWidth={2}
-              name="Aprobadas"
-            />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="rejected"
-              stroke="#EF4444"
-              strokeWidth={2}
-              name="Rechazadas"
-            />
-            <Line
-              yAxisId="right"
-              type="monotone"
-              dataKey="growthRate"
-              stroke="#F59E0B"
-              strokeWidth={2}
-              name="Tasa de Crecimiento (%)"
-              strokeDasharray="5 5"
-            />
-          </LineChart>
-        </ResponsiveContainer>
+        <EChart option={monthlyTrendsOption} height={400} />
       </div>
 
       {/* Year Comparison */}
@@ -199,33 +203,13 @@ export const TemporalTrendsView: React.FC = () => {
           {/* Total Applications Comparison */}
           <div className="bg-white shadow rounded-lg p-6">
             <h2 className="text-lg font-medium text-gray-900 mb-4">Comparativa de Postulaciones</h2>
-            <ResponsiveContainer width="100%" height={300}>
-              <BarChart data={comparisonData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="year" />
-                <YAxis />
-                <Tooltip />
-                <Legend />
-                <Bar dataKey="total" fill="#3B82F6" name="Total" />
-                <Bar dataKey="approved" fill="#10B981" name="Aprobadas" />
-                <Bar dataKey="rejected" fill="#EF4444" name="Rechazadas" />
-              </BarChart>
-            </ResponsiveContainer>
+            <EChart option={comparisonOption} height={300} />
           </div>
 
           {/* Acceptance Rate Comparison */}
           <div className="bg-white shadow rounded-lg p-6">
             <h2 className="text-lg font-medium text-gray-900 mb-4">Tasa de Aceptación por Año</h2>
-            <ResponsiveContainer width="100%" height={300}>
-              <BarChart data={comparisonData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="year" />
-                <YAxis domain={[0, 100]} />
-                <Tooltip formatter={(value) => `${Number(value).toFixed(1)}%`} />
-                <Legend />
-                <Bar dataKey="acceptanceRate" fill="#10B981" name="Tasa de Aceptación (%)" />
-              </BarChart>
-            </ResponsiveContainer>
+            <EChart option={acceptanceRateOption} height={300} />
           </div>
         </div>
       )}

--- a/microfrontends/apps/mf-admissions/App.tsx
+++ b/microfrontends/apps/mf-admissions/App.tsx
@@ -4,6 +4,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import HomePage from './pages/HomePage';
 import ApplicationForm from './pages/ApplicationForm';
 import ComplementaryApplicationForm from './pages/ComplementaryApplicationForm';
+import ApoderadoLogin from './pages/ApoderadoLogin';
 import { AppProvider } from './context/AppContext';
 import { AuthProvider } from './context/AuthContext';
 import Header from './components/layout/Header';
@@ -32,10 +33,11 @@ function App() {
                 <Routes>
 
         <Route path="/" element={<HomePage />} />
+        <Route path="/apoderado/login" element={<ApoderadoLogin />} />
         <Route path="/postulacion" element={<ApplicationForm />} />
         <Route path="/postulacion/complementaria" element={<ComplementaryApplicationForm />} />
         {legacyRedirects}
-        <Route path="*" element={<Navigate to="/postulacion" replace />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
     
                 </Routes>
               </Suspense>

--- a/microfrontends/apps/mf-admissions/components/admin/AnalyticsView.tsx
+++ b/microfrontends/apps/mf-admissions/components/admin/AnalyticsView.tsx
@@ -6,7 +6,8 @@
 import React, { useState, useEffect } from 'react';
 import { FiTrendingUp, FiUsers, FiAward, FiClock } from 'react-icons/fi';
 import Card from '../ui/Card';
-import { BarChart, Bar, LineChart, Line, RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { dashboardClient } from '../../src/api/dashboard.client';
 
 export const AnalyticsView: React.FC = () => {
@@ -54,7 +55,34 @@ export const AnalyticsView: React.FC = () => {
         );
     }
 
-    const COLORS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899'];
+    const evaluatorPerformanceOption: EChartsOption = {
+        color: ['#10B981', '#F59E0B'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: evaluatorData.map(item => item.name) },
+        yAxis: { type: 'value' },
+        series: [
+            { name: 'Completadas', type: 'bar', data: evaluatorData.map(item => item.completed) },
+            { name: 'Pendientes', type: 'bar', data: evaluatorData.map(item => item.pending) }
+        ]
+    };
+
+    const radarData = evaluatorData.slice(0, 6);
+    const evaluatorWorkloadOption: EChartsOption = {
+        color: ['#3B82F6'],
+        tooltip: {},
+        radar: {
+            indicator: radarData.map(item => ({ name: item.name, max: Math.max(...radarData.map(e => e.total || 0), 1) })),
+            splitArea: { areaStyle: { color: ['rgba(59, 130, 246, 0.04)', 'rgba(59, 130, 246, 0.1)'] } }
+        },
+        series: [{
+            name: 'Evaluaciones',
+            type: 'radar',
+            areaStyle: { opacity: 0.35 },
+            data: [{ name: 'Evaluaciones', value: radarData.map(item => item.total || 0) }]
+        }]
+    };
 
     return (
         <div className="space-y-6">
@@ -136,31 +164,13 @@ export const AnalyticsView: React.FC = () => {
                 {/* Evaluator Performance */}
                 <Card className="p-6">
                     <h3 className="text-lg font-semibold text-gray-900 mb-4">Rendimiento de Evaluadores</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <BarChart data={evaluatorData}>
-                            <CartesianGrid strokeDasharray="3 3" />
-                            <XAxis dataKey="name" />
-                            <YAxis />
-                            <Tooltip />
-                            <Legend />
-                            <Bar dataKey="completed" fill="#10B981" name="Completadas" />
-                            <Bar dataKey="pending" fill="#F59E0B" name="Pendientes" />
-                        </BarChart>
-                    </ResponsiveContainer>
+                    <EChart option={evaluatorPerformanceOption} height={300} />
                 </Card>
 
                 {/* Evaluator Workload Radar */}
                 <Card className="p-6">
                     <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución de Carga de Trabajo</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <RadarChart data={evaluatorData.slice(0, 6)}>
-                            <PolarGrid />
-                            <PolarAngleAxis dataKey="name" />
-                            <PolarRadiusAxis />
-                            <Radar name="Evaluaciones" dataKey="total" stroke="#3B82F6" fill="#3B82F6" fillOpacity={0.6} />
-                            <Tooltip />
-                        </RadarChart>
-                    </ResponsiveContainer>
+                    <EChart option={evaluatorWorkloadOption} height={300} />
                 </Card>
             </div>
 

--- a/microfrontends/apps/mf-admissions/components/admin/ApplicantMetricsView.tsx
+++ b/microfrontends/apps/mf-admissions/components/admin/ApplicantMetricsView.tsx
@@ -5,7 +5,8 @@ import Badge from '../ui/Badge';
 import Button from '../ui/Button';
 import { dashboardClient } from '../../src/api/dashboard.client';
 import type { ApplicantMetric, ApplicantMetricsFilters } from '../../src/api/dashboard.types';
-import { PieChart, Pie, BarChart, Bar, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, LabelList } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 
 // Version: 2025-11-11 - Added overallOpinionScore display
 export const ApplicantMetricsView: React.FC = () => {
@@ -178,6 +179,48 @@ export const ApplicantMetricsView: React.FC = () => {
   };
 
   const { performanceData, avgData } = getChartData();
+
+  const performanceDistributionOption: EChartsOption = {
+    color: performanceData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    legend: { bottom: 0 },
+    series: [{
+      type: 'pie',
+      radius: ['42%', '70%'],
+      center: ['50%', '44%'],
+      itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+      label: { formatter: '{d}%' },
+      data: performanceData.map(item => ({ name: item.name, value: item.value }))
+    }]
+  };
+
+  const examAverageOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', valueFormatter: value => `${value}%` },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 24, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: avgData.map(item => item.name) },
+    yAxis: { type: 'value', min: 0, max: 100 },
+    series: [{
+      name: 'Promedio (%)',
+      type: 'bar',
+      data: avgData.map(item => item.promedio),
+      barMaxWidth: 48,
+      label: { show: true, position: 'top', formatter: '{c}%' }
+    }]
+  };
+
+  const subjectDistributionOption: EChartsOption = {
+    color: subjectDistribution.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [{
+      type: 'pie',
+      radius: ['42%', '72%'],
+      itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+      label: { formatter: '{b}: {d}%' },
+      data: subjectDistribution.map(item => ({ name: item.name, value: item.value }))
+    }]
+  };
 
   const uniqueGrades = [...new Set(applicants.map(a => a.gradeApplied))].sort();
   const uniqueStatuses = [...new Set(applicants.map(a => a.applicationStatus))];
@@ -420,56 +463,17 @@ export const ApplicantMetricsView: React.FC = () => {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <Card className="p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución de Rendimiento</h3>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie
-                data={performanceData}
-                cx="50%"
-                cy="50%"
-                labelLine={false}
-                label={({ percent }: { percent?: number }) => `${Math.round((percent || 0) * 100)}%`}
-                outerRadius={80}
-                fill="#8884d8"
-                dataKey="value"
-              >
-                {performanceData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
-                ))}
-              </Pie>
-              <Tooltip />
-              <Legend
-                verticalAlign="bottom"
-                height={36}
-                formatter={(value, entry: any) => entry.payload.name}
-              />
-            </PieChart>
-          </ResponsiveContainer>
+          <EChart option={performanceDistributionOption} height={300} />
         </Card>
 
         <Card className="p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Promedio por Examen</h3>
           <p className="text-sm text-gray-500 mb-2">Haz clic en una barra para ver la distribución detallada</p>
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={avgData} onClick={(data) => {
-              if (data && data.activeLabel) {
-                handleSubjectClick(data.activeLabel);
-              }
-            }}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
-              <YAxis domain={[0, 100]} />
-              <Tooltip />
-              <Legend />
-              <Bar
-                dataKey="promedio"
-                fill="#3B82F6"
-                name="Promedio (%)"
-                cursor="pointer"
-              >
-                <LabelList dataKey="promedio" position="top" formatter={(value: number) => `${value}%`} />
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+          <EChart
+            option={examAverageOption}
+            height={300}
+            onEvents={{ click: params => params.name && handleSubjectClick(String(params.name)) }}
+          />
         </Card>
       </div>
 
@@ -680,27 +684,7 @@ export const ApplicantMetricsView: React.FC = () => {
               </div>
 
               <div className="mb-6">
-                <ResponsiveContainer width="100%" height={350}>
-                  <PieChart>
-                    <Pie
-                      data={subjectDistribution}
-                      cx="50%"
-                      cy="50%"
-                      labelLine={false}
-                      label={({ name, percent }: { name: string, percent?: number }) =>
-                        `${name}: ${Math.round((percent || 0) * 100)}%`
-                      }
-                      outerRadius={120}
-                      fill="#8884d8"
-                      dataKey="value"
-                    >
-                      {subjectDistribution.map((entry, index) => (
-                        <Cell key={`cell-${index}`} fill={entry.color} />
-                      ))}
-                    </Pie>
-                    <Tooltip />
-                  </PieChart>
-                </ResponsiveContainer>
+                <EChart option={subjectDistributionOption} height={350} />
               </div>
 
               <div className="border-t pt-4">

--- a/microfrontends/apps/mf-admissions/components/admin/ReportsView.tsx
+++ b/microfrontends/apps/mf-admissions/components/admin/ReportsView.tsx
@@ -7,7 +7,8 @@ import React, { useState, useEffect } from 'react';
 import { FiDownload, FiFilter, FiCalendar, FiBarChart2, FiPieChart, FiTrendingUp } from 'react-icons/fi';
 import Card from '../ui/Card';
 import Button from '../ui/Button';
-import { BarChart, Bar, PieChart, Pie, LineChart, Line, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { dashboardClient } from '../../src/api/dashboard.client';
 
 interface ReportFilters {
@@ -85,6 +86,64 @@ export const ReportsView: React.FC = () => {
     };
 
     const COLORS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899'];
+
+    const statusBarOption: EChartsOption = {
+        color: ['#3B82F6'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: statusData.map(item => item.name) },
+        yAxis: { type: 'value' },
+        series: [{ name: 'Cantidad', type: 'bar', data: statusData.map(item => item.value), barMaxWidth: 44 }]
+    };
+
+    const statusPieOption: EChartsOption = {
+        color: COLORS,
+        tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+        series: [{
+            type: 'pie',
+            radius: ['42%', '70%'],
+            itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+            label: { formatter: '{b}: {c}' },
+            data: statusData.map(item => ({ name: item.name, value: item.value }))
+        }]
+    };
+
+    const gradeBarOption: EChartsOption = {
+        color: ['#10B981'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: gradeData.map(item => item.grade) },
+        yAxis: { type: 'value' },
+        series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 44 }]
+    };
+
+    const gradePieOption: EChartsOption = {
+        color: COLORS,
+        tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+        series: [{
+            type: 'pie',
+            radius: ['42%', '70%'],
+            itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+            label: { formatter: '{b}: {c}' },
+            data: gradeData.map(item => ({ name: item.grade, value: item.count }))
+        }]
+    };
+
+    const temporalOption: EChartsOption = {
+        color: ['#3B82F6', '#10B981', '#EF4444'],
+        tooltip: { trigger: 'axis' },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 24, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: temporalData.map(item => item.month) },
+        yAxis: { type: 'value' },
+        series: [
+            { name: 'Postulaciones', type: 'line', smooth: true, data: temporalData.map(item => item.applications) },
+            { name: 'Aprobadas', type: 'line', smooth: true, data: temporalData.map(item => item.approved) },
+            { name: 'Rechazadas', type: 'line', smooth: true, data: temporalData.map(item => item.rejected) }
+        ]
+    };
 
     if (loading) {
         return (
@@ -196,38 +255,11 @@ export const ReportsView: React.FC = () => {
                     <>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución por Estado (Barras)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <BarChart data={statusData}>
-                                    <CartesianGrid strokeDasharray="3 3" />
-                                    <XAxis dataKey="name" />
-                                    <YAxis />
-                                    <Tooltip />
-                                    <Legend />
-                                    <Bar dataKey="value" fill="#3B82F6" />
-                                </BarChart>
-                            </ResponsiveContainer>
+                            <EChart option={statusBarOption} height={300} />
                         </Card>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución por Estado (Pastel)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <PieChart>
-                                    <Pie
-                                        data={statusData}
-                                        cx="50%"
-                                        cy="50%"
-                                        labelLine={false}
-                                        label={(entry) => `${entry.name}: ${entry.value}`}
-                                        outerRadius={80}
-                                        fill="#8884d8"
-                                        dataKey="value"
-                                    >
-                                        {statusData.map((entry, index) => (
-                                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                        ))}
-                                    </Pie>
-                                    <Tooltip />
-                                </PieChart>
-                            </ResponsiveContainer>
+                            <EChart option={statusPieOption} height={300} />
                         </Card>
                     </>
                 )}
@@ -236,38 +268,11 @@ export const ReportsView: React.FC = () => {
                     <>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Postulaciones por Grado (Barras)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <BarChart data={gradeData}>
-                                    <CartesianGrid strokeDasharray="3 3" />
-                                    <XAxis dataKey="grade" />
-                                    <YAxis />
-                                    <Tooltip />
-                                    <Legend />
-                                    <Bar dataKey="count" fill="#10B981" />
-                                </BarChart>
-                            </ResponsiveContainer>
+                            <EChart option={gradeBarOption} height={300} />
                         </Card>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Postulaciones por Grado (Pastel)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <PieChart>
-                                    <Pie
-                                        data={gradeData}
-                                        cx="50%"
-                                        cy="50%"
-                                        labelLine={false}
-                                        label={(entry) => `${entry.grade}: ${entry.count}`}
-                                        outerRadius={80}
-                                        fill="#8884d8"
-                                        dataKey="count"
-                                    >
-                                        {gradeData.map((entry, index) => (
-                                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                        ))}
-                                    </Pie>
-                                    <Tooltip />
-                                </PieChart>
-                            </ResponsiveContainer>
+                            <EChart option={gradePieOption} height={300} />
                         </Card>
                     </>
                 )}
@@ -275,18 +280,7 @@ export const ReportsView: React.FC = () => {
                 {selectedReport === 'temporal' && (
                     <Card className="p-6 lg:col-span-2">
                         <h3 className="text-lg font-semibold text-gray-900 mb-4">Tendencias Temporales de Postulaciones</h3>
-                        <ResponsiveContainer width="100%" height={400}>
-                            <LineChart data={temporalData}>
-                                <CartesianGrid strokeDasharray="3 3" />
-                                <XAxis dataKey="month" />
-                                <YAxis />
-                                <Tooltip />
-                                <Legend />
-                                <Line type="monotone" dataKey="applications" stroke="#3B82F6" strokeWidth={2} name="Postulaciones" />
-                                <Line type="monotone" dataKey="approved" stroke="#10B981" strokeWidth={2} name="Aprobadas" />
-                                <Line type="monotone" dataKey="rejected" stroke="#EF4444" strokeWidth={2} name="Rechazadas" />
-                            </LineChart>
-                        </ResponsiveContainer>
+                        <EChart option={temporalOption} height={400} />
                     </Card>
                 )}
             </div>

--- a/microfrontends/apps/mf-admissions/components/charts/EChart.tsx
+++ b/microfrontends/apps/mf-admissions/components/charts/EChart.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactECharts from 'echarts-for-react';
+import type { EChartsOption } from 'echarts';
+
+interface EChartProps {
+  option: EChartsOption;
+  height?: number;
+  onEvents?: Record<string, (params: any) => void>;
+}
+
+const EChart: React.FC<EChartProps> = ({ option, height = 300, onEvents }) => (
+  <ReactECharts
+    option={option}
+    notMerge
+    lazyUpdate
+    onEvents={onEvents}
+    style={{ width: '100%', height }}
+  />
+);
+
+export default EChart;

--- a/microfrontends/apps/mf-admissions/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-admissions/components/interviews/InterviewForm.tsx
@@ -1080,7 +1080,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : (
                   <div className="p-4 bg-gray-50 border border-gray-200 rounded-md">
                     <p className="text-sm text-gray-600 text-center">
-                      👆 Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
+                      Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
                     </p>
                   </div>
                 )}

--- a/microfrontends/apps/mf-admissions/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-admissions/components/interviews/InterviewForm.tsx
@@ -133,21 +133,18 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
 
         console.log('Array de entrevistadores:', dataArray);
 
-        // El backend ya devuelve el formato correcto con firstName, lastName, role, scheduleCount
+        // El backend puede devolver array directo o envuelto, y nombres separados o name.
         const mappedInterviewers: BackendInterviewer[] = dataArray.map((item: any) => ({
-          id: item.id,
-          name: `${item.firstName} ${item.lastName}`,
-          role: item.role,
-          subject: item.subject,
+          id: Number(item.id),
+          name: item.name || `${item.firstName || ''} ${item.lastName || ''}`.trim() || item.email,
+          role: item.role || '',
+          subject: item.subject || '',
           educationalLevel: item.educationalLevel,
-          scheduleCount: item.scheduleCount || 0
-        }));
+          scheduleCount: Number(item.scheduleCount || 0)
+        })).filter((item) => item.id && item.name);
 
-        // Filtrar solo entrevistadores con horarios configurados
-        const interviewersWithSchedules = mappedInterviewers.filter(i => i.scheduleCount > 0);
-
-        console.log(`Entrevistadores con horarios: ${interviewersWithSchedules.length}/${mappedInterviewers.length}`);
-        setInterviewers(interviewersWithSchedules);
+        console.log(`Entrevistadores cargados: ${mappedInterviewers.length}`);
+        setInterviewers(mappedInterviewers);
       } catch (error: any) {
         console.error('Error cargando entrevistadores:', error);
 
@@ -263,7 +260,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
     // Validación de parámetros requeridos
     if (!formData.interviewerId || !formData.scheduledDate) {
       console.log('[loadAvailableTimeSlots] Faltan parámetros requeridos - abortando');
-      setAvailableTimeSlots(INTERVIEW_CONFIG.DEFAULT_TIME_SLOTS);
+      setAvailableTimeSlots([]);
       return;
     }
 
@@ -350,7 +347,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
 
       // Solo actualizar estado si no fue cancelada
       if (!currentController.signal.aborted) {
-        setAvailableTimeSlots(INTERVIEW_CONFIG.DEFAULT_TIME_SLOTS);
+        setAvailableTimeSlots([]);
       }
     } finally {
       // Solo limpiar loading state si esta es la llamada más reciente
@@ -936,9 +933,8 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                     <option
                       key={interviewer.id}
                       value={interviewer.id}
-                      disabled={interviewer.scheduleCount === 0}
                     >
-                      {interviewer.name} - {interviewer.role} {interviewer.scheduleCount === 0 ? '(Sin horarios)' : `(${interviewer.scheduleCount} horarios)`}
+                      {interviewer.name} - {interviewer.role} {interviewer.scheduleCount > 0 ? `(${interviewer.scheduleCount} horarios)` : ''}
                     </option>
                   ))
                 )}
@@ -969,7 +965,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : interviewersError ? (
                   <option disabled>{interviewersError}</option>
                 ) : interviewers.length === 0 ? (
-                  <option disabled>No hay entrevistadores con horarios configurados</option>
+                  <option disabled>No hay entrevistadores disponibles</option>
                 ) : (
                   (() => {
                     const filteredInterviewers = interviewers.filter(interviewer => {
@@ -988,9 +984,8 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                       <option
                         key={interviewer.id}
                         value={interviewer.id}
-                        disabled={interviewer.scheduleCount === 0}
                       >
-                        {interviewer.name} - {interviewer.role} {interviewer.scheduleCount === 0 ? '(Sin horarios)' : `(${interviewer.scheduleCount} horarios)`}
+                        {interviewer.name} - {interviewer.role} {interviewer.scheduleCount > 0 ? `(${interviewer.scheduleCount} horarios)` : ''}
                       </option>
                     ));
                   })()

--- a/microfrontends/apps/mf-admissions/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-admissions/components/interviews/InterviewForm.tsx
@@ -1080,7 +1080,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : (
                   <div className="p-4 bg-gray-50 border border-gray-200 rounded-md">
                     <p className="text-sm text-gray-600 text-center">
-                      Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
+                      👆 Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
                     </p>
                   </div>
                 )}

--- a/microfrontends/apps/mf-admissions/components/layout/Footer.tsx
+++ b/microfrontends/apps/mf-admissions/components/layout/Footer.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Facebook, Instagram, Linkedin } from 'lucide-react';
+import { microfrontendUrls } from '../../utils/microfrontendUrls';
 
 const Footer: React.FC = () => {
     const [showModal, setShowModal] = useState(false);
@@ -63,8 +64,9 @@ const Footer: React.FC = () => {
                         </div>
                     </div>
                 </div>
-                <div className="border-t border-blue-800 mt-10 pt-6 text-center text-sm text-gray-400">
+                <div className="border-t border-blue-800 mt-10 pt-6 flex flex-col sm:flex-row items-center justify-between gap-2 text-sm text-gray-400">
                     <p>&copy; {new Date().getFullYear()} Colegio Monte Tabor y Nazaret. Todos los derechos reservados.</p>
+                    <a href={microfrontendUrls.adminLogin} className="text-gray-400 hover:text-dorado-nazaret transition-colors text-xs underline underline-offset-2">Acceso personal MTN</a>
                 </div>
             </div>
             {/* Modal de contacto */}

--- a/microfrontends/apps/mf-admissions/components/layout/Header.tsx
+++ b/microfrontends/apps/mf-admissions/components/layout/Header.tsx
@@ -1,14 +1,12 @@
 
 import React, { useState, useEffect } from 'react';
-import { Link, useNavigate, useLocation } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import Button from '../ui/Button';
 import { microfrontendUrls } from '../../utils/microfrontendUrls';
 import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 const Header: React.FC = () => {
     const navigate = useNavigate();
-    const location = useLocation();
-    const isHomePage = location.pathname === '/';
     const [isAdmin, setIsAdmin] = useState(false);
     const [isProfessorLoggedIn, setIsProfessorLoggedIn] = useState(false);
     const [isAnyUserLoggedIn, setIsAnyUserLoggedIn] = useState(false);
@@ -125,19 +123,7 @@ const Header: React.FC = () => {
                 </nav>
 
                 <div className="flex items-center gap-2 sm:gap-4">
-                    {!isAnyUserLoggedIn && isHomePage && (
-                        <div className="hidden sm:flex items-center gap-3">
-                            <a href={microfrontendUrls.guardianLogin} className="text-gris-piedra hover:text-azul-monte-tabor font-semibold transition-colors duration-200">
-                                Iniciar sesión
-                            </a>
-                            <a href={microfrontendUrls.admissions}>
-                                <Button variant="primary" size="sm" className="!text-blanco-pureza">
-                                    Postular
-                                </Button>
-                            </a>
-                        </div>
-                    )}
-                    {!isAnyUserLoggedIn && !isHomePage && (
+                    {!isAnyUserLoggedIn && (
                         <a href={microfrontendUrls.admissions} className="hidden sm:block">
                             <Button variant="primary" size="sm">
                                 Iniciar Postulación
@@ -207,21 +193,7 @@ const Header: React.FC = () => {
                                 Admin
                             </a>
                         )}
-                        {!isAnyUserLoggedIn && isHomePage && (
-                            <div className="pt-2 pb-1 flex flex-col gap-2">
-                                <a href={microfrontendUrls.guardianLogin} onClick={() => setIsMobileMenuOpen(false)}>
-                                    <Button variant="outline" className="w-full">
-                                        Iniciar sesión
-                                    </Button>
-                                </a>
-                                <a href={microfrontendUrls.admissions} onClick={() => setIsMobileMenuOpen(false)}>
-                                    <Button variant="primary" className="w-full">
-                                        Iniciar Postulación
-                                    </Button>
-                                </a>
-                            </div>
-                        )}
-                        {!isAnyUserLoggedIn && !isHomePage && (
+                        {!isAnyUserLoggedIn && (
                             <div className="pt-2 pb-1">
                                 <a href={microfrontendUrls.admissions} onClick={() => setIsMobileMenuOpen(false)}>
                                     <Button variant="primary" className="w-full">

--- a/microfrontends/apps/mf-admissions/components/layout/Header.tsx
+++ b/microfrontends/apps/mf-admissions/components/layout/Header.tsx
@@ -1,12 +1,14 @@
 
 import React, { useState, useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import Button from '../ui/Button';
 import { microfrontendUrls } from '../../utils/microfrontendUrls';
 import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 const Header: React.FC = () => {
     const navigate = useNavigate();
+    const location = useLocation();
+    const isHomePage = location.pathname === '/';
     const [isAdmin, setIsAdmin] = useState(false);
     const [isProfessorLoggedIn, setIsProfessorLoggedIn] = useState(false);
     const [isAnyUserLoggedIn, setIsAnyUserLoggedIn] = useState(false);
@@ -123,7 +125,19 @@ const Header: React.FC = () => {
                 </nav>
 
                 <div className="flex items-center gap-2 sm:gap-4">
-                    {!isAnyUserLoggedIn && (
+                    {!isAnyUserLoggedIn && isHomePage && (
+                        <div className="hidden sm:flex items-center gap-3">
+                            <a href={microfrontendUrls.guardianLogin} className="text-gris-piedra hover:text-azul-monte-tabor font-semibold transition-colors duration-200">
+                                Iniciar sesión
+                            </a>
+                            <a href={microfrontendUrls.admissions}>
+                                <Button variant="primary" size="sm" className="!text-blanco-pureza">
+                                    Postular
+                                </Button>
+                            </a>
+                        </div>
+                    )}
+                    {!isAnyUserLoggedIn && !isHomePage && (
                         <a href={microfrontendUrls.admissions} className="hidden sm:block">
                             <Button variant="primary" size="sm">
                                 Iniciar Postulación
@@ -193,7 +207,21 @@ const Header: React.FC = () => {
                                 Admin
                             </a>
                         )}
-                        {!isAnyUserLoggedIn && (
+                        {!isAnyUserLoggedIn && isHomePage && (
+                            <div className="pt-2 pb-1 flex flex-col gap-2">
+                                <a href={microfrontendUrls.guardianLogin} onClick={() => setIsMobileMenuOpen(false)}>
+                                    <Button variant="outline" className="w-full">
+                                        Iniciar sesión
+                                    </Button>
+                                </a>
+                                <a href={microfrontendUrls.admissions} onClick={() => setIsMobileMenuOpen(false)}>
+                                    <Button variant="primary" className="w-full !text-blanco-pureza">
+                                        Postular
+                                    </Button>
+                                </a>
+                            </div>
+                        )}
+                        {!isAnyUserLoggedIn && !isHomePage && (
                             <div className="pt-2 pb-1">
                                 <a href={microfrontendUrls.admissions} onClick={() => setIsMobileMenuOpen(false)}>
                                     <Button variant="primary" className="w-full">

--- a/microfrontends/apps/mf-admissions/components/layout/Header.tsx
+++ b/microfrontends/apps/mf-admissions/components/layout/Header.tsx
@@ -1,12 +1,14 @@
 
 import React, { useState, useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import Button from '../ui/Button';
 import { microfrontendUrls } from '../../utils/microfrontendUrls';
 import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 const Header: React.FC = () => {
     const navigate = useNavigate();
+    const location = useLocation();
+    const isHomePage = location.pathname === '/';
     const [isAdmin, setIsAdmin] = useState(false);
     const [isProfessorLoggedIn, setIsProfessorLoggedIn] = useState(false);
     const [isAnyUserLoggedIn, setIsAnyUserLoggedIn] = useState(false);
@@ -123,7 +125,19 @@ const Header: React.FC = () => {
                 </nav>
 
                 <div className="flex items-center gap-2 sm:gap-4">
-                    {!isAnyUserLoggedIn && (
+                    {!isAnyUserLoggedIn && isHomePage && (
+                        <div className="hidden sm:flex items-center gap-3">
+                            <a href={microfrontendUrls.guardianLogin} className="text-gris-piedra hover:text-azul-monte-tabor font-semibold transition-colors duration-200">
+                                Iniciar sesión
+                            </a>
+                            <a href={microfrontendUrls.admissions}>
+                                <Button variant="primary" size="sm" className="!text-blanco-pureza">
+                                    Postular
+                                </Button>
+                            </a>
+                        </div>
+                    )}
+                    {!isAnyUserLoggedIn && !isHomePage && (
                         <a href={microfrontendUrls.admissions} className="hidden sm:block">
                             <Button variant="primary" size="sm">
                                 Iniciar Postulación
@@ -193,7 +207,21 @@ const Header: React.FC = () => {
                                 Admin
                             </a>
                         )}
-                        {!isAnyUserLoggedIn && (
+                        {!isAnyUserLoggedIn && isHomePage && (
+                            <div className="pt-2 pb-1 flex flex-col gap-2">
+                                <a href={microfrontendUrls.guardianLogin} onClick={() => setIsMobileMenuOpen(false)}>
+                                    <Button variant="outline" className="w-full">
+                                        Iniciar sesión
+                                    </Button>
+                                </a>
+                                <a href={microfrontendUrls.admissions} onClick={() => setIsMobileMenuOpen(false)}>
+                                    <Button variant="primary" className="w-full">
+                                        Iniciar Postulación
+                                    </Button>
+                                </a>
+                            </div>
+                        )}
+                        {!isAnyUserLoggedIn && !isHomePage && (
                             <div className="pt-2 pb-1">
                                 <a href={microfrontendUrls.admissions} onClick={() => setIsMobileMenuOpen(false)}>
                                     <Button variant="primary" className="w-full">

--- a/microfrontends/apps/mf-admissions/components/modals/CoordinatorDashboardModal.tsx
+++ b/microfrontends/apps/mf-admissions/components/modals/CoordinatorDashboardModal.tsx
@@ -7,7 +7,8 @@ import React, { useState, useEffect } from 'react';
 import { FiX, FiRefreshCw } from 'react-icons/fi';
 import { dashboardClient } from '../../src/api/dashboard.client';
 import type { DetailedAdminStats, Alert } from '../../src/api/dashboard.types';
-import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 
 interface CoordinatorDashboardModalProps {
   isOpen: boolean;
@@ -115,6 +116,32 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
   const acceptanceRate = stats && stats.totalApplications > 0
     ? ((stats.statusBreakdown.approved / stats.totalApplications) * 100).toFixed(1)
     : '0.0';
+
+  const statusChartOption: EChartsOption = {
+    color: statusData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [
+      {
+        type: 'pie',
+        radius: ['42%', '70%'],
+        center: ['50%', '50%'],
+        avoidLabelOverlap: true,
+        itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+        label: { formatter: '{b}: {d}%' },
+        data: statusData.map(item => ({ name: item.name, value: item.value }))
+      }
+    ]
+  };
+
+  const gradeChartOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: gradeData.map(item => item.grade), axisTick: { alignWithLabel: true } },
+    yAxis: { type: 'value' },
+    series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 42 }]
+  };
 
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
@@ -348,25 +375,7 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
                   {/* Status Distribution Pie Chart */}
                   <div className="bg-white border border-gray-200 shadow-sm rounded-lg p-6">
                     <h3 className="text-lg font-medium text-gray-900 mb-4">Distribución por Estado</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                      <PieChart>
-                        <Pie
-                          data={statusData}
-                          cx="50%"
-                          cy="50%"
-                          labelLine={false}
-                          label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
-                          outerRadius={80}
-                          fill="#8884d8"
-                          dataKey="value"
-                        >
-                          {statusData.map((entry, index) => (
-                            <Cell key={`cell-${index}`} fill={entry.color} />
-                          ))}
-                        </Pie>
-                        <Tooltip />
-                      </PieChart>
-                    </ResponsiveContainer>
+                    <EChart option={statusChartOption} height={300} />
                     <div className="mt-4 grid grid-cols-2 gap-2 text-sm">
                       {statusData.map((item, index) => (
                         <div key={index} className="flex items-center">
@@ -383,16 +392,7 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
                   {/* Grade Distribution Bar Chart */}
                   <div className="bg-white border border-gray-200 shadow-sm rounded-lg p-6">
                     <h3 className="text-lg font-medium text-gray-900 mb-4">Distribución por Nivel</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                      <BarChart data={gradeData}>
-                        <CartesianGrid strokeDasharray="3 3" />
-                        <XAxis dataKey="grade" />
-                        <YAxis />
-                        <Tooltip />
-                        <Legend />
-                        <Bar dataKey="count" fill="#3B82F6" name="Postulaciones" />
-                      </BarChart>
-                    </ResponsiveContainer>
+                    <EChart option={gradeChartOption} height={300} />
                   </div>
                 </div>
 

--- a/microfrontends/apps/mf-admissions/package.json
+++ b/microfrontends/apps/mf-admissions/package.json
@@ -14,6 +14,8 @@
     "axios": "^1.11.0",
     "axios-retry": "^4.5.0",
     "date-fns": "^4.1.0",
+    "echarts": "^6.0.0",
+    "echarts-for-react": "^3.0.6",
     "express": "^4.18.2",
     "firebase": "^12.12.1",
     "lucide-react": "^0.540.0",
@@ -23,7 +25,6 @@
     "react-dropzone": "^14.3.8",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.3",
-    "recharts": "^3.2.1",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {

--- a/microfrontends/apps/mf-admissions/pages/ApoderadoLogin.tsx
+++ b/microfrontends/apps/mf-admissions/pages/ApoderadoLogin.tsx
@@ -49,7 +49,7 @@ const ApoderadoLogin: React.FC = () => {
         }
 
         try {
-            await login(email, password, 'apoderado');
+            await login(email, password, 'APODERADO');
 
             // Verificar que el rol sea APODERADO
             const storedUser = JSON.parse(localStorage.getItem('authenticated_user') || 'null');
@@ -99,7 +99,7 @@ const ApoderadoLogin: React.FC = () => {
         }
 
         try {
-            await register(registerData, 'apoderado');
+            await register(registerData, 'APODERADO');
             // Para usuarios nuevos registrados, redirigir al formulario de postulación
             // no al dashboard directamente
             navigate('/postulacion');

--- a/microfrontends/apps/mf-admissions/pages/ApoderadoLogin.tsx
+++ b/microfrontends/apps/mf-admissions/pages/ApoderadoLogin.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
-import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import Input from '../components/ui/Input';
 import RutInput from '../components/ui/RutInput';
 import Button from '../components/ui/Button';
 import Card from '../components/ui/Card';
 import EmailVerification from '../components/ui/EmailVerification';
-import { LogoIcon } from '../components/icons/Icons';
 import { useAuth } from '../context/AuthContext';
 import { useNotifications } from '../context/AppContext';
+import { microfrontendUrls } from '../utils/microfrontendUrls';
 
 const ApoderadoLogin: React.FC = () => {
     const [email, setEmail] = useState('');
@@ -120,28 +120,27 @@ const ApoderadoLogin: React.FC = () => {
     };
 
     return (
-        <div className="min-h-screen bg-gray-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+        <div className="min-h-screen bg-white flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
             <div className="max-w-md w-full space-y-8">
-                {/* Header */}
-                <div className="text-center">
-                    <div className="flex justify-center mb-8">
-                        <LogoIcon className="w-32 h-32" />
-                    </div>
-                    <h2 className="text-2xl sm:text-3xl font-bold text-azul-monte-tabor">
-                        {showRegister ? 'Crear Cuenta para Postular' : 'Acceso de Apoderados'}
-                    </h2>
-                    <p className="mt-2 text-gris-piedra">
-                        {showRegister 
-                            ? 'Cree su cuenta para iniciar el proceso de postulación de su hijo/a'
-                            : 'Ingrese a su cuenta para continuar con la postulación o acceder a su dashboard'
-                        }
-                    </p>
-                </div>
-
                 <Card className="p-5 sm:p-8">
+                    <div className="text-center">
+                        <div className="flex justify-center mb-8">
+                            <img src="/images/logoMTN.png" alt="Logo Monte Tabor y Nazaret" className="h-24" />
+                        </div>
+                        <h2 className="text-3xl sm:text-4xl font-bold text-azul-monte-tabor">
+                            {showRegister ? 'Crear Cuenta' : 'Acceso de Apoderados'}
+                        </h2>
+                        <p className="mt-2 text-lg text-azul-monte-tabor font-light">
+                            {showRegister
+                                ? 'Para iniciar la postulación'
+                                : 'Ingrese a su cuenta para postular'
+                            }
+                        </p>
+                    </div>
+
                     {!showRegister ? (
                         // Formulario de Login
-                        <form onSubmit={handleLogin} className="space-y-6">
+                        <form onSubmit={handleLogin} className="space-y-6 mt-8">
                             {error && (
                                 <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">
                                     {error}
@@ -292,22 +291,19 @@ const ApoderadoLogin: React.FC = () => {
                         </form>
                     )}
 
-                    <div className="mt-6 pt-6 border-t border-gray-200">
-                        <div className="text-center">
-                            <Link 
-                                to="/" 
-                                className="text-azul-monte-tabor hover:underline"
-                            >
-                                ← Volver al inicio
-                            </Link>
-                        </div>
+                    <div className="text-center pt-6 border-t border-gray-200">
+                        <a
+                            href={microfrontendUrls.home}
+                            className="text-azul-monte-tabor hover:underline text-sm font-semibold"
+                        >
+                            ← Volver al inicio
+                        </a>
                     </div>
                 </Card>
 
                 {/* Información adicional */}
                 <div className="text-center text-sm text-gris-piedra">
-                    <p>¿Problemas para acceder?</p>
-                    <p>Contacte a admisiones: <a href="mailto:admisiones@mtn.cl" className="text-azul-monte-tabor hover:underline">admisiones@mtn.cl</a></p>
+                    <p>¿Problemas para acceder? <a href="mailto:admisiones@mtn.cl" className="text-azul-monte-tabor hover:underline font-semibold">admisiones@mtn.cl</a></p>
                 </div>
             </div>
         </div>

--- a/microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx
+++ b/microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx
@@ -191,7 +191,7 @@ const ApplicationForm: React.FC = () => {
 
         try {
             console.log('ApplicationForm - handleLogin: Calling login with:', authData.email);
-            await login(authData.email, authData.password, 'apoderado');
+            await login(authData.email, authData.password, 'APODERADO');
             console.log('ApplicationForm - handleLogin: Login successful, hiding auth form');
             setShowAuthForm(false);
 
@@ -243,7 +243,7 @@ const ApplicationForm: React.FC = () => {
         try {
             // Registrar usuario con información básica
             console.log('ApplicationForm - handleRegister: Calling register with:', authData.email);
-            await register(authData, 'apoderado');
+            await register(authData, 'APODERADO');
             console.log('ApplicationForm - handleRegister: Registration successful, hiding auth form');
             setShowAuthForm(false);
 

--- a/microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx
+++ b/microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx
@@ -84,7 +84,7 @@ const ApplicationForm: React.FC = () => {
     const [isVerifying, setIsVerifying] = useState(false);
     const [verificationCode, setVerificationCode] = useState('');
     const [verificationError, setVerificationError] = useState('');
-    const [showAuthForm, setShowAuthForm] = useState(true);
+    const [showAuthForm, setShowAuthForm] = useState(false); // TEMP: Deshabilitado para desarrollo
     const [showRegister, setShowRegister] = useState(false);
     const [authLoading, setAuthLoading] = useState(false);
     const [authError, setAuthError] = useState('');
@@ -2330,7 +2330,8 @@ const ApplicationForm: React.FC = () => {
     };
 
     // Si no está autenticado, mostrar formulario de autenticación
-    if (showAuthForm || !isAuthenticated) {
+    // TEMP: Deshabilitado !isAuthenticated para desarrollo - permitir acceso directo
+    if (showAuthForm) {
         return renderAuthForm();
     }
 
@@ -2345,10 +2346,12 @@ const ApplicationForm: React.FC = () => {
                     </div>
                     <div className="text-right">
                         <p className="text-sm text-gris-piedra">Apoderado:</p>
-                        <p className="font-semibold text-azul-monte-tabor">{user?.firstName} {user?.lastName}</p>
-                        <Link to="/dashboard-apoderado" className="text-sm text-azul-monte-tabor hover:underline">
-                            Ver mi dashboard →
-                        </Link>
+                        <p className="font-semibold text-azul-monte-tabor">{user?.firstName || 'Usuario Prueba'} {user?.lastName || 'Development'}</p>
+                        {user && (
+                            <Link to="/dashboard-apoderado" className="text-sm text-azul-monte-tabor hover:underline">
+                                Ver mi dashboard →
+                            </Link>
+                        )}
                     </div>
                 </div>
 

--- a/microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx
+++ b/microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx
@@ -17,12 +17,15 @@ import { documentService, DOCUMENT_TYPES } from '../services/documentService';
 import profileService from '../services/profileService';
 
 const steps = [
-  "Datos del Postulante",
-  "Datos de los Padres",
-  "Sostenedor",
-  "Apoderado",
-  "Documentación",
-  "Confirmación"
+  "Información del Postulante",    // 0 - Nombre, RUT, Fecha de Nacimiento, Email
+  "Lugar de Residencia",           // 1 - Dirección, Comuna, Ciudad
+  "Postulación",                   // 2 - Grado, Colegio, Preferencia
+  "Datos del Padre",               // 3
+  "Datos de la Madre",             // 4
+  "Sostenedor",                    // 5
+  "Apoderado",                     // 6
+  "Documentación",                 // 7
+  "Confirmación"                   // 8
 ];
 
 const gradeOptions = educationalLevels.map(level => ({
@@ -678,124 +681,109 @@ const ApplicationForm: React.FC = () => {
     }, [data.parent1Name, data.parent1Email, data.parent1Phone, data.parent1Rut, data.parent2Name, data.parent2Email, data.parent2Phone, data.parent2Rut, updateField]);
 
     const validateCurrentStep = useCallback((): boolean => {
-        // Email validation helper
         const isValidEmail = (email: string): boolean => {
             const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
             return emailRegex.test(email);
         };
 
-        // Phone validation helper
         const isValidPhone = (phone: string): boolean => {
             const phoneRegex = /^[+]?[\d\s-]{8,}$/;
             return phoneRegex.test(phone);
         };
 
-        // Validation by step
         switch (currentStep) {
+            // Step 0: Información del Postulante
             case 0:
-                console.log('Validating Step 0 with data:', data);
-
-                // Validate postulant data
                 if (!data.firstName?.trim() || !data.paternalLastName?.trim() || !data.maternalLastName?.trim() ||
-                    !data.rut?.trim() || !data.birthDate || !data.grade || !data.schoolApplied ||
-                    !data.studentAddressStreet?.trim() || !data.studentAddressNumber?.trim() || !data.studentAddressCommune?.trim() ||
-                    !data.admissionPreference) {
-                    console.log('Basic fields validation failed');
-                    console.log('firstName:', data.firstName);
-                    console.log('paternalLastName:', data.paternalLastName);
-                    console.log('maternalLastName:', data.maternalLastName);
-                    console.log('rut:', data.rut);
-                    console.log('birthDate:', data.birthDate);
-                    console.log('grade:', data.grade);
-                    console.log('schoolApplied:', data.schoolApplied);
-                    console.log('studentAddressStreet:', data.studentAddressStreet);
-                    console.log('studentAddressNumber:', data.studentAddressNumber);
-                    console.log('studentAddressCommune:', data.studentAddressCommune);
-                    console.log('admissionPreference:', data.admissionPreference);
+                    !data.rut?.trim() || !data.birthDate) {
                     return false;
                 }
-
-                // Validate location fields
-                const pais = data.pais || 'Chile';
-                if (pais === 'Chile') {
-                    if (!data.region?.trim() || !data.comuna?.trim()) {
-                        console.log('Location validation failed - region:', data.region, 'comuna:', data.comuna);
+                // Validate birth date coherence with grade
+                if (data.grade) {
+                    const birthDateValidation = validateBirthDateForGrade(data.birthDate, data.grade);
+                    if (!birthDateValidation.valid) {
                         return false;
                     }
                 }
-
-                // Validate application year (must be current year + 1)
-                const currentYear = new Date().getFullYear();
-                const applicationYear = parseInt(data.applicationYear);
-                if (!data.applicationYear || applicationYear !== currentYear + 1) {
-                    console.log('Application year validation failed - expected:', currentYear + 1, 'got:', applicationYear);
-                    return false;
-                }
-
-                // Validate birth date coherence with grade
-                const birthDateValidation = validateBirthDateForGrade(data.birthDate, data.grade);
-                if (!birthDateValidation.valid) {
-                    console.log('Birth date validation failed:', birthDateValidation.message);
-                    return false;
-                }
-
-                // Check for school if required
-                if (requiresCurrentSchool(data.grade || '') && !data.currentSchool?.trim()) {
-                    console.log('Current school validation failed - currentSchool:', data.currentSchool);
-                    return false;
-                }
-
                 // Validate optional email if provided
                 if (data.studentEmail && !isValidEmail(data.studentEmail)) {
-                    console.log('Email validation failed:', data.studentEmail);
                     return false;
                 }
-
-                console.log('Step 0 validation passed!');
                 return true;
-                
+
+            // Step 1: Lugar de Residencia
             case 1:
-                // Validate both parents data
+                if (!data.studentAddressStreet?.trim() || !data.studentAddressNumber?.trim() || !data.studentAddressCommune?.trim()) {
+                    return false;
+                }
+                const pais = data.pais || 'Chile';
+                if (pais === 'Chile' && !data.region?.trim()) {
+                    return false;
+                }
+                return true;
+
+            // Step 2: Postulación
+            case 2:
+                if (!data.grade || !data.schoolApplied || !data.applicationYear || !data.admissionPreference) {
+                    return false;
+                }
+                if (requiresCurrentSchool(data.grade || '') && !data.currentSchool?.trim()) {
+                    return false;
+                }
+                return true;
+
+            // Step 3: Datos del Padre
+            case 3:
                 if (!data.parent1Name?.trim() || !data.parent1Email?.trim() || !data.parent1Phone?.trim() ||
-                    !data.parent1Rut?.trim() || !data.parent1Address?.trim() || !data.parent1Profession?.trim() ||
-                    !data.parent2Name?.trim() || !data.parent2Email?.trim() || !data.parent2Phone?.trim() ||
+                    !data.parent1Rut?.trim() || !data.parent1Address?.trim() || !data.parent1Profession?.trim()) {
+                    return false;
+                }
+                if (!isValidEmail(data.parent1Email || '') || !isValidPhone(data.parent1Phone || '')) {
+                    return false;
+                }
+                return true;
+
+            // Step 4: Datos de la Madre
+            case 4:
+                if (!data.parent2Name?.trim() || !data.parent2Email?.trim() || !data.parent2Phone?.trim() ||
                     !data.parent2Rut?.trim() || !data.parent2Address?.trim() || !data.parent2Profession?.trim()) {
                     return false;
                 }
-                // Validate email formats
-                if (!isValidEmail(data.parent1Email || '') || !isValidEmail(data.parent2Email || '')) {
-                    return false;
-                }
-                // Validate phone formats
-                if (!isValidPhone(data.parent1Phone || '') || !isValidPhone(data.parent2Phone || '')) {
+                if (!isValidEmail(data.parent2Email || '') || !isValidPhone(data.parent2Phone || '')) {
                     return false;
                 }
                 return true;
-                
-            case 2:
-                // Validate supporter data
+
+            // Step 5: Sostenedor
+            case 5:
                 if (!data.supporterName?.trim() || !data.supporterEmail?.trim() || !data.supporterPhone?.trim() ||
                     !data.supporterRut?.trim() || !data.supporterRelation) {
                     return false;
                 }
-                // Validate email and phone formats
                 if (!isValidEmail(data.supporterEmail || '') || !isValidPhone(data.supporterPhone || '')) {
                     return false;
                 }
                 return true;
-                
-            case 3:
-                // Validate guardian data
+
+            // Step 6: Apoderado
+            case 6:
                 if (!data.guardianName?.trim() || !data.guardianEmail?.trim() || !data.guardianPhone?.trim() ||
                     !data.guardianRut?.trim() || !data.guardianRelation) {
                     return false;
                 }
-                // Validate email and phone formats
                 if (!isValidEmail(data.guardianEmail || '') || !isValidPhone(data.guardianPhone || '')) {
                     return false;
                 }
                 return true;
-                
+
+            // Step 7: Documentación (opcional)
+            case 7:
+                return true;
+
+            // Step 8: Confirmación
+            case 8:
+                return true;
+
             default:
                 return true;
         }
@@ -815,16 +803,10 @@ const ApplicationForm: React.FC = () => {
 
     const nextStep = async () => {
         if (validateCurrentStep()) {
-            // When adding another child, skip steps 1, 2, 3 (family data)
-            // Jump from step 0 (student data) directly to step 4 (documents)
             let nextStepIndex = currentStep + 1;
-            if (isAddingAnotherChild && currentStep === 0) {
-                nextStepIndex = 4; // Skip to documents step
-                console.log('Adding another child - skipping family data steps (1,2,3), going directly to step 4 (documents)');
-            }
 
-            // Si es el último paso (documentos), enviar la postulación
-            if (currentStep === 4) {
+            // Si es el paso de documentación (step 7), enviar la postulación
+            if (currentStep === 7) {
                 setIsSubmitting(true);
                 try {
                     // Determinar si estamos en modo edición o creación
@@ -1093,65 +1075,85 @@ const ApplicationForm: React.FC = () => {
     // Helper function to get missing fields for current step
     const getMissingFields = useMemo((): string[] => {
         const missing: string[] = [];
-        
+
         switch (currentStep) {
+            // Step 0: Información del Postulante
             case 0:
                 if (!data.firstName?.trim()) missing.push('Nombres');
                 if (!data.paternalLastName?.trim()) missing.push('Apellido Paterno');
                 if (!data.maternalLastName?.trim()) missing.push('Apellido Materno');
                 if (!data.rut?.trim()) missing.push('RUT');
                 if (!data.birthDate) missing.push('Fecha de Nacimiento');
-                if (!data.grade) missing.push('Nivel al que postula');
-                if (!data.schoolApplied) missing.push('Colegio');
-                if (!data.admissionPreference) missing.push('Preferencia de Admisión');
-                if (!data.studentAddress?.trim()) missing.push('Dirección');
-
-                // Validate location fields
-                const paisValidation = data.pais || 'Chile';
-                if (paisValidation === 'Chile') {
-                    if (!data.region?.trim()) missing.push('Región');
-                    if (!data.comuna?.trim()) missing.push('Comuna');
-                }
-
-                // Validate application year
-                const currentYear = new Date().getFullYear();
-                const applicationYear = parseInt(data.applicationYear);
-                if (!data.applicationYear || applicationYear !== currentYear + 1) {
-                    missing.push('Año al que postula');
-                }
-
-                if (requiresCurrentSchool(data.grade || '') && !data.currentSchool?.trim()) missing.push('Colegio de Procedencia');
                 break;
+
+            // Step 1: Lugar de Residencia
             case 1:
-                if (!data.parent1Name?.trim()) missing.push('Nombre del Tutor 1');
-                if (!data.parent1Email?.trim()) missing.push('Email del Tutor 1');
-                if (!data.parent1Phone?.trim()) missing.push('Teléfono del Tutor 1');
-                if (!data.parent1Rut?.trim()) missing.push('RUT del Tutor 1');
-                if (!data.parent1Address?.trim()) missing.push('Dirección del Tutor 1');
-                if (!data.parent1Profession?.trim()) missing.push('Profesión del Tutor 1');
-                if (!data.parent2Name?.trim()) missing.push('Nombre del Tutor 2');
-                if (!data.parent2Email?.trim()) missing.push('Email del Tutor 2');
-                if (!data.parent2Phone?.trim()) missing.push('Teléfono del Tutor 2');
-                if (!data.parent2Rut?.trim()) missing.push('RUT del Tutor 2');
-                if (!data.parent2Address?.trim()) missing.push('Dirección del Tutor 2');
-                if (!data.parent2Profession?.trim()) missing.push('Profesión del Tutor 2');
+                if (!data.studentAddressStreet?.trim()) missing.push('Calle');
+                if (!data.studentAddressNumber?.trim()) missing.push('Número');
+                if (!data.studentAddressCommune?.trim()) missing.push('Comuna');
+                if (!data.pais && !data.pais) missing.push('País');
+                const pais = data.pais || 'Chile';
+                if (pais === 'Chile' && !data.region?.trim()) missing.push('Región');
                 break;
+
+            // Step 2: Postulación
             case 2:
-                if (!data.supporterRelation) missing.push('Parentesco del Sostenedor');
-                if (!data.supporterName?.trim()) missing.push('Nombre del Sostenedor');
-                if (!data.supporterEmail?.trim()) missing.push('Email del Sostenedor');
-                if (!data.supporterPhone?.trim()) missing.push('Teléfono del Sostenedor');
-                if (!data.supporterRut?.trim()) missing.push('RUT del Sostenedor');
+                if (!data.grade) missing.push('Nivel al que postula');
+                if (requiresCurrentSchool(data.grade || '') && !data.currentSchool?.trim()) missing.push('Colegio de Procedencia');
+                if (!data.schoolApplied) missing.push('Colegio al que postula');
+                if (!data.applicationYear) missing.push('Año al que postula');
+                if (!data.admissionPreference) missing.push('Tipo de Relación Familiar');
                 break;
+
+            // Step 3: Datos del Padre
             case 3:
-                if (!data.guardianRelation) missing.push('Parentesco del Apoderado');
-                if (!data.guardianName?.trim()) missing.push('Nombre del Apoderado');
-                if (!data.guardianEmail?.trim()) missing.push('Email del Apoderado');
-                if (!data.guardianPhone?.trim()) missing.push('Teléfono del Apoderado');
-                if (!data.guardianRut?.trim()) missing.push('RUT del Apoderado');
+                if (!data.parent1Name?.trim()) missing.push('Nombre');
+                if (!data.parent1Rut?.trim()) missing.push('RUT');
+                if (!data.parent1Email?.trim()) missing.push('Email');
+                if (!data.parent1Phone?.trim()) missing.push('Teléfono');
+                if (!data.parent1Address?.trim()) missing.push('Dirección');
+                if (!data.parent1Profession?.trim()) missing.push('Profesión');
+                break;
+
+            // Step 4: Datos de la Madre
+            case 4:
+                if (!data.parent2Name?.trim()) missing.push('Nombre');
+                if (!data.parent2Rut?.trim()) missing.push('RUT');
+                if (!data.parent2Email?.trim()) missing.push('Email');
+                if (!data.parent2Phone?.trim()) missing.push('Teléfono');
+                if (!data.parent2Address?.trim()) missing.push('Dirección');
+                if (!data.parent2Profession?.trim()) missing.push('Profesión');
+                break;
+
+            // Step 5: Sostenedor
+            case 5:
+                if (!data.supporterRelation) missing.push('Parentesco');
+                if (!data.supporterName?.trim()) missing.push('Nombre');
+                if (!data.supporterEmail?.trim()) missing.push('Email');
+                if (!data.supporterPhone?.trim()) missing.push('Teléfono');
+                if (!data.supporterRut?.trim()) missing.push('RUT');
+                break;
+
+            // Step 6: Apoderado
+            case 6:
+                if (!data.guardianRelation) missing.push('Parentesco');
+                if (!data.guardianName?.trim()) missing.push('Nombre');
+                if (!data.guardianEmail?.trim()) missing.push('Email');
+                if (!data.guardianPhone?.trim()) missing.push('Teléfono');
+                if (!data.guardianRut?.trim()) missing.push('RUT');
+                break;
+
+            // Step 7: Documentación (opcional)
+            case 7:
+                // No validation needed - documents are optional
+                break;
+
+            // Step 8: Confirmación (solo muestra info)
+            case 8:
+                // No validation needed
                 break;
         }
-        
+
         return missing;
     }, [data, currentStep, requiresCurrentSchool]);
 
@@ -1436,36 +1438,37 @@ const ApplicationForm: React.FC = () => {
 
     const renderStepContent = () => {
         switch (currentStep) {
+            // Step 0: Información del Postulante
             case 0:
                 return (
                     <div className="space-y-4">
                         <h3 className="text-xl font-bold text-azul-monte-tabor">Información del Postulante</h3>
                         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                            <Input 
-                                id="firstName" 
-                                label="Nombres" 
-                                placeholder="Juan Carlos" 
-                                isRequired 
+                            <Input
+                                id="firstName"
+                                label="Nombres"
+                                placeholder="Juan Carlos"
+                                isRequired
                                 value={data.firstName || ''}
                                 onChange={(e) => updateField('firstName', e.target.value)}
                                 onBlur={() => touchField('firstName')}
                                 error={errors.firstName}
                             />
-                            <Input 
-                                id="paternalLastName" 
-                                label="Apellido Paterno" 
-                                placeholder="Pérez" 
-                                isRequired 
+                            <Input
+                                id="paternalLastName"
+                                label="Apellido Paterno"
+                                placeholder="Pérez"
+                                isRequired
                                 value={data.paternalLastName || ''}
                                 onChange={(e) => updateField('paternalLastName', e.target.value)}
                                 onBlur={() => touchField('paternalLastName')}
                                 error={errors.paternalLastName}
                             />
-                            <Input 
-                                id="maternalLastName" 
-                                label="Apellido Materno" 
-                                placeholder="González" 
-                                isRequired 
+                            <Input
+                                id="maternalLastName"
+                                label="Apellido Materno"
+                                placeholder="González"
+                                isRequired
                                 value={data.maternalLastName || ''}
                                 onChange={(e) => updateField('maternalLastName', e.target.value)}
                                 onBlur={() => touchField('maternalLastName')}
@@ -1517,6 +1520,14 @@ const ApplicationForm: React.FC = () => {
                             onBlur={() => touchField('studentEmail')}
                             error={errors.studentEmail}
                         />
+                    </div>
+                );
+
+            // Step 1: Lugar de Residencia
+            case 1:
+                return (
+                    <div className="space-y-4">
+                        <h3 className="text-xl font-bold text-azul-monte-tabor">Lugar de Residencia</h3>
 
                         {/* Dirección segmentada */}
                         <div className="space-y-4">
@@ -1530,7 +1541,6 @@ const ApplicationForm: React.FC = () => {
                                     value={data.studentAddressStreet || ''}
                                     onChange={(e) => {
                                         updateField('studentAddressStreet', e.target.value);
-                                        // Update combined address
                                         const combined = `${e.target.value || ''} ${data.studentAddressNumber || ''}, ${data.studentAddressCommune || ''}, ${data.studentAddressApartment || ''}`.trim();
                                         updateField('studentAddress', combined);
                                     }}
@@ -1544,7 +1554,6 @@ const ApplicationForm: React.FC = () => {
                                     value={data.studentAddressNumber || ''}
                                     onChange={(e) => {
                                         updateField('studentAddressNumber', e.target.value);
-                                        // Update combined address
                                         const combined = `${data.studentAddressStreet || ''} ${e.target.value || ''}, ${data.studentAddressCommune || ''}, ${data.studentAddressApartment || ''}`.trim();
                                         updateField('studentAddress', combined);
                                     }}
@@ -1558,9 +1567,7 @@ const ApplicationForm: React.FC = () => {
                                     value={data.studentAddressCommune || ''}
                                     onChange={(e) => {
                                         updateField('studentAddressCommune', e.target.value);
-                                        // Also update the comuna field for geographic location (synchronize)
                                         updateField('comuna', e.target.value);
-                                        // Update combined address
                                         const combined = `${data.studentAddressStreet || ''} ${data.studentAddressNumber || ''}, ${e.target.value || ''}, ${data.studentAddressApartment || ''}`.trim();
                                         updateField('studentAddress', combined);
                                     }}
@@ -1574,7 +1581,6 @@ const ApplicationForm: React.FC = () => {
                                 value={data.studentAddressApartment || ''}
                                 onChange={(e) => {
                                     updateField('studentAddressApartment', e.target.value);
-                                    // Update combined address
                                     const combined = `${data.studentAddressStreet || ''} ${data.studentAddressNumber || ''}, ${data.studentAddressCommune || ''}, ${e.target.value || ''}`.trim();
                                     updateField('studentAddress', combined);
                                 }}
@@ -1600,7 +1606,6 @@ const ApplicationForm: React.FC = () => {
                                 value={data.pais || 'Chile'}
                                 onChange={(e) => {
                                     updateField('pais', e.target.value);
-                                    // Clear region if not Chile (comuna is handled via address field)
                                     if (e.target.value !== 'Chile') {
                                         updateField('region', '');
                                     }
@@ -1609,7 +1614,6 @@ const ApplicationForm: React.FC = () => {
                                 error={errors.pais}
                             />
 
-                            {/* Conditional fields for Chile */}
                             {(data.pais === 'Chile' || !data.pais) && (
                                 <>
                                     <Select
@@ -1644,7 +1648,6 @@ const ApplicationForm: React.FC = () => {
                                 </>
                             )}
 
-                            {/* Information message for non-Chilean countries */}
                             {data.pais && data.pais !== 'Chile' && (
                                 <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg">
                                     <p className="text-sm text-blue-800">
@@ -1653,6 +1656,14 @@ const ApplicationForm: React.FC = () => {
                                 </div>
                             )}
                         </div>
+                    </div>
+                );
+
+            // Step 2: Postulación
+            case 2:
+                return (
+                    <div className="space-y-4">
+                        <h3 className="text-xl font-bold text-azul-monte-tabor">Postulación</h3>
 
                         <Select
                             id="grade"
@@ -1665,7 +1676,6 @@ const ApplicationForm: React.FC = () => {
                             error={errors.grade}
                         />
 
-                        {/* Campo condicional para Colegio de Procedencia - MOVIDO DESPUÉS DEL NIVEL */}
                         {requiresCurrentSchool(data.grade || '') && (
                             <Input
                                 id="currentSchool"
@@ -1679,7 +1689,6 @@ const ApplicationForm: React.FC = () => {
                             />
                         )}
 
-                        {/* Mensaje informativo para niveles que no requieren colegio anterior */}
                         {!requiresCurrentSchool(data.grade || '') && data.grade && (
                             <div className="p-4 bg-blue-50 rounded-lg">
                                 <p className="text-sm text-blue-800">
@@ -1701,7 +1710,7 @@ const ApplicationForm: React.FC = () => {
                             onBlur={() => touchField('schoolApplied')}
                             error={errors.schoolApplied}
                         />
-                        
+
                         <Input
                             id="applicationYear"
                             label="Año al que postula"
@@ -1723,7 +1732,6 @@ const ApplicationForm: React.FC = () => {
                             helpText={`Las postulaciones son siempre para el año ${new Date().getFullYear() + 1}`}
                         />
 
-                        {/* Tipo de Relación Familiar / Preferencia de Admisión */}
                         <div className="space-y-3">
                             <label className="block text-sm font-medium text-gray-700">
                                 Tipo de Relación Familiar <span className="text-red-500">*</span>
@@ -1779,7 +1787,6 @@ const ApplicationForm: React.FC = () => {
                             )}
                         </div>
 
-                        {/* Información adicional según preferencia seleccionada */}
                         {data.admissionPreference === 'HIJO_EX_ALUMNO' && (
                             <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg">
                                 <p className="text-sm text-blue-800">
@@ -1796,7 +1803,6 @@ const ApplicationForm: React.FC = () => {
                             </div>
                         )}
 
-                        {/* Campo de observaciones adicionales */}
                         <div className="mt-4">
                             <label htmlFor="additionalNotes" className="block text-sm font-medium text-gray-700 mb-2">
                                 Observaciones Adicionales (Opcional)
@@ -1815,177 +1821,183 @@ const ApplicationForm: React.FC = () => {
                         </div>
                     </div>
                 );
-            case 1:
+
+            // Step 3: Datos del Padre
+            case 3:
                 return (
-                    <div className="space-y-6">
-                        <div>
-                            <h3 className="text-xl font-bold text-azul-monte-tabor mb-4">Información del Tutor 1</h3>
-                            {isLoadingProfile && (
-                                <div className="mb-4 p-3 bg-blue-50 rounded-lg">
-                                    <p className="text-sm text-azul-monte-tabor">
-                                        Cargando datos del perfil para completar automáticamente...
-                                    </p>
-                                </div>
-                            )}
-                            {!isLoadingProfile && userProfile && (
-                                <div className="mb-4 p-3 bg-green-50 rounded-lg">
-                                    <p className="text-sm text-green-800">
-                                        Datos completados automáticamente desde su perfil. Puede editarlos si es necesario.
-                                    </p>
-                                </div>
-                            )}
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <Input 
-                                    id="parent1-name" 
-                                    label="Nombre Completo" 
-                                    placeholder="María Elena González"
-                                    isRequired 
-                                    value={data.parent1Name || ''}
-                                    onChange={(e) => updateField('parent1Name', e.target.value)}
-                                    onBlur={() => touchField('parent1Name')}
-                                    error={errors.parent1Name}
-                                />
-                                <RutInput 
-                                    name="parent1-rut" 
-                                    label="RUT" 
-                                    placeholder="16.789.123-4"
-                                    required 
-                                    value={data.parent1Rut || ''}
-                                    onChange={(value) => updateField('parent1Rut', value)}
-                                    onBlur={() => touchField('parent1Rut')}
-                                    error={errors.parent1Rut}
-                                />
-                                <Input 
-                                    id="parent1-email" 
-                                    label="Email" 
-                                    type="email" 
-                                    placeholder="maria.gonzalez@ejemplo.com"
-                                    isRequired 
-                                    value={data.parent1Email || ''}
-                                    onChange={(e) => updateField('parent1Email', e.target.value)}
-                                    onBlur={() => touchField('parent1Email')}
-                                    error={errors.parent1Email}
-                                />
-                                <Input 
-                                    id="parent1-phone" 
-                                    label="Teléfono" 
-                                    type="tel" 
-                                    isRequired 
-                                    placeholder="+569 1234 5678"
-                                    value={data.parent1Phone || ''}
-                                    onChange={(e) => updateField('parent1Phone', e.target.value)}
-                                    onBlur={() => touchField('parent1Phone')}
-                                    error={errors.parent1Phone}
-                                />
+                    <div className="space-y-4">
+                        <h3 className="text-xl font-bold text-azul-monte-tabor mb-4">Datos del Padre</h3>
+                        {isLoadingProfile && (
+                            <div className="mb-4 p-3 bg-blue-50 rounded-lg">
+                                <p className="text-sm text-azul-monte-tabor">
+                                    Cargando datos del perfil para completar automáticamente...
+                                </p>
                             </div>
-                            <div className="mt-4">
-                                <Input 
-                                    id="parent1-address" 
-                                    label="Dirección" 
-                                    placeholder="Los Leones 456, Providencia, Santiago"
-                                    isRequired 
-                                    value={data.parent1Address || ''}
-                                    onChange={(e) => updateField('parent1Address', e.target.value)}
-                                    onBlur={() => touchField('parent1Address')}
-                                    error={errors.parent1Address}
-                                />
+                        )}
+                        {!isLoadingProfile && userProfile && (
+                            <div className="mb-4 p-3 bg-green-50 rounded-lg">
+                                <p className="text-sm text-green-800">
+                                    Datos completados automáticamente desde su perfil. Puede editarlos si es necesario.
+                                </p>
                             </div>
-                            <div className="mt-4">
-                                <Input 
-                                    id="parent1-profession" 
-                                    label="Profesión" 
-                                    placeholder="Ingeniero Comercial"
-                                    isRequired 
-                                    value={data.parent1Profession || ''}
-                                    onChange={(e) => updateField('parent1Profession', e.target.value)}
-                                    onBlur={() => touchField('parent1Profession')}
-                                    error={errors.parent1Profession}
-                                />
-                            </div>
+                        )}
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <Input
+                                id="parent1-name"
+                                label="Nombre Completo"
+                                placeholder="María Elena González"
+                                isRequired
+                                value={data.parent1Name || ''}
+                                onChange={(e) => updateField('parent1Name', e.target.value)}
+                                onBlur={() => touchField('parent1Name')}
+                                error={errors.parent1Name}
+                            />
+                            <RutInput
+                                name="parent1-rut"
+                                label="RUT"
+                                placeholder="16.789.123-4"
+                                required
+                                value={data.parent1Rut || ''}
+                                onChange={(value) => updateField('parent1Rut', value)}
+                                onBlur={() => touchField('parent1Rut')}
+                                error={errors.parent1Rut}
+                            />
+                            <Input
+                                id="parent1-email"
+                                label="Email"
+                                type="email"
+                                placeholder="maria.gonzalez@ejemplo.com"
+                                isRequired
+                                value={data.parent1Email || ''}
+                                onChange={(e) => updateField('parent1Email', e.target.value)}
+                                onBlur={() => touchField('parent1Email')}
+                                error={errors.parent1Email}
+                            />
+                            <Input
+                                id="parent1-phone"
+                                label="Teléfono"
+                                type="tel"
+                                isRequired
+                                placeholder="+569 1234 5678"
+                                value={data.parent1Phone || ''}
+                                onChange={(e) => updateField('parent1Phone', e.target.value)}
+                                onBlur={() => touchField('parent1Phone')}
+                                error={errors.parent1Phone}
+                            />
                         </div>
-                         <div>
-                            <h3 className="text-xl font-bold text-azul-monte-tabor mb-4">Información del Tutor 2</h3>
-                             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <Input 
-                                    id="parent2-name" 
-                                    label="Nombre Completo"
-                                    placeholder="María Elena González"
-                                    isRequired
-                                    value={data.parent2Name || ''}
-                                    onChange={(e) => updateField('parent2Name', e.target.value)}
-                                    onBlur={() => touchField('parent2Name')}
-                                    error={errors.parent2Name}
-                                />
-                                <RutInput 
-                                    name="parent2-rut" 
-                                    label="RUT"
-                                    placeholder="15.678.912-3"
-                                    required
-                                    value={data.parent2Rut || ''}
-                                    onChange={(value) => updateField('parent2Rut', value)}
-                                    onBlur={() => touchField('parent2Rut')}
-                                    error={errors.parent2Rut}
-                                />
-                                <Input 
-                                    id="parent2-email" 
-                                    label="Email" 
-                                    type="email"
-                                    placeholder="maria.gonzalez@ejemplo.com"
-                                    isRequired
-                                    value={data.parent2Email || ''}
-                                    onChange={(e) => updateField('parent2Email', e.target.value)}
-                                    onBlur={() => touchField('parent2Email')}
-                                    error={errors.parent2Email}
-                                />
-                                <Input 
-                                    id="parent2-phone" 
-                                    label="Teléfono" 
-                                    type="tel"
-                                    placeholder="+569 8765 4321"
-                                    isRequired
-                                    value={data.parent2Phone || ''}
-                                    onChange={(e) => updateField('parent2Phone', e.target.value)}
-                                    onBlur={() => touchField('parent2Phone')}
-                                    error={errors.parent2Phone}
-                                />
-                            </div>
-                            <div className="mt-4">
-                                <Input 
-                                    id="parent2-address" 
-                                    label="Dirección"
-                                    placeholder="Av. Vitacura 789, Las Condes, Santiago"
-                                    isRequired
-                                    value={data.parent2Address || ''}
-                                    onChange={(e) => updateField('parent2Address', e.target.value)}
-                                    onBlur={() => touchField('parent2Address')}
-                                    error={errors.parent2Address}
-                                />
-                            </div>
-                            <div className="mt-4">
-                                <Input 
-                                    id="parent2-profession" 
-                                    label="Profesión"
-                                    placeholder="Profesora de Educación Básica"
-                                    isRequired
-                                    value={data.parent2Profession || ''}
-                                    onChange={(e) => updateField('parent2Profession', e.target.value)}
-                                    onBlur={() => touchField('parent2Profession')}
-                                    error={errors.parent2Profession}
-                                />
-                            </div>
+                        <div className="mt-4">
+                            <Input
+                                id="parent1-address"
+                                label="Dirección"
+                                placeholder="Los Leones 456, Providencia, Santiago"
+                                isRequired
+                                value={data.parent1Address || ''}
+                                onChange={(e) => updateField('parent1Address', e.target.value)}
+                                onBlur={() => touchField('parent1Address')}
+                                error={errors.parent1Address}
+                            />
+                        </div>
+                        <div className="mt-4">
+                            <Input
+                                id="parent1-profession"
+                                label="Profesión"
+                                placeholder="Ingeniero Comercial"
+                                isRequired
+                                value={data.parent1Profession || ''}
+                                onChange={(e) => updateField('parent1Profession', e.target.value)}
+                                onBlur={() => touchField('parent1Profession')}
+                                error={errors.parent1Profession}
+                            />
                         </div>
                     </div>
                 );
-            case 2:
+
+            // Step 4: Datos de la Madre
+            case 4:
+                return (
+                    <div className="space-y-4">
+                        <h3 className="text-xl font-bold text-azul-monte-tabor mb-4">Datos de la Madre</h3>
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <Input
+                                id="parent2-name"
+                                label="Nombre Completo"
+                                placeholder="María Elena González"
+                                isRequired
+                                value={data.parent2Name || ''}
+                                onChange={(e) => updateField('parent2Name', e.target.value)}
+                                onBlur={() => touchField('parent2Name')}
+                                error={errors.parent2Name}
+                            />
+                            <RutInput
+                                name="parent2-rut"
+                                label="RUT"
+                                placeholder="15.678.912-3"
+                                required
+                                value={data.parent2Rut || ''}
+                                onChange={(value) => updateField('parent2Rut', value)}
+                                onBlur={() => touchField('parent2Rut')}
+                                error={errors.parent2Rut}
+                            />
+                            <Input
+                                id="parent2-email"
+                                label="Email"
+                                type="email"
+                                placeholder="maria.gonzalez@ejemplo.com"
+                                isRequired
+                                value={data.parent2Email || ''}
+                                onChange={(e) => updateField('parent2Email', e.target.value)}
+                                onBlur={() => touchField('parent2Email')}
+                                error={errors.parent2Email}
+                            />
+                            <Input
+                                id="parent2-phone"
+                                label="Teléfono"
+                                type="tel"
+                                placeholder="+569 8765 4321"
+                                isRequired
+                                value={data.parent2Phone || ''}
+                                onChange={(e) => updateField('parent2Phone', e.target.value)}
+                                onBlur={() => touchField('parent2Phone')}
+                                error={errors.parent2Phone}
+                            />
+                        </div>
+                        <div className="mt-4">
+                            <Input
+                                id="parent2-address"
+                                label="Dirección"
+                                placeholder="Av. Vitacura 789, Las Condes, Santiago"
+                                isRequired
+                                value={data.parent2Address || ''}
+                                onChange={(e) => updateField('parent2Address', e.target.value)}
+                                onBlur={() => touchField('parent2Address')}
+                                error={errors.parent2Address}
+                            />
+                        </div>
+                        <div className="mt-4">
+                            <Input
+                                id="parent2-profession"
+                                label="Profesión"
+                                placeholder="Profesora de Educación Básica"
+                                isRequired
+                                value={data.parent2Profession || ''}
+                                onChange={(e) => updateField('parent2Profession', e.target.value)}
+                                onBlur={() => touchField('parent2Profession')}
+                                error={errors.parent2Profession}
+                            />
+                        </div>
+                    </div>
+                );
+
+            // Step 5: Sostenedor
+            case 5:
                 return (
                     <div className="space-y-4">
                         <h3 className="text-xl font-bold text-azul-monte-tabor">Información del Sostenedor</h3>
                         <p className="text-gris-piedra mb-4">Persona responsable del pago de mensualidades y compromisos económicos.</p>
-                        
-                        {/* Selección de parentesco primero */}
-                        <Select 
-                            id="supporter-relation" 
-                            label="Parentesco con el postulante" 
+
+                        <Select
+                            id="supporter-relation"
+                            label="Parentesco con el postulante"
                             options={[
                                 { value: '', label: 'Seleccione...' },
                                 { value: 'padre', label: 'Padre' },
@@ -1996,14 +2008,13 @@ const ApplicationForm: React.FC = () => {
                                 { value: 'tutor', label: 'Tutor Legal' },
                                 { value: 'otro', label: 'Otro' }
                             ]}
-                            isRequired 
+                            isRequired
                             value={data.supporterRelation || ''}
                             onChange={(e) => handleParentRelationChange('supporterRelation', e.target.value, 'supporter')}
                             onBlur={() => touchField('supporterRelation')}
                             error={errors.supporterRelation}
                         />
 
-                        {/* Mensaje informativo para padre/madre */}
                         {(data.supporterRelation === 'padre' || data.supporterRelation === 'madre') && (
                             <div className="p-3 bg-green-50 rounded-lg">
                                 <p className="text-sm text-green-800">
@@ -2013,45 +2024,45 @@ const ApplicationForm: React.FC = () => {
                         )}
 
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                            <Input 
-                                id="supporter-name" 
-                                label="Nombre Completo" 
+                            <Input
+                                id="supporter-name"
+                                label="Nombre Completo"
                                 placeholder="Ana María Rodríguez"
-                                isRequired 
+                                isRequired
                                 value={data.supporterName || ''}
                                 onChange={(e) => updateField('supporterName', e.target.value)}
                                 onBlur={() => touchField('supporterName')}
                                 error={errors.supporterName}
                                 disabled={data.supporterRelation === 'padre' || data.supporterRelation === 'madre'}
                             />
-                            <RutInput 
-                                name="supporter-rut" 
-                                label="RUT" 
+                            <RutInput
+                                name="supporter-rut"
+                                label="RUT"
                                 placeholder="18.456.789-2"
-                                required 
+                                required
                                 value={data.supporterRut || ''}
                                 onChange={(value) => updateField('supporterRut', value)}
                                 onBlur={() => touchField('supporterRut')}
                                 error={errors.supporterRut}
                                 disabled={data.supporterRelation === 'padre' || data.supporterRelation === 'madre'}
                             />
-                            <Input 
-                                id="supporter-email" 
-                                label="Email" 
-                                type="email" 
+                            <Input
+                                id="supporter-email"
+                                label="Email"
+                                type="email"
                                 placeholder="ana.rodriguez@ejemplo.com"
-                                isRequired 
+                                isRequired
                                 value={data.supporterEmail || ''}
                                 onChange={(e) => updateField('supporterEmail', e.target.value)}
                                 onBlur={() => touchField('supporterEmail')}
                                 error={errors.supporterEmail}
                                 disabled={data.supporterRelation === 'padre' || data.supporterRelation === 'madre'}
                             />
-                            <Input 
-                                id="supporter-phone" 
-                                label="Teléfono" 
-                                type="tel" 
-                                isRequired 
+                            <Input
+                                id="supporter-phone"
+                                label="Teléfono"
+                                type="tel"
+                                isRequired
                                 placeholder="+569 9876 5432"
                                 value={data.supporterPhone || ''}
                                 onChange={(e) => updateField('supporterPhone', e.target.value)}
@@ -2062,16 +2073,17 @@ const ApplicationForm: React.FC = () => {
                         </div>
                     </div>
                 );
-            case 3:
+
+            // Step 6: Apoderado
+            case 6:
                 return (
                     <div className="space-y-4">
                         <h3 className="text-xl font-bold text-azul-monte-tabor">Información del Apoderado</h3>
                         <p className="text-gris-piedra mb-4">Persona responsable de la representación del estudiante en el colegio.</p>
-                        
-                        {/* Selección de parentesco primero */}
-                        <Select 
-                            id="guardian-relation" 
-                            label="Parentesco con el postulante" 
+
+                        <Select
+                            id="guardian-relation"
+                            label="Parentesco con el postulante"
                             options={[
                                 { value: '', label: 'Seleccione...' },
                                 { value: 'padre', label: 'Padre' },
@@ -2082,14 +2094,13 @@ const ApplicationForm: React.FC = () => {
                                 { value: 'tutor', label: 'Tutor Legal' },
                                 { value: 'otro', label: 'Otro' }
                             ]}
-                            isRequired 
+                            isRequired
                             value={data.guardianRelation || ''}
                             onChange={(e) => handleParentRelationChange('guardianRelation', e.target.value, 'guardian')}
                             onBlur={() => touchField('guardianRelation')}
                             error={errors.guardianRelation}
                         />
 
-                        {/* Mensaje informativo para padre/madre */}
                         {(data.guardianRelation === 'padre' || data.guardianRelation === 'madre') && (
                             <div className="p-3 bg-green-50 rounded-lg">
                                 <p className="text-sm text-green-800">
@@ -2099,45 +2110,45 @@ const ApplicationForm: React.FC = () => {
                         )}
 
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                            <Input 
-                                id="guardian-name" 
-                                label="Nombre Completo" 
+                            <Input
+                                id="guardian-name"
+                                label="Nombre Completo"
                                 placeholder="Roberto Silva Martínez"
-                                isRequired 
+                                isRequired
                                 value={data.guardianName || ''}
                                 onChange={(e) => updateField('guardianName', e.target.value)}
                                 onBlur={() => touchField('guardianName')}
                                 error={errors.guardianName}
                                 disabled={data.guardianRelation === 'padre' || data.guardianRelation === 'madre'}
                             />
-                            <RutInput 
-                                name="guardian-rut" 
-                                label="RUT" 
+                            <RutInput
+                                name="guardian-rut"
+                                label="RUT"
                                 placeholder="19.234.567-8"
-                                required 
+                                required
                                 value={data.guardianRut || ''}
                                 onChange={(value) => updateField('guardianRut', value)}
                                 onBlur={() => touchField('guardianRut')}
                                 error={errors.guardianRut}
                                 disabled={data.guardianRelation === 'padre' || data.guardianRelation === 'madre'}
                             />
-                            <Input 
-                                id="guardian-email" 
-                                label="Email" 
-                                type="email" 
+                            <Input
+                                id="guardian-email"
+                                label="Email"
+                                type="email"
                                 placeholder="roberto.silva@ejemplo.com"
-                                isRequired 
+                                isRequired
                                 value={data.guardianEmail || ''}
                                 onChange={(e) => updateField('guardianEmail', e.target.value)}
                                 onBlur={() => touchField('guardianEmail')}
                                 error={errors.guardianEmail}
                                 disabled={data.guardianRelation === 'padre' || data.guardianRelation === 'madre'}
                             />
-                            <Input 
-                                id="guardian-phone" 
-                                label="Teléfono" 
-                                type="tel" 
-                                isRequired 
+                            <Input
+                                id="guardian-phone"
+                                label="Teléfono"
+                                type="tel"
+                                isRequired
                                 placeholder="+569 5555 1234"
                                 value={data.guardianPhone || ''}
                                 onChange={(e) => updateField('guardianPhone', e.target.value)}
@@ -2148,7 +2159,9 @@ const ApplicationForm: React.FC = () => {
                         </div>
                     </div>
                 );
-            case 4:
+
+            // Step 7: Documentación
+            case 7:
                 const documentTypes = [
                     { key: 'BIRTH_CERTIFICATE', label: 'Certificado de Nacimiento', required: true },
                     { key: 'GRADES_2023', label: 'Certificado de Estudios 2023 (si aplica)', required: true },
@@ -2288,7 +2301,9 @@ const ApplicationForm: React.FC = () => {
                         </div>
                     </div>
                 );
-            case 5:
+
+            // Step 8: Confirmación
+            case 8:
                 return (
                     <div className="text-center">
                         <h3 className="text-2xl font-bold text-azul-monte-tabor mb-4">Postulación Enviada</h3>
@@ -2377,35 +2392,6 @@ const ApplicationForm: React.FC = () => {
                     {renderStepContent()}
                 </Card>
 
-                {/* Missing Fields Warning */}
-                {currentStep < 4 && getMissingFields.length > 0 && (
-                    <div className="mt-6 p-6 bg-red-100 border-4 border-red-500 rounded-lg shadow-lg">
-                        <div className="flex items-start">
-                            <div className="flex-shrink-0">
-                                <svg className="h-8 w-8 text-red-600" viewBox="0 0 20 20" fill="currentColor">
-                                    <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
-                                </svg>
-                            </div>
-                            <div className="ml-4 flex-1">
-                                <h3 className="text-lg font-bold text-red-900 mb-3">
-                                    FALTAN {getMissingFields.length} CAMPO(S) OBLIGATORIO(S)
-                                </h3>
-                                <p className="text-sm text-red-800 mb-3">
-                                    Por favor complete los siguientes campos para continuar:
-                                </p>
-                                <div className="bg-white p-4 rounded-lg border-2 border-red-300">
-                                    <ul className="list-disc list-inside text-base text-red-900 space-y-2">
-                                        {getMissingFields.map((field, index) => (
-                                            <li key={index} className="font-semibold">
-                                                {field}
-                                            </li>
-                                        ))}
-                                    </ul>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                )}
 
                 {/* Navigation Buttons */}
                 {currentStep < steps.length - 1 && (
@@ -2420,7 +2406,7 @@ const ApplicationForm: React.FC = () => {
                             loadingText={location.state?.editMode ? "Guardando..." : "Enviando..."}
                             disabled={!canProceedToNextStep && !isSubmitting}
                         >
-                            {currentStep === 4
+                            {currentStep === 7
                                 ? (location.state?.editMode ? 'Guardar Cambios' : 'Enviar Postulación')
                                 : 'Siguiente'
                             }

--- a/microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx
+++ b/microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx
@@ -87,7 +87,7 @@ const ApplicationForm: React.FC = () => {
     const [isVerifying, setIsVerifying] = useState(false);
     const [verificationCode, setVerificationCode] = useState('');
     const [verificationError, setVerificationError] = useState('');
-    const [showAuthForm, setShowAuthForm] = useState(false); // TEMP: Deshabilitado para desarrollo
+    const [showAuthForm, setShowAuthForm] = useState(true);
     const [showRegister, setShowRegister] = useState(false);
     const [authLoading, setAuthLoading] = useState(false);
     const [authError, setAuthError] = useState('');
@@ -2345,8 +2345,7 @@ const ApplicationForm: React.FC = () => {
     };
 
     // Si no está autenticado, mostrar formulario de autenticación
-    // TEMP: Deshabilitado !isAuthenticated para desarrollo - permitir acceso directo
-    if (showAuthForm) {
+    if (showAuthForm || !isAuthenticated) {
         return renderAuthForm();
     }
 
@@ -2361,12 +2360,10 @@ const ApplicationForm: React.FC = () => {
                     </div>
                     <div className="text-right">
                         <p className="text-sm text-gris-piedra">Apoderado:</p>
-                        <p className="font-semibold text-azul-monte-tabor">{user?.firstName || 'Usuario Prueba'} {user?.lastName || 'Development'}</p>
-                        {user && (
-                            <Link to="/dashboard-apoderado" className="text-sm text-azul-monte-tabor hover:underline">
-                                Ver mi dashboard →
-                            </Link>
-                        )}
+                        <p className="font-semibold text-azul-monte-tabor">{user?.firstName} {user?.lastName}</p>
+                        <Link to="/dashboard-apoderado" className="text-sm text-azul-monte-tabor hover:underline">
+                            Ver mi dashboard →
+                        </Link>
                     </div>
                 </div>
 

--- a/microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx
+++ b/microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx
@@ -2408,6 +2408,24 @@ const ApplicationForm: React.FC = () => {
                         </div>
                         <p className="text-xs text-gris-piedra mt-3">Paso {currentStep + 1}</p>
                     </div>
+
+                    {/* Barra de Progreso */}
+                    <div className="w-full">
+                        <div className="flex justify-between items-center mb-2">
+                            <span className="text-xs font-medium text-azul-monte-tabor">
+                                {Math.round(((currentStep + 1) / steps.length) * 100)}%
+                            </span>
+                            <span className="text-xs text-gris-piedra">
+                                {currentStep + 1} de {steps.length}
+                            </span>
+                        </div>
+                        <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+                            <div
+                                className="h-full bg-gradient-to-r from-dorado-nazaret to-verde-esperanza rounded-full transition-all duration-500"
+                                style={{ width: `${((currentStep + 1) / steps.length) * 100}%` }}
+                            ></div>
+                        </div>
+                    </div>
                 </div>
 
                 <Card className="p-4 sm:p-8 md:p-12">

--- a/microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx
+++ b/microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx
@@ -11,6 +11,7 @@ import { CheckCircleIcon, LogoIcon, UploadIcon } from '../components/icons/Icons
 import { useApplications, useNotifications } from '../context/AppContext';
 import { useAuth } from '../context/AuthContext';
 import { educationalLevelsForForm as educationalLevels } from '../services/staticData';
+import { microfrontendUrls } from '../utils/microfrontendUrls';
 import api from '../services/api';
 import { applicationService } from '../services/applicationService';
 import { documentService, DOCUMENT_TYPES } from '../services/documentService';
@@ -2321,17 +2322,16 @@ const ApplicationForm: React.FC = () => {
                             </ol>
                         </div>
                         <div className="mt-6 space-y-3">
-                            <Link to="/dashboard-apoderado">
-                                <Button 
-                                    variant="primary"
-                                    className="w-full"
-                                >
-                                    Ver Mi Dashboard
-                                </Button>
-                            </Link>
-                            <Button 
-                                variant="outline" 
-                                onClick={() => window.location.href = '/'}
+                            <Button
+                                variant="primary"
+                                onClick={() => window.location.href = microfrontendUrls.guardianDashboard}
+                                className="w-full"
+                            >
+                                Ver Mi Dashboard
+                            </Button>
+                            <Button
+                                variant="outline"
+                                onClick={() => window.location.href = microfrontendUrls.home}
                                 className="w-full"
                             >
                                 Volver al Inicio

--- a/microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx
+++ b/microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx
@@ -2370,21 +2370,43 @@ const ApplicationForm: React.FC = () => {
                     </div>
                 </div>
 
-                {/* Progress Bar */}
+                {/* Progress Bar con Círculos */}
                 <div className="mb-8 sm:mb-10">
-                    <div className="hidden sm:flex justify-between mb-2">
+                    {/* Desktop View */}
+                    <div className="hidden sm:flex justify-between items-center gap-2 mb-8">
                         {steps.map((step, index) => (
-                             <div key={index} className={`text-center w-1/4 text-sm ${index <= currentStep ? 'text-azul-monte-tabor font-bold' : 'text-gris-piedra'}`}>
-                                {step}
+                            <div key={index} className="flex flex-col items-center flex-1">
+                                <div className={`w-10 h-10 rounded-full flex items-center justify-center font-bold text-sm transition-all duration-300 ${
+                                    index < currentStep
+                                        ? 'bg-verde-esperanza text-white'
+                                        : index === currentStep
+                                        ? 'bg-dorado-nazaret text-azul-monte-tabor border-2 border-dorado-nazaret'
+                                        : 'bg-gray-300 text-white'
+                                }`}>
+                                    {index + 1}
+                                </div>
+                                {index < steps.length - 1 && (
+                                    <div className={`h-0.5 w-full mt-3 transition-all duration-300 ${
+                                        index < currentStep ? 'bg-verde-esperanza' : 'bg-gray-300'
+                                    }`}></div>
+                                )}
                             </div>
                         ))}
                     </div>
-                    <div className="sm:hidden flex justify-between mb-2 text-xs">
-                        <span className={currentStep > 0 ? 'text-azul-monte-tabor font-bold' : 'text-gris-piedra'}>Paso {currentStep + 1}/{steps.length}</span>
-                        <span className="font-semibold text-azul-monte-tabor">{steps[currentStep]}</span>
-                    </div>
-                    <div className="w-full bg-gray-200 rounded-full h-2.5">
-                        <div className="bg-dorado-nazaret h-2.5 rounded-full" style={{ width: `${(currentStep / (steps.length - 1)) * 100}%` }}></div>
+
+                    {/* Mobile View */}
+                    <div className="sm:hidden text-center mb-6">
+                        <div className="inline-flex items-center gap-4">
+                            <div className={`w-12 h-12 rounded-full flex items-center justify-center font-bold text-lg transition-all duration-300 ${
+                                currentStep === 0
+                                    ? 'bg-dorado-nazaret text-azul-monte-tabor border-2 border-dorado-nazaret'
+                                    : 'bg-verde-esperanza text-white'
+                            }`}>
+                                {currentStep + 1}
+                            </div>
+                            <span className="text-sm text-gris-piedra">de {steps.length}</span>
+                        </div>
+                        <p className="text-xs text-gris-piedra mt-3">Paso {currentStep + 1}</p>
                     </div>
                 </div>
 

--- a/microfrontends/apps/mf-admissions/pages/HomePage.tsx
+++ b/microfrontends/apps/mf-admissions/pages/HomePage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import Button from '../components/ui/Button';
 import Card from '../components/ui/Card';
-import { FileText, Users, CheckCircle, Calculator, BookOpen, Globe } from 'lucide-react';
+import { FileText, Users, CheckCircle, Clock, Calendar, Calculator, BookOpen, Globe } from 'lucide-react';
 import { microfrontendUrls } from '../utils/microfrontendUrls';
 
 const HomePage: React.FC = () => {
@@ -13,42 +13,30 @@ const HomePage: React.FC = () => {
     ];
 
     const admissionTimeline = [
-        {
-            date: 'AGOSTO 2026',
-            event: 'Apertura de Postulaciones',
-            description: 'Inicio del periodo oficial para la recepción de documentos y solicitudes en línea.',
-            current: true,
-            status: 'active',
-        },
-        {
-            date: 'SEPTIEMBRE - OCTUBRE 2026',
-            event: 'Exámenes y Entrevistas',
-            description: 'Periodo de evaluaciones académicas y encuentros personales con las familias postulantes.',
-            current: false,
-            status: 'upcoming',
-        },
-        {
-            date: 'NOVIEMBRE 2026',
-            event: 'Publicación de Resultados',
-            description: 'Comunicación oficial de las admisiones y formalización de la matrícula para el ciclo 2026.',
-            current: false,
-            status: 'future',
-        },
+        { date: '1 de Agosto', event: 'Inicio del Proceso de Postulación', current: true },
+        { date: '30 de Septiembre', event: 'Cierre de Postulaciones', current: false },
+        { date: '1 al 15 de Octubre', event: 'Periodo de Entrevistas', current: false },
+        { date: '1 de Noviembre', event: 'Publicación de Resultados', current: false },
     ];
 
     return (
         <div className="bg-blanco-pureza">
             {/* Hero Section */}
-            <section className="relative text-blanco-pureza py-[7.5rem] sm:py-48 text-center bg-cover bg-center" style={{ backgroundImage: `url('/images/colegio.png')`}}>
+            <section className="relative text-blanco-pureza py-20 sm:py-32 text-center bg-cover bg-center" style={{ backgroundImage: `url('/images/colegio.png')`}}>
                 {/* Overlay azul con opacidad 85% */}
-                <div className="absolute inset-0 bg-azul-monte-tabor" style={{ opacity: 0.85, filter: 'brightness(0.75)' }}></div>
+                <div className="absolute inset-0 bg-azul-monte-tabor" style={{ opacity: 0.85 }}></div>
                 <div className="relative container mx-auto px-4 sm:px-6">
-                    <h1 className="text-3xl sm:text-5xl md:text-6xl font-black font-serif mb-4 animate-fade-in-down">Formando líderes con espíritu de servicio</h1>
-                    <p className="text-base sm:text-xl text-gray-200 mb-8 max-w-3xl mx-auto">Únanse a una comunidad educativa comprometida con la excelencia académica y formación católica</p>
-                    <div className="flex justify-center">
-                        <a href={microfrontendUrls.admissions}>
-                            <Button size="lg" variant="primary" className="!text-blanco-pureza">
-                                Iniciar postulación
+                    <h1 className="text-3xl sm:text-5xl md:text-6xl font-black font-serif mb-4 animate-fade-in-down">Formando Líderes con Espíritu de Servicio</h1>
+                    <p className="text-base sm:text-xl text-gray-200 mb-8 max-w-3xl mx-auto">Únase a una comunidad educativa comprometida con la excelencia académica y la formación católica.</p>
+                    <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center items-center">
+                        <a href={microfrontendUrls.guardianLogin}>
+                            <Button size="lg" variant="primary">
+                                Postular Aquí
+                            </Button>
+                        </a>
+                        <a href={microfrontendUrls.guardianLogin}>
+                            <Button size="lg" variant="secondary">
+                                Portal Apoderados
                             </Button>
                         </a>
                     </div>
@@ -57,50 +45,50 @@ const HomePage: React.FC = () => {
 
             {/* Steps Section */}
             <section className="py-12 sm:py-20 bg-gray-50">
-                <div className="container mx-auto px-4 sm:px-6">
-                    <h2 className="text-2xl sm:text-4xl font-bold text-azul-monte-tabor mb-4 font-serif text-center">Proceso de Admisión</h2>
-                    <p className="text-gris-piedra mb-12 max-w-2xl mx-auto text-center">Un camino claro y guiado para formar parte de nuestra comunidad educativa.</p>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-6">
+                <div className="container mx-auto px-4 sm:px-6 text-center">
+                    <h2 className="text-2xl sm:text-4xl font-bold text-azul-monte-tabor mb-4 font-serif">Proceso de Admisión</h2>
+                    <p className="text-gris-piedra mb-12 max-w-2xl mx-auto">Un camino claro y guiado para formar parte de nuestra comunidad educativa.</p>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 sm:gap-10">
                         {admissionSteps.map((step, index) => (
-                            <div key={index} className="bg-blanco-pureza p-8 rounded-2xl border border-gray-200 text-center">
-                                <div className="flex justify-center mb-4">{step.icon}</div>
-                                <h3 className="text-lg font-bold text-azul-monte-tabor mb-3">{step.title}</h3>
-                                <p className="text-gris-piedra text-sm">{step.description}</p>
-                            </div>
+                            <Card key={index} className="text-center p-8">
+                                <div className="flex justify-center mb-6">{step.icon}</div>
+                                <h3 className="text-xl font-bold text-azul-monte-tabor mb-2">{step.title}</h3>
+                                <p className="text-gris-piedra">{step.description}</p>
+                            </Card>
                         ))}
                     </div>
                 </div>
             </section>
 
             {/* Exam Portal Section */}
-            <section className="py-12 sm:py-20 bg-gray-100">
+            <section className="py-12 sm:py-20 bg-azul-monte-tabor text-blanco-pureza">
                 <div className="container mx-auto px-4 sm:px-6 text-center">
-                    <h2 className="text-2xl sm:text-4xl font-bold text-azul-monte-tabor mb-4 font-serif">Portal de Exámenes de Admisión</h2>
-                    <p className="text-gris-piedra mb-8 max-w-3xl mx-auto text-base sm:text-lg">
-                        Una vez completada tu postulación, podrás acceder al portal de exámenes para programar
+                    <h2 className="text-2xl sm:text-4xl font-bold mb-4 font-serif">Portal de Exámenes de Admisión</h2>
+                    <p className="text-gray-200 mb-8 max-w-3xl mx-auto text-base sm:text-lg">
+                        Una vez completada tu postulación, podrás acceder al portal de exámenes para programar 
                         y rendir las evaluaciones de Matemática, Lenguaje e Inglés.
                     </p>
-                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6 mb-8 text-center">
-                        <div className="bg-blanco-pureza p-8 rounded-2xl border border-gray-200">
-                            <div className="flex justify-center mb-4">
-                                <Calculator className="w-10 h-10 text-dorado-nazaret" />
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6 mb-8">
+                        <div className="bg-blanco-pureza bg-opacity-10 p-6 rounded-lg">
+                            <div className="flex justify-center mb-3">
+                                <Calculator className="w-12 h-12 text-dorado-nazaret" />
                             </div>
-                            <h3 className="font-bold text-azul-monte-tabor text-lg mb-3">Matemática</h3>
-                            <p className="text-gris-piedra text-sm">Evaluación adaptada según tu nivel educativo</p>
+                            <h3 className="font-bold text-dorado-nazaret mb-2">Matemática</h3>
+                            <p className="text-gray-200 text-sm">Evaluación adaptada según tu nivel educativo</p>
                         </div>
-                        <div className="bg-blanco-pureza p-8 rounded-2xl border border-gray-200">
-                            <div className="flex justify-center mb-4">
-                                <BookOpen className="w-10 h-10 text-dorado-nazaret" />
+                        <div className="bg-blanco-pureza bg-opacity-10 p-6 rounded-lg">
+                            <div className="flex justify-center mb-3">
+                                <BookOpen className="w-12 h-12 text-dorado-nazaret" />
                             </div>
-                            <h3 className="font-bold text-azul-monte-tabor text-lg mb-3">Lenguaje</h3>
-                            <p className="text-gris-piedra text-sm">Comprensión lectora y expresión escrita</p>
+                            <h3 className="font-bold text-dorado-nazaret mb-2">Lenguaje</h3>
+                            <p className="text-gray-200 text-sm">Comprensión lectora y expresión escrita</p>
                         </div>
-                        <div className="bg-blanco-pureza p-8 rounded-2xl border border-gray-200">
-                            <div className="flex justify-center mb-4">
-                                <Globe className="w-10 h-10 text-dorado-nazaret" />
+                        <div className="bg-blanco-pureza bg-opacity-10 p-6 rounded-lg">
+                            <div className="flex justify-center mb-3">
+                                <Globe className="w-12 h-12 text-dorado-nazaret" />
                             </div>
-                            <h3 className="font-bold text-azul-monte-tabor text-lg mb-3">Inglés</h3>
-                            <p className="text-gris-piedra text-sm">Gramática, vocabulario y comprensión</p>
+                            <h3 className="font-bold text-dorado-nazaret mb-2">Inglés</h3>
+                            <p className="text-gray-200 text-sm">Gramática, vocabulario y comprensión</p>
                         </div>
                     </div>
                     <a href={microfrontendUrls.studentExams}>
@@ -112,52 +100,37 @@ const HomePage: React.FC = () => {
             </section>
 
             {/* Timeline Section */}
-            <section className="py-12 sm:py-20 bg-gray-50">
+            <section className="py-12 sm:py-20">
                 <div className="container mx-auto px-4 sm:px-6">
-                    <div className="text-center mb-12 sm:mb-16">
-                        <h2 className="text-2xl sm:text-4xl font-bold text-azul-monte-tabor mb-3 font-serif">Calendario de Admisión 2027</h2>
-                        <p className="text-dorado-nazaret font-medium">Fechas clave e hitos importantes para tu postulación</p>
-                    </div>
+                    <h2 className="text-2xl sm:text-4xl font-bold text-azul-monte-tabor text-center mb-8 sm:mb-12 font-serif">Calendario de Admisión 2025</h2>
                     {/* Desktop: alternating timeline */}
                     <div className="hidden sm:block relative max-w-3xl mx-auto">
-                        <div className="absolute left-1/2 h-full w-0.5 bg-gray-300 transform -translate-x-1/2"></div>
+                        <div className="absolute left-1/2 h-full w-1 bg-azul-monte-tabor rounded-full transform -translate-x-1/2"></div>
                         {admissionTimeline.map((item, index) => (
-                            <div key={index} className="flex items-center w-full mb-16">
-                                <div className="flex-1 pr-10 text-right">
-                                    {index % 2 === 0 ? (
-                                        <>
-                                            <p className={`text-xs font-bold uppercase tracking-wider mb-1 ${item.status === 'future' ? 'text-gray-400' : 'text-dorado-nazaret'}`}>{item.date}</p>
-                                            <p className={`font-bold text-base ${item.status === 'future' ? 'text-gray-400' : 'text-azul-monte-tabor'}`}>{item.event}</p>
-                                        </>
-                                    ) : (
-                                        <p className="text-gris-piedra text-sm">{item.description}</p>
-                                    )}
+                            <div key={index} className={`flex items-center w-full mb-8 ${index % 2 === 0 ? 'justify-start' : 'justify-end'}`}>
+                                <div className={`w-5/12 ${index % 2 === 0 ? 'text-right pr-8' : 'text-left pl-8'}`}>
+                                    <p className="font-bold text-dorado-nazaret">{item.date}</p>
+                                    <p className="text-gris-piedra">{item.event}</p>
                                 </div>
-                                <div className="flex-shrink-0 z-10 w-3">
-                                    <div className={`w-3 h-3 rounded-full ${item.current ? 'bg-dorado-nazaret' : item.status === 'future' ? 'bg-gray-300' : 'bg-azul-monte-tabor'}`}></div>
+                                <div className="relative">
+                                    <div className={`w-8 h-8 rounded-full flex items-center justify-center z-10 ${item.current ? 'bg-dorado-nazaret ring-8 ring-amber-200' : 'bg-azul-monte-tabor'}`}>
+                                        <Clock className="w-5 h-5 text-blanco-pureza" />
+                                    </div>
                                 </div>
-                                <div className="flex-1 pl-10 text-left">
-                                    {index % 2 === 0 ? (
-                                        <p className="text-gris-piedra text-sm">{item.description}</p>
-                                    ) : (
-                                        <>
-                                            <p className={`text-xs font-bold uppercase tracking-wider mb-1 ${item.status === 'future' ? 'text-gray-400' : 'text-dorado-nazaret'}`}>{item.date}</p>
-                                            <p className={`font-bold text-base ${item.status === 'future' ? 'text-gray-400' : 'text-azul-monte-tabor'}`}>{item.event}</p>
-                                        </>
-                                    )}
-                                </div>
+                                <div className="w-5/12"></div>
                             </div>
                         ))}
                     </div>
                     {/* Mobile: vertical list */}
                     <div className="sm:hidden space-y-4 max-w-sm mx-auto">
                         {admissionTimeline.map((item, index) => (
-                            <div key={index} className={`flex items-start gap-4 p-4 rounded-lg border-l-4 ${item.current ? 'border-dorado-nazaret bg-amber-50' : item.status === 'future' ? 'border-gray-300 bg-gray-100' : 'border-azul-monte-tabor bg-blanco-pureza'}`}>
-                                <div className={`w-3 h-3 rounded-full mt-1 flex-shrink-0 ${item.current ? 'bg-dorado-nazaret' : item.status === 'future' ? 'bg-gray-300' : 'bg-azul-monte-tabor'}`}></div>
+                            <div key={index} className={`flex items-start gap-4 p-4 rounded-lg border-l-4 ${item.current ? 'border-dorado-nazaret bg-amber-50' : 'border-azul-monte-tabor bg-gray-50'}`}>
+                                <div className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${item.current ? 'bg-dorado-nazaret' : 'bg-azul-monte-tabor'}`}>
+                                    <Clock className="w-4 h-4 text-blanco-pureza" />
+                                </div>
                                 <div>
-                                    <p className={`text-xs font-bold uppercase tracking-wider mb-1 ${item.status === 'future' ? 'text-gray-400' : 'text-dorado-nazaret'}`}>{item.date}</p>
-                                    <p className={`font-bold text-sm mb-1 ${item.status === 'future' ? 'text-gray-400' : 'text-azul-monte-tabor'}`}>{item.event}</p>
-                                    <p className="text-gris-piedra text-sm">{item.description}</p>
+                                    <p className="font-bold text-dorado-nazaret text-sm">{item.date}</p>
+                                    <p className="text-gris-piedra text-sm">{item.event}</p>
                                 </div>
                             </div>
                         ))}
@@ -166,17 +139,17 @@ const HomePage: React.FC = () => {
             </section>
 
             {/* Sección de Contacto */}
-            <section className="py-12 sm:py-16 bg-blanco-pureza border-t border-gray-200">
+            <section className="py-12 sm:py-16 bg-azul-monte-tabor text-blanco-pureza">
                 <div className="container mx-auto px-4 sm:px-6 text-center">
-                    <h2 className="text-2xl sm:text-3xl font-bold text-azul-monte-tabor mb-4 font-serif">¿Tienes Preguntas?</h2>
-                    <p className="text-gris-piedra text-lg mb-8 max-w-2xl mx-auto">
+                    <h2 className="text-3xl font-bold mb-8">¿Tienes Preguntas?</h2>
+                    <p className="text-xl mb-8">
                         Nuestro equipo está aquí para ayudarte en todo el proceso de admisión
                     </p>
                     <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                        <Button variant="outline" size="lg">
+                        <Button variant="outline" size="lg" className="text-blanco-pureza border-blanco-pureza hover:bg-blanco-pureza hover:text-azul-monte-tabor">
                             Contactar Admisión
                         </Button>
-                        <Button variant="secondary" size="lg">
+                        <Button variant="primary" size="lg">
                             Agendar Visita
                         </Button>
                     </div>

--- a/microfrontends/apps/mf-admissions/pages/HomePage.tsx
+++ b/microfrontends/apps/mf-admissions/pages/HomePage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import Button from '../components/ui/Button';
 import Card from '../components/ui/Card';
-import { FileText, Users, CheckCircle, Clock, Calendar, Calculator, BookOpen, Globe } from 'lucide-react';
+import { FileText, Users, CheckCircle, Calculator, BookOpen, Globe } from 'lucide-react';
 import { microfrontendUrls } from '../utils/microfrontendUrls';
 
 const HomePage: React.FC = () => {
@@ -13,30 +13,42 @@ const HomePage: React.FC = () => {
     ];
 
     const admissionTimeline = [
-        { date: '1 de Agosto', event: 'Inicio del Proceso de Postulación', current: true },
-        { date: '30 de Septiembre', event: 'Cierre de Postulaciones', current: false },
-        { date: '1 al 15 de Octubre', event: 'Periodo de Entrevistas', current: false },
-        { date: '1 de Noviembre', event: 'Publicación de Resultados', current: false },
+        {
+            date: 'AGOSTO 2026',
+            event: 'Apertura de Postulaciones',
+            description: 'Inicio del periodo oficial para la recepción de documentos y solicitudes en línea.',
+            current: true,
+            status: 'active',
+        },
+        {
+            date: 'SEPTIEMBRE - OCTUBRE 2026',
+            event: 'Exámenes y Entrevistas',
+            description: 'Periodo de evaluaciones académicas y encuentros personales con las familias postulantes.',
+            current: false,
+            status: 'upcoming',
+        },
+        {
+            date: 'NOVIEMBRE 2026',
+            event: 'Publicación de Resultados',
+            description: 'Comunicación oficial de las admisiones y formalización de la matrícula para el ciclo 2026.',
+            current: false,
+            status: 'future',
+        },
     ];
 
     return (
         <div className="bg-blanco-pureza">
             {/* Hero Section */}
-            <section className="relative text-blanco-pureza py-20 sm:py-32 text-center bg-cover bg-center" style={{ backgroundImage: `url('/images/colegio.png')`}}>
+            <section className="relative text-blanco-pureza py-[7.5rem] sm:py-48 text-center bg-cover bg-center" style={{ backgroundImage: `url('/images/colegio.png')`}}>
                 {/* Overlay azul con opacidad 85% */}
-                <div className="absolute inset-0 bg-azul-monte-tabor" style={{ opacity: 0.85 }}></div>
+                <div className="absolute inset-0 bg-azul-monte-tabor" style={{ opacity: 0.85, filter: 'brightness(0.75)' }}></div>
                 <div className="relative container mx-auto px-4 sm:px-6">
-                    <h1 className="text-3xl sm:text-5xl md:text-6xl font-black font-serif mb-4 animate-fade-in-down">Formando Líderes con Espíritu de Servicio</h1>
-                    <p className="text-base sm:text-xl text-gray-200 mb-8 max-w-3xl mx-auto">Únase a una comunidad educativa comprometida con la excelencia académica y la formación católica.</p>
-                    <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center items-center">
-                        <a href={microfrontendUrls.guardianLogin}>
-                            <Button size="lg" variant="primary">
-                                Postular Aquí
-                            </Button>
-                        </a>
-                        <a href={microfrontendUrls.guardianLogin}>
-                            <Button size="lg" variant="secondary">
-                                Portal Apoderados
+                    <h1 className="text-3xl sm:text-5xl md:text-6xl font-black font-serif mb-4 animate-fade-in-down">Formando líderes con espíritu de servicio</h1>
+                    <p className="text-base sm:text-xl text-gray-200 mb-8 max-w-3xl mx-auto">Únanse a una comunidad educativa comprometida con la excelencia académica y formación católica</p>
+                    <div className="flex justify-center">
+                        <a href={microfrontendUrls.admissions}>
+                            <Button size="lg" variant="primary" className="!text-blanco-pureza">
+                                Iniciar postulación
                             </Button>
                         </a>
                     </div>
@@ -45,50 +57,50 @@ const HomePage: React.FC = () => {
 
             {/* Steps Section */}
             <section className="py-12 sm:py-20 bg-gray-50">
-                <div className="container mx-auto px-4 sm:px-6 text-center">
-                    <h2 className="text-2xl sm:text-4xl font-bold text-azul-monte-tabor mb-4 font-serif">Proceso de Admisión</h2>
-                    <p className="text-gris-piedra mb-12 max-w-2xl mx-auto">Un camino claro y guiado para formar parte de nuestra comunidad educativa.</p>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 sm:gap-10">
+                <div className="container mx-auto px-4 sm:px-6">
+                    <h2 className="text-2xl sm:text-4xl font-bold text-azul-monte-tabor mb-4 font-serif text-center">Proceso de Admisión</h2>
+                    <p className="text-gris-piedra mb-12 max-w-2xl mx-auto text-center">Un camino claro y guiado para formar parte de nuestra comunidad educativa.</p>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-6">
                         {admissionSteps.map((step, index) => (
-                            <Card key={index} className="text-center p-8">
-                                <div className="flex justify-center mb-6">{step.icon}</div>
-                                <h3 className="text-xl font-bold text-azul-monte-tabor mb-2">{step.title}</h3>
-                                <p className="text-gris-piedra">{step.description}</p>
-                            </Card>
+                            <div key={index} className="bg-blanco-pureza p-8 rounded-2xl border border-gray-200 text-center">
+                                <div className="flex justify-center mb-4">{step.icon}</div>
+                                <h3 className="text-lg font-bold text-azul-monte-tabor mb-3">{step.title}</h3>
+                                <p className="text-gris-piedra text-sm">{step.description}</p>
+                            </div>
                         ))}
                     </div>
                 </div>
             </section>
 
             {/* Exam Portal Section */}
-            <section className="py-12 sm:py-20 bg-azul-monte-tabor text-blanco-pureza">
+            <section className="py-12 sm:py-20 bg-gray-100">
                 <div className="container mx-auto px-4 sm:px-6 text-center">
-                    <h2 className="text-2xl sm:text-4xl font-bold mb-4 font-serif">Portal de Exámenes de Admisión</h2>
-                    <p className="text-gray-200 mb-8 max-w-3xl mx-auto text-base sm:text-lg">
-                        Una vez completada tu postulación, podrás acceder al portal de exámenes para programar 
+                    <h2 className="text-2xl sm:text-4xl font-bold text-azul-monte-tabor mb-4 font-serif">Portal de Exámenes de Admisión</h2>
+                    <p className="text-gris-piedra mb-8 max-w-3xl mx-auto text-base sm:text-lg">
+                        Una vez completada tu postulación, podrás acceder al portal de exámenes para programar
                         y rendir las evaluaciones de Matemática, Lenguaje e Inglés.
                     </p>
-                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6 mb-8">
-                        <div className="bg-blanco-pureza bg-opacity-10 p-6 rounded-lg">
-                            <div className="flex justify-center mb-3">
-                                <Calculator className="w-12 h-12 text-dorado-nazaret" />
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6 mb-8 text-center">
+                        <div className="bg-blanco-pureza p-8 rounded-2xl border border-gray-200">
+                            <div className="flex justify-center mb-4">
+                                <Calculator className="w-10 h-10 text-dorado-nazaret" />
                             </div>
-                            <h3 className="font-bold text-dorado-nazaret mb-2">Matemática</h3>
-                            <p className="text-gray-200 text-sm">Evaluación adaptada según tu nivel educativo</p>
+                            <h3 className="font-bold text-azul-monte-tabor text-lg mb-3">Matemática</h3>
+                            <p className="text-gris-piedra text-sm">Evaluación adaptada según tu nivel educativo</p>
                         </div>
-                        <div className="bg-blanco-pureza bg-opacity-10 p-6 rounded-lg">
-                            <div className="flex justify-center mb-3">
-                                <BookOpen className="w-12 h-12 text-dorado-nazaret" />
+                        <div className="bg-blanco-pureza p-8 rounded-2xl border border-gray-200">
+                            <div className="flex justify-center mb-4">
+                                <BookOpen className="w-10 h-10 text-dorado-nazaret" />
                             </div>
-                            <h3 className="font-bold text-dorado-nazaret mb-2">Lenguaje</h3>
-                            <p className="text-gray-200 text-sm">Comprensión lectora y expresión escrita</p>
+                            <h3 className="font-bold text-azul-monte-tabor text-lg mb-3">Lenguaje</h3>
+                            <p className="text-gris-piedra text-sm">Comprensión lectora y expresión escrita</p>
                         </div>
-                        <div className="bg-blanco-pureza bg-opacity-10 p-6 rounded-lg">
-                            <div className="flex justify-center mb-3">
-                                <Globe className="w-12 h-12 text-dorado-nazaret" />
+                        <div className="bg-blanco-pureza p-8 rounded-2xl border border-gray-200">
+                            <div className="flex justify-center mb-4">
+                                <Globe className="w-10 h-10 text-dorado-nazaret" />
                             </div>
-                            <h3 className="font-bold text-dorado-nazaret mb-2">Inglés</h3>
-                            <p className="text-gray-200 text-sm">Gramática, vocabulario y comprensión</p>
+                            <h3 className="font-bold text-azul-monte-tabor text-lg mb-3">Inglés</h3>
+                            <p className="text-gris-piedra text-sm">Gramática, vocabulario y comprensión</p>
                         </div>
                     </div>
                     <a href={microfrontendUrls.studentExams}>
@@ -100,37 +112,52 @@ const HomePage: React.FC = () => {
             </section>
 
             {/* Timeline Section */}
-            <section className="py-12 sm:py-20">
+            <section className="py-12 sm:py-20 bg-gray-50">
                 <div className="container mx-auto px-4 sm:px-6">
-                    <h2 className="text-2xl sm:text-4xl font-bold text-azul-monte-tabor text-center mb-8 sm:mb-12 font-serif">Calendario de Admisión 2025</h2>
+                    <div className="text-center mb-12 sm:mb-16">
+                        <h2 className="text-2xl sm:text-4xl font-bold text-azul-monte-tabor mb-3 font-serif">Calendario de Admisión 2027</h2>
+                        <p className="text-dorado-nazaret font-medium">Fechas clave e hitos importantes para tu postulación</p>
+                    </div>
                     {/* Desktop: alternating timeline */}
                     <div className="hidden sm:block relative max-w-3xl mx-auto">
-                        <div className="absolute left-1/2 h-full w-1 bg-azul-monte-tabor rounded-full transform -translate-x-1/2"></div>
+                        <div className="absolute left-1/2 h-full w-0.5 bg-gray-300 transform -translate-x-1/2"></div>
                         {admissionTimeline.map((item, index) => (
-                            <div key={index} className={`flex items-center w-full mb-8 ${index % 2 === 0 ? 'justify-start' : 'justify-end'}`}>
-                                <div className={`w-5/12 ${index % 2 === 0 ? 'text-right pr-8' : 'text-left pl-8'}`}>
-                                    <p className="font-bold text-dorado-nazaret">{item.date}</p>
-                                    <p className="text-gris-piedra">{item.event}</p>
+                            <div key={index} className="flex items-center w-full mb-16">
+                                <div className="flex-1 pr-10 text-right">
+                                    {index % 2 === 0 ? (
+                                        <>
+                                            <p className={`text-xs font-bold uppercase tracking-wider mb-1 ${item.status === 'future' ? 'text-gray-400' : 'text-dorado-nazaret'}`}>{item.date}</p>
+                                            <p className={`font-bold text-base ${item.status === 'future' ? 'text-gray-400' : 'text-azul-monte-tabor'}`}>{item.event}</p>
+                                        </>
+                                    ) : (
+                                        <p className="text-gris-piedra text-sm">{item.description}</p>
+                                    )}
                                 </div>
-                                <div className="relative">
-                                    <div className={`w-8 h-8 rounded-full flex items-center justify-center z-10 ${item.current ? 'bg-dorado-nazaret ring-8 ring-amber-200' : 'bg-azul-monte-tabor'}`}>
-                                        <Clock className="w-5 h-5 text-blanco-pureza" />
-                                    </div>
+                                <div className="flex-shrink-0 z-10 w-3">
+                                    <div className={`w-3 h-3 rounded-full ${item.current ? 'bg-dorado-nazaret' : item.status === 'future' ? 'bg-gray-300' : 'bg-azul-monte-tabor'}`}></div>
                                 </div>
-                                <div className="w-5/12"></div>
+                                <div className="flex-1 pl-10 text-left">
+                                    {index % 2 === 0 ? (
+                                        <p className="text-gris-piedra text-sm">{item.description}</p>
+                                    ) : (
+                                        <>
+                                            <p className={`text-xs font-bold uppercase tracking-wider mb-1 ${item.status === 'future' ? 'text-gray-400' : 'text-dorado-nazaret'}`}>{item.date}</p>
+                                            <p className={`font-bold text-base ${item.status === 'future' ? 'text-gray-400' : 'text-azul-monte-tabor'}`}>{item.event}</p>
+                                        </>
+                                    )}
+                                </div>
                             </div>
                         ))}
                     </div>
                     {/* Mobile: vertical list */}
                     <div className="sm:hidden space-y-4 max-w-sm mx-auto">
                         {admissionTimeline.map((item, index) => (
-                            <div key={index} className={`flex items-start gap-4 p-4 rounded-lg border-l-4 ${item.current ? 'border-dorado-nazaret bg-amber-50' : 'border-azul-monte-tabor bg-gray-50'}`}>
-                                <div className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${item.current ? 'bg-dorado-nazaret' : 'bg-azul-monte-tabor'}`}>
-                                    <Clock className="w-4 h-4 text-blanco-pureza" />
-                                </div>
+                            <div key={index} className={`flex items-start gap-4 p-4 rounded-lg border-l-4 ${item.current ? 'border-dorado-nazaret bg-amber-50' : item.status === 'future' ? 'border-gray-300 bg-gray-100' : 'border-azul-monte-tabor bg-blanco-pureza'}`}>
+                                <div className={`w-3 h-3 rounded-full mt-1 flex-shrink-0 ${item.current ? 'bg-dorado-nazaret' : item.status === 'future' ? 'bg-gray-300' : 'bg-azul-monte-tabor'}`}></div>
                                 <div>
-                                    <p className="font-bold text-dorado-nazaret text-sm">{item.date}</p>
-                                    <p className="text-gris-piedra text-sm">{item.event}</p>
+                                    <p className={`text-xs font-bold uppercase tracking-wider mb-1 ${item.status === 'future' ? 'text-gray-400' : 'text-dorado-nazaret'}`}>{item.date}</p>
+                                    <p className={`font-bold text-sm mb-1 ${item.status === 'future' ? 'text-gray-400' : 'text-azul-monte-tabor'}`}>{item.event}</p>
+                                    <p className="text-gris-piedra text-sm">{item.description}</p>
                                 </div>
                             </div>
                         ))}
@@ -139,17 +166,17 @@ const HomePage: React.FC = () => {
             </section>
 
             {/* Sección de Contacto */}
-            <section className="py-12 sm:py-16 bg-azul-monte-tabor text-blanco-pureza">
+            <section className="py-12 sm:py-16 bg-blanco-pureza border-t border-gray-200">
                 <div className="container mx-auto px-4 sm:px-6 text-center">
-                    <h2 className="text-3xl font-bold mb-8">¿Tienes Preguntas?</h2>
-                    <p className="text-xl mb-8">
+                    <h2 className="text-2xl sm:text-3xl font-bold text-azul-monte-tabor mb-4 font-serif">¿Tienes Preguntas?</h2>
+                    <p className="text-gris-piedra text-lg mb-8 max-w-2xl mx-auto">
                         Nuestro equipo está aquí para ayudarte en todo el proceso de admisión
                     </p>
                     <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                        <Button variant="outline" size="lg" className="text-blanco-pureza border-blanco-pureza hover:bg-blanco-pureza hover:text-azul-monte-tabor">
+                        <Button variant="outline" size="lg">
                             Contactar Admisión
                         </Button>
-                        <Button variant="primary" size="lg">
+                        <Button variant="secondary" size="lg">
                             Agendar Visita
                         </Button>
                     </div>

--- a/microfrontends/apps/mf-admissions/pages/HomePage.tsx
+++ b/microfrontends/apps/mf-admissions/pages/HomePage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import Button from '../components/ui/Button';
 import Card from '../components/ui/Card';
-import { FileText, Users, CheckCircle, Clock, Calendar, Calculator, BookOpen, Globe } from 'lucide-react';
+import { FileText, Users, CheckCircle, Calculator, BookOpen, Globe } from 'lucide-react';
 import { microfrontendUrls } from '../utils/microfrontendUrls';
 
 const HomePage: React.FC = () => {
@@ -13,30 +13,42 @@ const HomePage: React.FC = () => {
     ];
 
     const admissionTimeline = [
-        { date: '1 de Agosto', event: 'Inicio del Proceso de Postulación', current: true },
-        { date: '30 de Septiembre', event: 'Cierre de Postulaciones', current: false },
-        { date: '1 al 15 de Octubre', event: 'Periodo de Entrevistas', current: false },
-        { date: '1 de Noviembre', event: 'Publicación de Resultados', current: false },
+        {
+            date: 'AGOSTO 2025',
+            event: 'Apertura de Postulaciones',
+            description: 'Inicio del periodo oficial para la recepción de documentos y solicitudes en línea.',
+            current: true,
+            status: 'active',
+        },
+        {
+            date: 'SEPTIEMBRE - OCTUBRE 2025',
+            event: 'Exámenes y Entrevistas',
+            description: 'Periodo de evaluaciones académicas y encuentros personales con las familias postulantes.',
+            current: false,
+            status: 'upcoming',
+        },
+        {
+            date: 'NOVIEMBRE 2025',
+            event: 'Publicación de Resultados',
+            description: 'Comunicación oficial de las admisiones y formalización de la matrícula para el ciclo 2026.',
+            current: false,
+            status: 'future',
+        },
     ];
 
     return (
         <div className="bg-blanco-pureza">
             {/* Hero Section */}
-            <section className="relative text-blanco-pureza py-20 sm:py-32 text-center bg-cover bg-center" style={{ backgroundImage: `url('/images/colegio.png')`}}>
+            <section className="relative text-blanco-pureza py-[7.5rem] sm:py-48 text-center bg-cover bg-center" style={{ backgroundImage: `url('/images/colegio.png')`}}>
                 {/* Overlay azul con opacidad 85% */}
-                <div className="absolute inset-0 bg-azul-monte-tabor" style={{ opacity: 0.85 }}></div>
+                <div className="absolute inset-0 bg-azul-monte-tabor" style={{ opacity: 0.85, filter: 'brightness(0.75)' }}></div>
                 <div className="relative container mx-auto px-4 sm:px-6">
-                    <h1 className="text-3xl sm:text-5xl md:text-6xl font-black font-serif mb-4 animate-fade-in-down">Formando Líderes con Espíritu de Servicio</h1>
-                    <p className="text-base sm:text-xl text-gray-200 mb-8 max-w-3xl mx-auto">Únase a una comunidad educativa comprometida con la excelencia académica y la formación católica.</p>
-                    <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center items-center">
-                        <a href={microfrontendUrls.guardianLogin}>
-                            <Button size="lg" variant="primary">
-                                Postular Aquí
-                            </Button>
-                        </a>
-                        <a href={microfrontendUrls.guardianLogin}>
-                            <Button size="lg" variant="secondary">
-                                Portal Apoderados
+                    <h1 className="text-3xl sm:text-5xl md:text-6xl font-black font-serif mb-4 animate-fade-in-down">Formando líderes con espíritu de servicio</h1>
+                    <p className="text-base sm:text-xl text-gray-200 mb-8 max-w-3xl mx-auto">Únanse a una comunidad educativa comprometida con la excelencia académica y formación católica</p>
+                    <div className="flex justify-center">
+                        <a href={microfrontendUrls.admissions}>
+                            <Button size="lg" variant="primary" className="!text-blanco-pureza">
+                                Iniciar postulación
                             </Button>
                         </a>
                     </div>
@@ -45,50 +57,50 @@ const HomePage: React.FC = () => {
 
             {/* Steps Section */}
             <section className="py-12 sm:py-20 bg-gray-50">
-                <div className="container mx-auto px-4 sm:px-6 text-center">
-                    <h2 className="text-2xl sm:text-4xl font-bold text-azul-monte-tabor mb-4 font-serif">Proceso de Admisión</h2>
-                    <p className="text-gris-piedra mb-12 max-w-2xl mx-auto">Un camino claro y guiado para formar parte de nuestra comunidad educativa.</p>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 sm:gap-10">
+                <div className="container mx-auto px-4 sm:px-6">
+                    <h2 className="text-2xl sm:text-4xl font-bold text-azul-monte-tabor mb-4 font-serif text-center">Proceso de Admisión</h2>
+                    <p className="text-gris-piedra mb-12 max-w-2xl mx-auto text-center">Un camino claro y guiado para formar parte de nuestra comunidad educativa.</p>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-6">
                         {admissionSteps.map((step, index) => (
-                            <Card key={index} className="text-center p-8">
-                                <div className="flex justify-center mb-6">{step.icon}</div>
-                                <h3 className="text-xl font-bold text-azul-monte-tabor mb-2">{step.title}</h3>
-                                <p className="text-gris-piedra">{step.description}</p>
-                            </Card>
+                            <div key={index} className="bg-blanco-pureza p-8 rounded-2xl border border-gray-200 text-center">
+                                <div className="flex justify-center mb-4">{step.icon}</div>
+                                <h3 className="text-lg font-bold text-azul-monte-tabor mb-3">{step.title}</h3>
+                                <p className="text-gris-piedra text-sm">{step.description}</p>
+                            </div>
                         ))}
                     </div>
                 </div>
             </section>
 
             {/* Exam Portal Section */}
-            <section className="py-12 sm:py-20 bg-azul-monte-tabor text-blanco-pureza">
+            <section className="py-12 sm:py-20 bg-gray-100">
                 <div className="container mx-auto px-4 sm:px-6 text-center">
-                    <h2 className="text-2xl sm:text-4xl font-bold mb-4 font-serif">Portal de Exámenes de Admisión</h2>
-                    <p className="text-gray-200 mb-8 max-w-3xl mx-auto text-base sm:text-lg">
-                        Una vez completada tu postulación, podrás acceder al portal de exámenes para programar 
+                    <h2 className="text-2xl sm:text-4xl font-bold text-azul-monte-tabor mb-4 font-serif">Portal de Exámenes de Admisión</h2>
+                    <p className="text-gris-piedra mb-8 max-w-3xl mx-auto text-base sm:text-lg">
+                        Una vez completada tu postulación, podrás acceder al portal de exámenes para programar
                         y rendir las evaluaciones de Matemática, Lenguaje e Inglés.
                     </p>
-                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6 mb-8">
-                        <div className="bg-blanco-pureza bg-opacity-10 p-6 rounded-lg">
-                            <div className="flex justify-center mb-3">
-                                <Calculator className="w-12 h-12 text-dorado-nazaret" />
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6 mb-8 text-center">
+                        <div className="bg-blanco-pureza p-8 rounded-2xl border border-gray-200">
+                            <div className="flex justify-center mb-4">
+                                <Calculator className="w-10 h-10 text-dorado-nazaret" />
                             </div>
-                            <h3 className="font-bold text-dorado-nazaret mb-2">Matemática</h3>
-                            <p className="text-gray-200 text-sm">Evaluación adaptada según tu nivel educativo</p>
+                            <h3 className="font-bold text-azul-monte-tabor text-lg mb-3">Matemática</h3>
+                            <p className="text-gris-piedra text-sm">Evaluación adaptada según tu nivel educativo</p>
                         </div>
-                        <div className="bg-blanco-pureza bg-opacity-10 p-6 rounded-lg">
-                            <div className="flex justify-center mb-3">
-                                <BookOpen className="w-12 h-12 text-dorado-nazaret" />
+                        <div className="bg-blanco-pureza p-8 rounded-2xl border border-gray-200">
+                            <div className="flex justify-center mb-4">
+                                <BookOpen className="w-10 h-10 text-dorado-nazaret" />
                             </div>
-                            <h3 className="font-bold text-dorado-nazaret mb-2">Lenguaje</h3>
-                            <p className="text-gray-200 text-sm">Comprensión lectora y expresión escrita</p>
+                            <h3 className="font-bold text-azul-monte-tabor text-lg mb-3">Lenguaje</h3>
+                            <p className="text-gris-piedra text-sm">Comprensión lectora y expresión escrita</p>
                         </div>
-                        <div className="bg-blanco-pureza bg-opacity-10 p-6 rounded-lg">
-                            <div className="flex justify-center mb-3">
-                                <Globe className="w-12 h-12 text-dorado-nazaret" />
+                        <div className="bg-blanco-pureza p-8 rounded-2xl border border-gray-200">
+                            <div className="flex justify-center mb-4">
+                                <Globe className="w-10 h-10 text-dorado-nazaret" />
                             </div>
-                            <h3 className="font-bold text-dorado-nazaret mb-2">Inglés</h3>
-                            <p className="text-gray-200 text-sm">Gramática, vocabulario y comprensión</p>
+                            <h3 className="font-bold text-azul-monte-tabor text-lg mb-3">Inglés</h3>
+                            <p className="text-gris-piedra text-sm">Gramática, vocabulario y comprensión</p>
                         </div>
                     </div>
                     <a href={microfrontendUrls.studentExams}>
@@ -100,37 +112,52 @@ const HomePage: React.FC = () => {
             </section>
 
             {/* Timeline Section */}
-            <section className="py-12 sm:py-20">
+            <section className="py-12 sm:py-20 bg-gray-50">
                 <div className="container mx-auto px-4 sm:px-6">
-                    <h2 className="text-2xl sm:text-4xl font-bold text-azul-monte-tabor text-center mb-8 sm:mb-12 font-serif">Calendario de Admisión 2025</h2>
+                    <div className="text-center mb-12 sm:mb-16">
+                        <h2 className="text-2xl sm:text-4xl font-bold text-azul-monte-tabor mb-3 font-serif">Calendario de Admisión 2025</h2>
+                        <p className="text-dorado-nazaret font-medium">Fechas clave e hitos importantes para tu postulación</p>
+                    </div>
                     {/* Desktop: alternating timeline */}
                     <div className="hidden sm:block relative max-w-3xl mx-auto">
-                        <div className="absolute left-1/2 h-full w-1 bg-azul-monte-tabor rounded-full transform -translate-x-1/2"></div>
+                        <div className="absolute left-1/2 h-full w-0.5 bg-gray-300 transform -translate-x-1/2"></div>
                         {admissionTimeline.map((item, index) => (
-                            <div key={index} className={`flex items-center w-full mb-8 ${index % 2 === 0 ? 'justify-start' : 'justify-end'}`}>
-                                <div className={`w-5/12 ${index % 2 === 0 ? 'text-right pr-8' : 'text-left pl-8'}`}>
-                                    <p className="font-bold text-dorado-nazaret">{item.date}</p>
-                                    <p className="text-gris-piedra">{item.event}</p>
+                            <div key={index} className="flex items-center w-full mb-16">
+                                <div className="flex-1 pr-10 text-right">
+                                    {index % 2 === 0 ? (
+                                        <>
+                                            <p className={`text-xs font-bold uppercase tracking-wider mb-1 ${item.status === 'future' ? 'text-gray-400' : 'text-dorado-nazaret'}`}>{item.date}</p>
+                                            <p className={`font-bold text-base ${item.status === 'future' ? 'text-gray-400' : 'text-azul-monte-tabor'}`}>{item.event}</p>
+                                        </>
+                                    ) : (
+                                        <p className="text-gris-piedra text-sm">{item.description}</p>
+                                    )}
                                 </div>
-                                <div className="relative">
-                                    <div className={`w-8 h-8 rounded-full flex items-center justify-center z-10 ${item.current ? 'bg-dorado-nazaret ring-8 ring-amber-200' : 'bg-azul-monte-tabor'}`}>
-                                        <Clock className="w-5 h-5 text-blanco-pureza" />
-                                    </div>
+                                <div className="flex-shrink-0 z-10 w-3">
+                                    <div className={`w-3 h-3 rounded-full ${item.current ? 'bg-dorado-nazaret' : item.status === 'future' ? 'bg-gray-300' : 'bg-azul-monte-tabor'}`}></div>
                                 </div>
-                                <div className="w-5/12"></div>
+                                <div className="flex-1 pl-10 text-left">
+                                    {index % 2 === 0 ? (
+                                        <p className="text-gris-piedra text-sm">{item.description}</p>
+                                    ) : (
+                                        <>
+                                            <p className={`text-xs font-bold uppercase tracking-wider mb-1 ${item.status === 'future' ? 'text-gray-400' : 'text-dorado-nazaret'}`}>{item.date}</p>
+                                            <p className={`font-bold text-base ${item.status === 'future' ? 'text-gray-400' : 'text-azul-monte-tabor'}`}>{item.event}</p>
+                                        </>
+                                    )}
+                                </div>
                             </div>
                         ))}
                     </div>
                     {/* Mobile: vertical list */}
                     <div className="sm:hidden space-y-4 max-w-sm mx-auto">
                         {admissionTimeline.map((item, index) => (
-                            <div key={index} className={`flex items-start gap-4 p-4 rounded-lg border-l-4 ${item.current ? 'border-dorado-nazaret bg-amber-50' : 'border-azul-monte-tabor bg-gray-50'}`}>
-                                <div className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${item.current ? 'bg-dorado-nazaret' : 'bg-azul-monte-tabor'}`}>
-                                    <Clock className="w-4 h-4 text-blanco-pureza" />
-                                </div>
+                            <div key={index} className={`flex items-start gap-4 p-4 rounded-lg border-l-4 ${item.current ? 'border-dorado-nazaret bg-amber-50' : item.status === 'future' ? 'border-gray-300 bg-gray-100' : 'border-azul-monte-tabor bg-blanco-pureza'}`}>
+                                <div className={`w-3 h-3 rounded-full mt-1 flex-shrink-0 ${item.current ? 'bg-dorado-nazaret' : item.status === 'future' ? 'bg-gray-300' : 'bg-azul-monte-tabor'}`}></div>
                                 <div>
-                                    <p className="font-bold text-dorado-nazaret text-sm">{item.date}</p>
-                                    <p className="text-gris-piedra text-sm">{item.event}</p>
+                                    <p className={`text-xs font-bold uppercase tracking-wider mb-1 ${item.status === 'future' ? 'text-gray-400' : 'text-dorado-nazaret'}`}>{item.date}</p>
+                                    <p className={`font-bold text-sm mb-1 ${item.status === 'future' ? 'text-gray-400' : 'text-azul-monte-tabor'}`}>{item.event}</p>
+                                    <p className="text-gris-piedra text-sm">{item.description}</p>
                                 </div>
                             </div>
                         ))}
@@ -139,17 +166,17 @@ const HomePage: React.FC = () => {
             </section>
 
             {/* Sección de Contacto */}
-            <section className="py-12 sm:py-16 bg-azul-monte-tabor text-blanco-pureza">
+            <section className="py-12 sm:py-16 bg-blanco-pureza border-t border-gray-200">
                 <div className="container mx-auto px-4 sm:px-6 text-center">
-                    <h2 className="text-3xl font-bold mb-8">¿Tienes Preguntas?</h2>
-                    <p className="text-xl mb-8">
+                    <h2 className="text-2xl sm:text-3xl font-bold text-azul-monte-tabor mb-4 font-serif">¿Tienes Preguntas?</h2>
+                    <p className="text-gris-piedra text-lg mb-8 max-w-2xl mx-auto">
                         Nuestro equipo está aquí para ayudarte en todo el proceso de admisión
                     </p>
                     <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                        <Button variant="outline" size="lg" className="text-blanco-pureza border-blanco-pureza hover:bg-blanco-pureza hover:text-azul-monte-tabor">
+                        <Button variant="outline" size="lg">
                             Contactar Admisión
                         </Button>
-                        <Button variant="primary" size="lg">
+                        <Button variant="secondary" size="lg">
                             Agendar Visita
                         </Button>
                     </div>

--- a/microfrontends/apps/mf-admissions/services/interviewService.ts
+++ b/microfrontends/apps/mf-admissions/services/interviewService.ts
@@ -796,14 +796,14 @@ class InterviewService {
       const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
       if (!dateRegex.test(date)) {
         console.error(`getAvailableTimeSlots: Formato de fecha inválido "${date}". Se esperaba YYYY-MM-DD`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Verificar que el año sea razonable
       const year = parseInt(date.split('-')[0]);
       if (year < 2020 || year > 2100) {
         console.error(`getAvailableTimeSlots: Año inválido ${year}. Debe estar entre 2020 y 2100`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Validar y usar duración por defecto si es inválida
@@ -825,8 +825,8 @@ class InterviewService {
 
       // Verificar si la respuesta es del placeholder (microservicio no implementado)
       if (response.data && typeof response.data === 'object' && 'error' in response.data) {
-        console.log('Available slots service no implementado, usando horarios por defecto');
-        return this.getDefaultTimeSlots();
+        console.log('Available slots service no implementado, devolviendo horarios vacíos');
+        return [];
       }
 
       // CASO 1: Backend devuelve estructura { success: true, data: { availableSlots: [...] } }
@@ -878,13 +878,12 @@ class InterviewService {
         }
       }
 
-      console.log('Estructura de respuesta inesperada para available slots, usando horarios por defecto');
+      console.log('Estructura de respuesta inesperada para available slots, devolviendo horarios vacíos');
       console.log('Data recibida:', response.data);
-      return this.getDefaultTimeSlots();
+      return [];
     } catch (error) {
       console.error('Error fetching available slots:', error);
-      // Fallback: horarios estándar si el backend no los tiene configurados
-      return this.getDefaultTimeSlots();
+      return [];
     }
   }
 
@@ -979,14 +978,14 @@ class InterviewService {
       const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
       if (!dateRegex.test(date)) {
         console.error(`getCommonTimeSlots: Formato de fecha inválido "${date}". Se esperaba YYYY-MM-DD`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Verificar que el año sea razonable
       const year = parseInt(date.split('-')[0]);
       if (year < 2020 || year > 2100) {
         console.error(`getCommonTimeSlots: Año inválido ${year}. Debe estar entre 2020 y 2100`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Obtener los horarios disponibles de ambos entrevistadores
@@ -1006,8 +1005,7 @@ class InterviewService {
       return commonSlots;
     } catch (error) {
       console.error('Error obteniendo horarios comunes:', error);
-      // Fallback: horarios por defecto
-      return this.getDefaultTimeSlots();
+      return [];
     }
   }
 

--- a/microfrontends/apps/mf-admissions/src/components/charts/EChart.tsx
+++ b/microfrontends/apps/mf-admissions/src/components/charts/EChart.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactECharts from 'echarts-for-react';
+import type { EChartsOption } from 'echarts';
+
+interface EChartProps {
+  option: EChartsOption;
+  height?: number;
+  onEvents?: Record<string, (params: any) => void>;
+}
+
+const EChart: React.FC<EChartProps> = ({ option, height = 300, onEvents }) => (
+  <ReactECharts
+    option={option}
+    notMerge
+    lazyUpdate
+    onEvents={onEvents}
+    style={{ width: '100%', height }}
+  />
+);
+
+export default EChart;

--- a/microfrontends/apps/mf-admissions/src/components/coordinator/CoordinatorDashboard.tsx
+++ b/microfrontends/apps/mf-admissions/src/components/coordinator/CoordinatorDashboard.tsx
@@ -9,7 +9,8 @@
 import React, { useState, useEffect } from 'react';
 import { dashboardClient } from '../../api/dashboard.client';
 import type { DetailedAdminStats, Alert } from '../../api/dashboard.types';
-import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { ApplicantMetricsModal } from '../../../components/modals/ApplicantMetricsModal';
 
 export const CoordinatorDashboard: React.FC = () => {
@@ -143,6 +144,32 @@ export const CoordinatorDashboard: React.FC = () => {
   const acceptanceRate = stats.totalApplications > 0
     ? ((stats.statusBreakdown.approved / stats.totalApplications) * 100).toFixed(1)
     : '0.0';
+
+  const statusChartOption: EChartsOption = {
+    color: statusData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [
+      {
+        type: 'pie',
+        radius: ['42%', '70%'],
+        center: ['50%', '50%'],
+        avoidLabelOverlap: true,
+        itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+        label: { formatter: '{b}: {d}%' },
+        data: statusData.map(item => ({ name: item.name, value: item.value }))
+      }
+    ]
+  };
+
+  const gradeChartOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: gradeData.map(item => item.grade), axisTick: { alignWithLabel: true } },
+    yAxis: { type: 'value' },
+    series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 42 }]
+  };
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -336,25 +363,7 @@ export const CoordinatorDashboard: React.FC = () => {
         {/* Status Distribution Pie Chart */}
         <div className="bg-white shadow rounded-lg p-6">
           <h2 className="text-lg font-medium text-gray-900 mb-4">Distribución por Estado</h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie
-                data={statusData}
-                cx="50%"
-                cy="50%"
-                labelLine={false}
-                label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
-                outerRadius={80}
-                fill="#8884d8"
-                dataKey="value"
-              >
-                {statusData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
-                ))}
-              </Pie>
-              <Tooltip />
-            </PieChart>
-          </ResponsiveContainer>
+          <EChart option={statusChartOption} height={300} />
           <div className="mt-4 grid grid-cols-2 gap-2 text-sm">
             {statusData.map((item, index) => (
               <div key={index} className="flex items-center">
@@ -371,16 +380,7 @@ export const CoordinatorDashboard: React.FC = () => {
         {/* Grade Distribution Bar Chart */}
         <div className="bg-white shadow rounded-lg p-6">
           <h2 className="text-lg font-medium text-gray-900 mb-4">Distribución por Nivel</h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={gradeData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="grade" />
-              <YAxis />
-              <Tooltip />
-              <Legend />
-              <Bar dataKey="count" fill="#3B82F6" name="Postulaciones" />
-            </BarChart>
-          </ResponsiveContainer>
+          <EChart option={gradeChartOption} height={300} />
         </div>
       </div>
 

--- a/microfrontends/apps/mf-admissions/src/components/coordinator/TemporalTrendsView.tsx
+++ b/microfrontends/apps/mf-admissions/src/components/coordinator/TemporalTrendsView.tsx
@@ -8,7 +8,8 @@
 import React, { useState, useEffect } from 'react';
 import { dashboardClient } from '../../api/dashboard.client';
 import type { TemporalTrend, DetailedAdminStats } from '../../api/dashboard.types';
-import { LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { format } from 'date-fns';
 
 export const TemporalTrendsView: React.FC = () => {
@@ -114,6 +115,52 @@ export const TemporalTrendsView: React.FC = () => {
     };
   }).filter(Boolean);
 
+  const monthlyTrendsOption: EChartsOption = {
+    color: ['#3B82F6', '#10B981', '#EF4444', '#F59E0B'],
+    tooltip: { trigger: 'axis' },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 48, top: 24, bottom: 80, containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: monthlyTrendsData.map(item => item.month),
+      axisLabel: { rotate: 45 }
+    },
+    yAxis: [
+      { type: 'value', name: 'Postulaciones' },
+      { type: 'value', name: '%' }
+    ],
+    series: [
+      { name: 'Total Postulaciones', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.total) },
+      { name: 'Aprobadas', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.approved) },
+      { name: 'Rechazadas', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.rejected) },
+      { name: 'Tasa de Crecimiento (%)', type: 'line', smooth: true, yAxisIndex: 1, lineStyle: { type: 'dashed' }, data: monthlyTrendsData.map(item => item.growthRate) }
+    ]
+  };
+
+  const comparisonOption: EChartsOption = {
+    color: ['#3B82F6', '#10B981', '#EF4444'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: comparisonData.map((item: any) => item.year) },
+    yAxis: { type: 'value' },
+    series: [
+      { name: 'Total', type: 'bar', data: comparisonData.map((item: any) => item.total) },
+      { name: 'Aprobadas', type: 'bar', data: comparisonData.map((item: any) => item.approved) },
+      { name: 'Rechazadas', type: 'bar', data: comparisonData.map((item: any) => item.rejected) }
+    ]
+  };
+
+  const acceptanceRateOption: EChartsOption = {
+    color: ['#10B981'],
+    tooltip: { trigger: 'axis', valueFormatter: value => `${Number(value).toFixed(1)}%` },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: comparisonData.map((item: any) => item.year) },
+    yAxis: { type: 'value', min: 0, max: 100 },
+    series: [{ name: 'Tasa de Aceptación (%)', type: 'bar', data: comparisonData.map((item: any) => item.acceptanceRate), barMaxWidth: 48 }]
+  };
+
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       {/* Header */}
@@ -147,50 +194,7 @@ export const TemporalTrendsView: React.FC = () => {
       {/* Monthly Trends Chart */}
       <div className="bg-white shadow rounded-lg p-6 mb-6">
         <h2 className="text-lg font-medium text-gray-900 mb-4">Tendencia Mensual (Últimos 12 meses)</h2>
-        <ResponsiveContainer width="100%" height={400}>
-          <LineChart data={monthlyTrendsData}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="month" angle={-45} textAnchor="end" height={80} />
-            <YAxis yAxisId="left" />
-            <YAxis yAxisId="right" orientation="right" />
-            <Tooltip />
-            <Legend />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="total"
-              stroke="#3B82F6"
-              strokeWidth={2}
-              name="Total Postulaciones"
-              dot={{ r: 4 }}
-            />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="approved"
-              stroke="#10B981"
-              strokeWidth={2}
-              name="Aprobadas"
-            />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="rejected"
-              stroke="#EF4444"
-              strokeWidth={2}
-              name="Rechazadas"
-            />
-            <Line
-              yAxisId="right"
-              type="monotone"
-              dataKey="growthRate"
-              stroke="#F59E0B"
-              strokeWidth={2}
-              name="Tasa de Crecimiento (%)"
-              strokeDasharray="5 5"
-            />
-          </LineChart>
-        </ResponsiveContainer>
+        <EChart option={monthlyTrendsOption} height={400} />
       </div>
 
       {/* Year Comparison */}
@@ -199,33 +203,13 @@ export const TemporalTrendsView: React.FC = () => {
           {/* Total Applications Comparison */}
           <div className="bg-white shadow rounded-lg p-6">
             <h2 className="text-lg font-medium text-gray-900 mb-4">Comparativa de Postulaciones</h2>
-            <ResponsiveContainer width="100%" height={300}>
-              <BarChart data={comparisonData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="year" />
-                <YAxis />
-                <Tooltip />
-                <Legend />
-                <Bar dataKey="total" fill="#3B82F6" name="Total" />
-                <Bar dataKey="approved" fill="#10B981" name="Aprobadas" />
-                <Bar dataKey="rejected" fill="#EF4444" name="Rechazadas" />
-              </BarChart>
-            </ResponsiveContainer>
+            <EChart option={comparisonOption} height={300} />
           </div>
 
           {/* Acceptance Rate Comparison */}
           <div className="bg-white shadow rounded-lg p-6">
             <h2 className="text-lg font-medium text-gray-900 mb-4">Tasa de Aceptación por Año</h2>
-            <ResponsiveContainer width="100%" height={300}>
-              <BarChart data={comparisonData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="year" />
-                <YAxis domain={[0, 100]} />
-                <Tooltip formatter={(value) => `${Number(value).toFixed(1)}%`} />
-                <Legend />
-                <Bar dataKey="acceptanceRate" fill="#10B981" name="Tasa de Aceptación (%)" />
-              </BarChart>
-            </ResponsiveContainer>
+            <EChart option={acceptanceRateOption} height={300} />
           </div>
         </div>
       )}

--- a/microfrontends/apps/mf-admissions/utils/microfrontendUrls.ts
+++ b/microfrontends/apps/mf-admissions/utils/microfrontendUrls.ts
@@ -44,7 +44,7 @@ const buildUrl = (app: keyof typeof localPorts, hashPath: string) => {
 
 export const microfrontendUrls = {
   home: buildUrl('admissions', '/'),
-  admissions: buildUrl('admissions', '/postulacion'),
+  admissions: buildUrl('admissions', '/apoderado/login'),
   admissionsComplementary: buildUrl('admissions', '/postulacion/complementaria'),
   guardianLogin: buildUrl('guardian', '/apoderado/login'),
   guardianDashboard: buildUrl('guardian', '/familia'),

--- a/microfrontends/apps/mf-admissions/utils/microfrontendUrls.ts
+++ b/microfrontends/apps/mf-admissions/utils/microfrontendUrls.ts
@@ -44,7 +44,7 @@ const buildUrl = (app: keyof typeof localPorts, hashPath: string) => {
 
 export const microfrontendUrls = {
   home: buildUrl('admissions', '/'),
-  admissions: buildUrl('admin', '/apoderado/login'),
+  admissions: buildUrl('admissions', '/postulacion'),
   admissionsComplementary: buildUrl('admissions', '/postulacion/complementaria'),
   guardianLogin: buildUrl('guardian', '/apoderado/login'),
   guardianDashboard: buildUrl('guardian', '/familia'),

--- a/microfrontends/apps/mf-admissions/utils/microfrontendUrls.ts
+++ b/microfrontends/apps/mf-admissions/utils/microfrontendUrls.ts
@@ -44,7 +44,7 @@ const buildUrl = (app: keyof typeof localPorts, hashPath: string) => {
 
 export const microfrontendUrls = {
   home: buildUrl('admissions', '/'),
-  admissions: buildUrl('admissions', '/postulacion'),
+  admissions: buildUrl('admin', '/apoderado/login'),
   admissionsComplementary: buildUrl('admissions', '/postulacion/complementaria'),
   guardianLogin: buildUrl('guardian', '/apoderado/login'),
   guardianDashboard: buildUrl('guardian', '/familia'),

--- a/microfrontends/apps/mf-coordinator/components/admin/AnalyticsView.tsx
+++ b/microfrontends/apps/mf-coordinator/components/admin/AnalyticsView.tsx
@@ -6,7 +6,8 @@
 import React, { useState, useEffect } from 'react';
 import { FiTrendingUp, FiUsers, FiAward, FiClock } from 'react-icons/fi';
 import Card from '../ui/Card';
-import { BarChart, Bar, LineChart, Line, RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { dashboardClient } from '../../src/api/dashboard.client';
 
 export const AnalyticsView: React.FC = () => {
@@ -54,7 +55,34 @@ export const AnalyticsView: React.FC = () => {
         );
     }
 
-    const COLORS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899'];
+    const evaluatorPerformanceOption: EChartsOption = {
+        color: ['#10B981', '#F59E0B'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: evaluatorData.map(item => item.name) },
+        yAxis: { type: 'value' },
+        series: [
+            { name: 'Completadas', type: 'bar', data: evaluatorData.map(item => item.completed) },
+            { name: 'Pendientes', type: 'bar', data: evaluatorData.map(item => item.pending) }
+        ]
+    };
+
+    const radarData = evaluatorData.slice(0, 6);
+    const evaluatorWorkloadOption: EChartsOption = {
+        color: ['#3B82F6'],
+        tooltip: {},
+        radar: {
+            indicator: radarData.map(item => ({ name: item.name, max: Math.max(...radarData.map(e => e.total || 0), 1) })),
+            splitArea: { areaStyle: { color: ['rgba(59, 130, 246, 0.04)', 'rgba(59, 130, 246, 0.1)'] } }
+        },
+        series: [{
+            name: 'Evaluaciones',
+            type: 'radar',
+            areaStyle: { opacity: 0.35 },
+            data: [{ name: 'Evaluaciones', value: radarData.map(item => item.total || 0) }]
+        }]
+    };
 
     return (
         <div className="space-y-6">
@@ -136,31 +164,13 @@ export const AnalyticsView: React.FC = () => {
                 {/* Evaluator Performance */}
                 <Card className="p-6">
                     <h3 className="text-lg font-semibold text-gray-900 mb-4">Rendimiento de Evaluadores</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <BarChart data={evaluatorData}>
-                            <CartesianGrid strokeDasharray="3 3" />
-                            <XAxis dataKey="name" />
-                            <YAxis />
-                            <Tooltip />
-                            <Legend />
-                            <Bar dataKey="completed" fill="#10B981" name="Completadas" />
-                            <Bar dataKey="pending" fill="#F59E0B" name="Pendientes" />
-                        </BarChart>
-                    </ResponsiveContainer>
+                    <EChart option={evaluatorPerformanceOption} height={300} />
                 </Card>
 
                 {/* Evaluator Workload Radar */}
                 <Card className="p-6">
                     <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución de Carga de Trabajo</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <RadarChart data={evaluatorData.slice(0, 6)}>
-                            <PolarGrid />
-                            <PolarAngleAxis dataKey="name" />
-                            <PolarRadiusAxis />
-                            <Radar name="Evaluaciones" dataKey="total" stroke="#3B82F6" fill="#3B82F6" fillOpacity={0.6} />
-                            <Tooltip />
-                        </RadarChart>
-                    </ResponsiveContainer>
+                    <EChart option={evaluatorWorkloadOption} height={300} />
                 </Card>
             </div>
 

--- a/microfrontends/apps/mf-coordinator/components/admin/ApplicantMetricsView.tsx
+++ b/microfrontends/apps/mf-coordinator/components/admin/ApplicantMetricsView.tsx
@@ -5,7 +5,8 @@ import Badge from '../ui/Badge';
 import Button from '../ui/Button';
 import { dashboardClient } from '../../src/api/dashboard.client';
 import type { ApplicantMetric, ApplicantMetricsFilters } from '../../src/api/dashboard.types';
-import { PieChart, Pie, BarChart, Bar, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, LabelList } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 
 // Version: 2025-11-11 - Added overallOpinionScore display
 export const ApplicantMetricsView: React.FC = () => {
@@ -178,6 +179,48 @@ export const ApplicantMetricsView: React.FC = () => {
   };
 
   const { performanceData, avgData } = getChartData();
+
+  const performanceDistributionOption: EChartsOption = {
+    color: performanceData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    legend: { bottom: 0 },
+    series: [{
+      type: 'pie',
+      radius: ['42%', '70%'],
+      center: ['50%', '44%'],
+      itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+      label: { formatter: '{d}%' },
+      data: performanceData.map(item => ({ name: item.name, value: item.value }))
+    }]
+  };
+
+  const examAverageOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', valueFormatter: value => `${value}%` },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 24, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: avgData.map(item => item.name) },
+    yAxis: { type: 'value', min: 0, max: 100 },
+    series: [{
+      name: 'Promedio (%)',
+      type: 'bar',
+      data: avgData.map(item => item.promedio),
+      barMaxWidth: 48,
+      label: { show: true, position: 'top', formatter: '{c}%' }
+    }]
+  };
+
+  const subjectDistributionOption: EChartsOption = {
+    color: subjectDistribution.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [{
+      type: 'pie',
+      radius: ['42%', '72%'],
+      itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+      label: { formatter: '{b}: {d}%' },
+      data: subjectDistribution.map(item => ({ name: item.name, value: item.value }))
+    }]
+  };
 
   const uniqueGrades = [...new Set(applicants.map(a => a.gradeApplied))].sort();
   const uniqueStatuses = [...new Set(applicants.map(a => a.applicationStatus))];
@@ -420,56 +463,17 @@ export const ApplicantMetricsView: React.FC = () => {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <Card className="p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución de Rendimiento</h3>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie
-                data={performanceData}
-                cx="50%"
-                cy="50%"
-                labelLine={false}
-                label={({ percent }: { percent?: number }) => `${Math.round((percent || 0) * 100)}%`}
-                outerRadius={80}
-                fill="#8884d8"
-                dataKey="value"
-              >
-                {performanceData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
-                ))}
-              </Pie>
-              <Tooltip />
-              <Legend
-                verticalAlign="bottom"
-                height={36}
-                formatter={(value, entry: any) => entry.payload.name}
-              />
-            </PieChart>
-          </ResponsiveContainer>
+          <EChart option={performanceDistributionOption} height={300} />
         </Card>
 
         <Card className="p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Promedio por Examen</h3>
           <p className="text-sm text-gray-500 mb-2">Haz clic en una barra para ver la distribución detallada</p>
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={avgData} onClick={(data) => {
-              if (data && data.activeLabel) {
-                handleSubjectClick(data.activeLabel);
-              }
-            }}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
-              <YAxis domain={[0, 100]} />
-              <Tooltip />
-              <Legend />
-              <Bar
-                dataKey="promedio"
-                fill="#3B82F6"
-                name="Promedio (%)"
-                cursor="pointer"
-              >
-                <LabelList dataKey="promedio" position="top" formatter={(value: number) => `${value}%`} />
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+          <EChart
+            option={examAverageOption}
+            height={300}
+            onEvents={{ click: params => params.name && handleSubjectClick(String(params.name)) }}
+          />
         </Card>
       </div>
 
@@ -680,27 +684,7 @@ export const ApplicantMetricsView: React.FC = () => {
               </div>
 
               <div className="mb-6">
-                <ResponsiveContainer width="100%" height={350}>
-                  <PieChart>
-                    <Pie
-                      data={subjectDistribution}
-                      cx="50%"
-                      cy="50%"
-                      labelLine={false}
-                      label={({ name, percent }: { name: string, percent?: number }) =>
-                        `${name}: ${Math.round((percent || 0) * 100)}%`
-                      }
-                      outerRadius={120}
-                      fill="#8884d8"
-                      dataKey="value"
-                    >
-                      {subjectDistribution.map((entry, index) => (
-                        <Cell key={`cell-${index}`} fill={entry.color} />
-                      ))}
-                    </Pie>
-                    <Tooltip />
-                  </PieChart>
-                </ResponsiveContainer>
+                <EChart option={subjectDistributionOption} height={350} />
               </div>
 
               <div className="border-t pt-4">

--- a/microfrontends/apps/mf-coordinator/components/admin/ReportsView.tsx
+++ b/microfrontends/apps/mf-coordinator/components/admin/ReportsView.tsx
@@ -7,7 +7,8 @@ import React, { useState, useEffect } from 'react';
 import { FiDownload, FiFilter, FiCalendar, FiBarChart2, FiPieChart, FiTrendingUp } from 'react-icons/fi';
 import Card from '../ui/Card';
 import Button from '../ui/Button';
-import { BarChart, Bar, PieChart, Pie, LineChart, Line, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { dashboardClient } from '../../src/api/dashboard.client';
 
 interface ReportFilters {
@@ -85,6 +86,64 @@ export const ReportsView: React.FC = () => {
     };
 
     const COLORS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899'];
+
+    const statusBarOption: EChartsOption = {
+        color: ['#3B82F6'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: statusData.map(item => item.name) },
+        yAxis: { type: 'value' },
+        series: [{ name: 'Cantidad', type: 'bar', data: statusData.map(item => item.value), barMaxWidth: 44 }]
+    };
+
+    const statusPieOption: EChartsOption = {
+        color: COLORS,
+        tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+        series: [{
+            type: 'pie',
+            radius: ['42%', '70%'],
+            itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+            label: { formatter: '{b}: {c}' },
+            data: statusData.map(item => ({ name: item.name, value: item.value }))
+        }]
+    };
+
+    const gradeBarOption: EChartsOption = {
+        color: ['#10B981'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: gradeData.map(item => item.grade) },
+        yAxis: { type: 'value' },
+        series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 44 }]
+    };
+
+    const gradePieOption: EChartsOption = {
+        color: COLORS,
+        tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+        series: [{
+            type: 'pie',
+            radius: ['42%', '70%'],
+            itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+            label: { formatter: '{b}: {c}' },
+            data: gradeData.map(item => ({ name: item.grade, value: item.count }))
+        }]
+    };
+
+    const temporalOption: EChartsOption = {
+        color: ['#3B82F6', '#10B981', '#EF4444'],
+        tooltip: { trigger: 'axis' },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 24, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: temporalData.map(item => item.month) },
+        yAxis: { type: 'value' },
+        series: [
+            { name: 'Postulaciones', type: 'line', smooth: true, data: temporalData.map(item => item.applications) },
+            { name: 'Aprobadas', type: 'line', smooth: true, data: temporalData.map(item => item.approved) },
+            { name: 'Rechazadas', type: 'line', smooth: true, data: temporalData.map(item => item.rejected) }
+        ]
+    };
 
     if (loading) {
         return (
@@ -196,38 +255,11 @@ export const ReportsView: React.FC = () => {
                     <>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución por Estado (Barras)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <BarChart data={statusData}>
-                                    <CartesianGrid strokeDasharray="3 3" />
-                                    <XAxis dataKey="name" />
-                                    <YAxis />
-                                    <Tooltip />
-                                    <Legend />
-                                    <Bar dataKey="value" fill="#3B82F6" />
-                                </BarChart>
-                            </ResponsiveContainer>
+                            <EChart option={statusBarOption} height={300} />
                         </Card>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución por Estado (Pastel)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <PieChart>
-                                    <Pie
-                                        data={statusData}
-                                        cx="50%"
-                                        cy="50%"
-                                        labelLine={false}
-                                        label={(entry) => `${entry.name}: ${entry.value}`}
-                                        outerRadius={80}
-                                        fill="#8884d8"
-                                        dataKey="value"
-                                    >
-                                        {statusData.map((entry, index) => (
-                                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                        ))}
-                                    </Pie>
-                                    <Tooltip />
-                                </PieChart>
-                            </ResponsiveContainer>
+                            <EChart option={statusPieOption} height={300} />
                         </Card>
                     </>
                 )}
@@ -236,38 +268,11 @@ export const ReportsView: React.FC = () => {
                     <>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Postulaciones por Grado (Barras)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <BarChart data={gradeData}>
-                                    <CartesianGrid strokeDasharray="3 3" />
-                                    <XAxis dataKey="grade" />
-                                    <YAxis />
-                                    <Tooltip />
-                                    <Legend />
-                                    <Bar dataKey="count" fill="#10B981" />
-                                </BarChart>
-                            </ResponsiveContainer>
+                            <EChart option={gradeBarOption} height={300} />
                         </Card>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Postulaciones por Grado (Pastel)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <PieChart>
-                                    <Pie
-                                        data={gradeData}
-                                        cx="50%"
-                                        cy="50%"
-                                        labelLine={false}
-                                        label={(entry) => `${entry.grade}: ${entry.count}`}
-                                        outerRadius={80}
-                                        fill="#8884d8"
-                                        dataKey="count"
-                                    >
-                                        {gradeData.map((entry, index) => (
-                                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                        ))}
-                                    </Pie>
-                                    <Tooltip />
-                                </PieChart>
-                            </ResponsiveContainer>
+                            <EChart option={gradePieOption} height={300} />
                         </Card>
                     </>
                 )}
@@ -275,18 +280,7 @@ export const ReportsView: React.FC = () => {
                 {selectedReport === 'temporal' && (
                     <Card className="p-6 lg:col-span-2">
                         <h3 className="text-lg font-semibold text-gray-900 mb-4">Tendencias Temporales de Postulaciones</h3>
-                        <ResponsiveContainer width="100%" height={400}>
-                            <LineChart data={temporalData}>
-                                <CartesianGrid strokeDasharray="3 3" />
-                                <XAxis dataKey="month" />
-                                <YAxis />
-                                <Tooltip />
-                                <Legend />
-                                <Line type="monotone" dataKey="applications" stroke="#3B82F6" strokeWidth={2} name="Postulaciones" />
-                                <Line type="monotone" dataKey="approved" stroke="#10B981" strokeWidth={2} name="Aprobadas" />
-                                <Line type="monotone" dataKey="rejected" stroke="#EF4444" strokeWidth={2} name="Rechazadas" />
-                            </LineChart>
-                        </ResponsiveContainer>
+                        <EChart option={temporalOption} height={400} />
                     </Card>
                 )}
             </div>

--- a/microfrontends/apps/mf-coordinator/components/charts/EChart.tsx
+++ b/microfrontends/apps/mf-coordinator/components/charts/EChart.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactECharts from 'echarts-for-react';
+import type { EChartsOption } from 'echarts';
+
+interface EChartProps {
+  option: EChartsOption;
+  height?: number;
+  onEvents?: Record<string, (params: any) => void>;
+}
+
+const EChart: React.FC<EChartProps> = ({ option, height = 300, onEvents }) => (
+  <ReactECharts
+    option={option}
+    notMerge
+    lazyUpdate
+    onEvents={onEvents}
+    style={{ width: '100%', height }}
+  />
+);
+
+export default EChart;

--- a/microfrontends/apps/mf-coordinator/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-coordinator/components/interviews/InterviewForm.tsx
@@ -1080,7 +1080,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : (
                   <div className="p-4 bg-gray-50 border border-gray-200 rounded-md">
                     <p className="text-sm text-gray-600 text-center">
-                      👆 Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
+                      Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
                     </p>
                   </div>
                 )}

--- a/microfrontends/apps/mf-coordinator/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-coordinator/components/interviews/InterviewForm.tsx
@@ -133,21 +133,18 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
 
         console.log('Array de entrevistadores:', dataArray);
 
-        // El backend ya devuelve el formato correcto con firstName, lastName, role, scheduleCount
+        // El backend puede devolver array directo o envuelto, y nombres separados o name.
         const mappedInterviewers: BackendInterviewer[] = dataArray.map((item: any) => ({
-          id: item.id,
-          name: `${item.firstName} ${item.lastName}`,
-          role: item.role,
-          subject: item.subject,
+          id: Number(item.id),
+          name: item.name || `${item.firstName || ''} ${item.lastName || ''}`.trim() || item.email,
+          role: item.role || '',
+          subject: item.subject || '',
           educationalLevel: item.educationalLevel,
-          scheduleCount: item.scheduleCount || 0
-        }));
+          scheduleCount: Number(item.scheduleCount || 0)
+        })).filter((item) => item.id && item.name);
 
-        // Filtrar solo entrevistadores con horarios configurados
-        const interviewersWithSchedules = mappedInterviewers.filter(i => i.scheduleCount > 0);
-
-        console.log(`Entrevistadores con horarios: ${interviewersWithSchedules.length}/${mappedInterviewers.length}`);
-        setInterviewers(interviewersWithSchedules);
+        console.log(`Entrevistadores cargados: ${mappedInterviewers.length}`);
+        setInterviewers(mappedInterviewers);
       } catch (error: any) {
         console.error('Error cargando entrevistadores:', error);
 
@@ -263,7 +260,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
     // Validación de parámetros requeridos
     if (!formData.interviewerId || !formData.scheduledDate) {
       console.log('[loadAvailableTimeSlots] Faltan parámetros requeridos - abortando');
-      setAvailableTimeSlots(INTERVIEW_CONFIG.DEFAULT_TIME_SLOTS);
+      setAvailableTimeSlots([]);
       return;
     }
 
@@ -350,7 +347,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
 
       // Solo actualizar estado si no fue cancelada
       if (!currentController.signal.aborted) {
-        setAvailableTimeSlots(INTERVIEW_CONFIG.DEFAULT_TIME_SLOTS);
+        setAvailableTimeSlots([]);
       }
     } finally {
       // Solo limpiar loading state si esta es la llamada más reciente
@@ -936,9 +933,8 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                     <option
                       key={interviewer.id}
                       value={interviewer.id}
-                      disabled={interviewer.scheduleCount === 0}
                     >
-                      {interviewer.name} - {interviewer.role} {interviewer.scheduleCount === 0 ? '(Sin horarios)' : `(${interviewer.scheduleCount} horarios)`}
+                      {interviewer.name} - {interviewer.role} {interviewer.scheduleCount > 0 ? `(${interviewer.scheduleCount} horarios)` : ''}
                     </option>
                   ))
                 )}
@@ -969,7 +965,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : interviewersError ? (
                   <option disabled>{interviewersError}</option>
                 ) : interviewers.length === 0 ? (
-                  <option disabled>No hay entrevistadores con horarios configurados</option>
+                  <option disabled>No hay entrevistadores disponibles</option>
                 ) : (
                   (() => {
                     const filteredInterviewers = interviewers.filter(interviewer => {
@@ -988,9 +984,8 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                       <option
                         key={interviewer.id}
                         value={interviewer.id}
-                        disabled={interviewer.scheduleCount === 0}
                       >
-                        {interviewer.name} - {interviewer.role} {interviewer.scheduleCount === 0 ? '(Sin horarios)' : `(${interviewer.scheduleCount} horarios)`}
+                        {interviewer.name} - {interviewer.role} {interviewer.scheduleCount > 0 ? `(${interviewer.scheduleCount} horarios)` : ''}
                       </option>
                     ));
                   })()

--- a/microfrontends/apps/mf-coordinator/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-coordinator/components/interviews/InterviewForm.tsx
@@ -1080,7 +1080,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : (
                   <div className="p-4 bg-gray-50 border border-gray-200 rounded-md">
                     <p className="text-sm text-gray-600 text-center">
-                      Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
+                      👆 Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
                     </p>
                   </div>
                 )}

--- a/microfrontends/apps/mf-coordinator/components/layout/Footer.tsx
+++ b/microfrontends/apps/mf-coordinator/components/layout/Footer.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Facebook, Instagram, Linkedin } from 'lucide-react';
+import { microfrontendUrls } from '../../utils/microfrontendUrls';
 
 const Footer: React.FC = () => {
     const [showModal, setShowModal] = useState(false);
@@ -63,8 +64,9 @@ const Footer: React.FC = () => {
                         </div>
                     </div>
                 </div>
-                <div className="border-t border-blue-800 mt-10 pt-6 text-center text-sm text-gray-400">
+                <div className="border-t border-blue-800 mt-10 pt-6 flex flex-col sm:flex-row items-center justify-between gap-2 text-sm text-gray-400">
                     <p>&copy; {new Date().getFullYear()} Colegio Monte Tabor y Nazaret. Todos los derechos reservados.</p>
+                    <a href={microfrontendUrls.adminLogin} className="text-gray-400 hover:text-dorado-nazaret transition-colors text-xs underline underline-offset-2">Acceso personal MTN</a>
                 </div>
             </div>
             {/* Modal de contacto */}

--- a/microfrontends/apps/mf-coordinator/components/modals/CoordinatorDashboardModal.tsx
+++ b/microfrontends/apps/mf-coordinator/components/modals/CoordinatorDashboardModal.tsx
@@ -7,7 +7,8 @@ import React, { useState, useEffect } from 'react';
 import { FiX, FiRefreshCw } from 'react-icons/fi';
 import { dashboardClient } from '../../src/api/dashboard.client';
 import type { DetailedAdminStats, Alert } from '../../src/api/dashboard.types';
-import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 
 interface CoordinatorDashboardModalProps {
   isOpen: boolean;
@@ -115,6 +116,32 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
   const acceptanceRate = stats && stats.totalApplications > 0
     ? ((stats.statusBreakdown.approved / stats.totalApplications) * 100).toFixed(1)
     : '0.0';
+
+  const statusChartOption: EChartsOption = {
+    color: statusData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [
+      {
+        type: 'pie',
+        radius: ['42%', '70%'],
+        center: ['50%', '50%'],
+        avoidLabelOverlap: true,
+        itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+        label: { formatter: '{b}: {d}%' },
+        data: statusData.map(item => ({ name: item.name, value: item.value }))
+      }
+    ]
+  };
+
+  const gradeChartOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: gradeData.map(item => item.grade), axisTick: { alignWithLabel: true } },
+    yAxis: { type: 'value' },
+    series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 42 }]
+  };
 
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
@@ -348,25 +375,7 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
                   {/* Status Distribution Pie Chart */}
                   <div className="bg-white border border-gray-200 shadow-sm rounded-lg p-6">
                     <h3 className="text-lg font-medium text-gray-900 mb-4">Distribución por Estado</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                      <PieChart>
-                        <Pie
-                          data={statusData}
-                          cx="50%"
-                          cy="50%"
-                          labelLine={false}
-                          label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
-                          outerRadius={80}
-                          fill="#8884d8"
-                          dataKey="value"
-                        >
-                          {statusData.map((entry, index) => (
-                            <Cell key={`cell-${index}`} fill={entry.color} />
-                          ))}
-                        </Pie>
-                        <Tooltip />
-                      </PieChart>
-                    </ResponsiveContainer>
+                    <EChart option={statusChartOption} height={300} />
                     <div className="mt-4 grid grid-cols-2 gap-2 text-sm">
                       {statusData.map((item, index) => (
                         <div key={index} className="flex items-center">
@@ -383,16 +392,7 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
                   {/* Grade Distribution Bar Chart */}
                   <div className="bg-white border border-gray-200 shadow-sm rounded-lg p-6">
                     <h3 className="text-lg font-medium text-gray-900 mb-4">Distribución por Nivel</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                      <BarChart data={gradeData}>
-                        <CartesianGrid strokeDasharray="3 3" />
-                        <XAxis dataKey="grade" />
-                        <YAxis />
-                        <Tooltip />
-                        <Legend />
-                        <Bar dataKey="count" fill="#3B82F6" name="Postulaciones" />
-                      </BarChart>
-                    </ResponsiveContainer>
+                    <EChart option={gradeChartOption} height={300} />
                   </div>
                 </div>
 

--- a/microfrontends/apps/mf-coordinator/package.json
+++ b/microfrontends/apps/mf-coordinator/package.json
@@ -14,6 +14,8 @@
     "axios": "^1.11.0",
     "axios-retry": "^4.5.0",
     "date-fns": "^4.1.0",
+    "echarts": "^6.0.0",
+    "echarts-for-react": "^3.0.6",
     "express": "^4.18.2",
     "firebase": "^12.12.1",
     "lucide-react": "^0.540.0",
@@ -23,7 +25,6 @@
     "react-dropzone": "^14.3.8",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.3",
-    "recharts": "^3.2.1",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {

--- a/microfrontends/apps/mf-coordinator/services/interviewService.ts
+++ b/microfrontends/apps/mf-coordinator/services/interviewService.ts
@@ -796,14 +796,14 @@ class InterviewService {
       const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
       if (!dateRegex.test(date)) {
         console.error(`getAvailableTimeSlots: Formato de fecha inválido "${date}". Se esperaba YYYY-MM-DD`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Verificar que el año sea razonable
       const year = parseInt(date.split('-')[0]);
       if (year < 2020 || year > 2100) {
         console.error(`getAvailableTimeSlots: Año inválido ${year}. Debe estar entre 2020 y 2100`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Validar y usar duración por defecto si es inválida
@@ -825,8 +825,8 @@ class InterviewService {
 
       // Verificar si la respuesta es del placeholder (microservicio no implementado)
       if (response.data && typeof response.data === 'object' && 'error' in response.data) {
-        console.log('Available slots service no implementado, usando horarios por defecto');
-        return this.getDefaultTimeSlots();
+        console.log('Available slots service no implementado, devolviendo horarios vacíos');
+        return [];
       }
 
       // CASO 1: Backend devuelve estructura { success: true, data: { availableSlots: [...] } }
@@ -878,13 +878,12 @@ class InterviewService {
         }
       }
 
-      console.log('Estructura de respuesta inesperada para available slots, usando horarios por defecto');
+      console.log('Estructura de respuesta inesperada para available slots, devolviendo horarios vacíos');
       console.log('Data recibida:', response.data);
-      return this.getDefaultTimeSlots();
+      return [];
     } catch (error) {
       console.error('Error fetching available slots:', error);
-      // Fallback: horarios estándar si el backend no los tiene configurados
-      return this.getDefaultTimeSlots();
+      return [];
     }
   }
 
@@ -979,14 +978,14 @@ class InterviewService {
       const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
       if (!dateRegex.test(date)) {
         console.error(`getCommonTimeSlots: Formato de fecha inválido "${date}". Se esperaba YYYY-MM-DD`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Verificar que el año sea razonable
       const year = parseInt(date.split('-')[0]);
       if (year < 2020 || year > 2100) {
         console.error(`getCommonTimeSlots: Año inválido ${year}. Debe estar entre 2020 y 2100`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Obtener los horarios disponibles de ambos entrevistadores
@@ -1006,8 +1005,7 @@ class InterviewService {
       return commonSlots;
     } catch (error) {
       console.error('Error obteniendo horarios comunes:', error);
-      // Fallback: horarios por defecto
-      return this.getDefaultTimeSlots();
+      return [];
     }
   }
 

--- a/microfrontends/apps/mf-coordinator/src/components/charts/EChart.tsx
+++ b/microfrontends/apps/mf-coordinator/src/components/charts/EChart.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactECharts from 'echarts-for-react';
+import type { EChartsOption } from 'echarts';
+
+interface EChartProps {
+  option: EChartsOption;
+  height?: number;
+  onEvents?: Record<string, (params: any) => void>;
+}
+
+const EChart: React.FC<EChartProps> = ({ option, height = 300, onEvents }) => (
+  <ReactECharts
+    option={option}
+    notMerge
+    lazyUpdate
+    onEvents={onEvents}
+    style={{ width: '100%', height }}
+  />
+);
+
+export default EChart;

--- a/microfrontends/apps/mf-coordinator/src/components/coordinator/CoordinatorDashboard.tsx
+++ b/microfrontends/apps/mf-coordinator/src/components/coordinator/CoordinatorDashboard.tsx
@@ -9,7 +9,8 @@
 import React, { useState, useEffect } from 'react';
 import { dashboardClient } from '../../api/dashboard.client';
 import type { DetailedAdminStats, Alert } from '../../api/dashboard.types';
-import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { ApplicantMetricsModal } from '../../../components/modals/ApplicantMetricsModal';
 
 export const CoordinatorDashboard: React.FC = () => {
@@ -143,6 +144,32 @@ export const CoordinatorDashboard: React.FC = () => {
   const acceptanceRate = stats.totalApplications > 0
     ? ((stats.statusBreakdown.approved / stats.totalApplications) * 100).toFixed(1)
     : '0.0';
+
+  const statusChartOption: EChartsOption = {
+    color: statusData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [
+      {
+        type: 'pie',
+        radius: ['42%', '70%'],
+        center: ['50%', '50%'],
+        avoidLabelOverlap: true,
+        itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+        label: { formatter: '{b}: {d}%' },
+        data: statusData.map(item => ({ name: item.name, value: item.value }))
+      }
+    ]
+  };
+
+  const gradeChartOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: gradeData.map(item => item.grade), axisTick: { alignWithLabel: true } },
+    yAxis: { type: 'value' },
+    series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 42 }]
+  };
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -336,25 +363,7 @@ export const CoordinatorDashboard: React.FC = () => {
         {/* Status Distribution Pie Chart */}
         <div className="bg-white shadow rounded-lg p-6">
           <h2 className="text-lg font-medium text-gray-900 mb-4">Distribución por Estado</h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie
-                data={statusData}
-                cx="50%"
-                cy="50%"
-                labelLine={false}
-                label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
-                outerRadius={80}
-                fill="#8884d8"
-                dataKey="value"
-              >
-                {statusData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
-                ))}
-              </Pie>
-              <Tooltip />
-            </PieChart>
-          </ResponsiveContainer>
+          <EChart option={statusChartOption} height={300} />
           <div className="mt-4 grid grid-cols-2 gap-2 text-sm">
             {statusData.map((item, index) => (
               <div key={index} className="flex items-center">
@@ -371,16 +380,7 @@ export const CoordinatorDashboard: React.FC = () => {
         {/* Grade Distribution Bar Chart */}
         <div className="bg-white shadow rounded-lg p-6">
           <h2 className="text-lg font-medium text-gray-900 mb-4">Distribución por Nivel</h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={gradeData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="grade" />
-              <YAxis />
-              <Tooltip />
-              <Legend />
-              <Bar dataKey="count" fill="#3B82F6" name="Postulaciones" />
-            </BarChart>
-          </ResponsiveContainer>
+          <EChart option={gradeChartOption} height={300} />
         </div>
       </div>
 

--- a/microfrontends/apps/mf-coordinator/src/components/coordinator/TemporalTrendsView.tsx
+++ b/microfrontends/apps/mf-coordinator/src/components/coordinator/TemporalTrendsView.tsx
@@ -8,7 +8,8 @@
 import React, { useState, useEffect } from 'react';
 import { dashboardClient } from '../../api/dashboard.client';
 import type { TemporalTrend, DetailedAdminStats } from '../../api/dashboard.types';
-import { LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { format } from 'date-fns';
 
 export const TemporalTrendsView: React.FC = () => {
@@ -114,6 +115,52 @@ export const TemporalTrendsView: React.FC = () => {
     };
   }).filter(Boolean);
 
+  const monthlyTrendsOption: EChartsOption = {
+    color: ['#3B82F6', '#10B981', '#EF4444', '#F59E0B'],
+    tooltip: { trigger: 'axis' },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 48, top: 24, bottom: 80, containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: monthlyTrendsData.map(item => item.month),
+      axisLabel: { rotate: 45 }
+    },
+    yAxis: [
+      { type: 'value', name: 'Postulaciones' },
+      { type: 'value', name: '%' }
+    ],
+    series: [
+      { name: 'Total Postulaciones', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.total) },
+      { name: 'Aprobadas', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.approved) },
+      { name: 'Rechazadas', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.rejected) },
+      { name: 'Tasa de Crecimiento (%)', type: 'line', smooth: true, yAxisIndex: 1, lineStyle: { type: 'dashed' }, data: monthlyTrendsData.map(item => item.growthRate) }
+    ]
+  };
+
+  const comparisonOption: EChartsOption = {
+    color: ['#3B82F6', '#10B981', '#EF4444'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: comparisonData.map((item: any) => item.year) },
+    yAxis: { type: 'value' },
+    series: [
+      { name: 'Total', type: 'bar', data: comparisonData.map((item: any) => item.total) },
+      { name: 'Aprobadas', type: 'bar', data: comparisonData.map((item: any) => item.approved) },
+      { name: 'Rechazadas', type: 'bar', data: comparisonData.map((item: any) => item.rejected) }
+    ]
+  };
+
+  const acceptanceRateOption: EChartsOption = {
+    color: ['#10B981'],
+    tooltip: { trigger: 'axis', valueFormatter: value => `${Number(value).toFixed(1)}%` },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: comparisonData.map((item: any) => item.year) },
+    yAxis: { type: 'value', min: 0, max: 100 },
+    series: [{ name: 'Tasa de Aceptación (%)', type: 'bar', data: comparisonData.map((item: any) => item.acceptanceRate), barMaxWidth: 48 }]
+  };
+
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       {/* Header */}
@@ -147,50 +194,7 @@ export const TemporalTrendsView: React.FC = () => {
       {/* Monthly Trends Chart */}
       <div className="bg-white shadow rounded-lg p-6 mb-6">
         <h2 className="text-lg font-medium text-gray-900 mb-4">Tendencia Mensual (Últimos 12 meses)</h2>
-        <ResponsiveContainer width="100%" height={400}>
-          <LineChart data={monthlyTrendsData}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="month" angle={-45} textAnchor="end" height={80} />
-            <YAxis yAxisId="left" />
-            <YAxis yAxisId="right" orientation="right" />
-            <Tooltip />
-            <Legend />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="total"
-              stroke="#3B82F6"
-              strokeWidth={2}
-              name="Total Postulaciones"
-              dot={{ r: 4 }}
-            />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="approved"
-              stroke="#10B981"
-              strokeWidth={2}
-              name="Aprobadas"
-            />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="rejected"
-              stroke="#EF4444"
-              strokeWidth={2}
-              name="Rechazadas"
-            />
-            <Line
-              yAxisId="right"
-              type="monotone"
-              dataKey="growthRate"
-              stroke="#F59E0B"
-              strokeWidth={2}
-              name="Tasa de Crecimiento (%)"
-              strokeDasharray="5 5"
-            />
-          </LineChart>
-        </ResponsiveContainer>
+        <EChart option={monthlyTrendsOption} height={400} />
       </div>
 
       {/* Year Comparison */}
@@ -199,33 +203,13 @@ export const TemporalTrendsView: React.FC = () => {
           {/* Total Applications Comparison */}
           <div className="bg-white shadow rounded-lg p-6">
             <h2 className="text-lg font-medium text-gray-900 mb-4">Comparativa de Postulaciones</h2>
-            <ResponsiveContainer width="100%" height={300}>
-              <BarChart data={comparisonData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="year" />
-                <YAxis />
-                <Tooltip />
-                <Legend />
-                <Bar dataKey="total" fill="#3B82F6" name="Total" />
-                <Bar dataKey="approved" fill="#10B981" name="Aprobadas" />
-                <Bar dataKey="rejected" fill="#EF4444" name="Rechazadas" />
-              </BarChart>
-            </ResponsiveContainer>
+            <EChart option={comparisonOption} height={300} />
           </div>
 
           {/* Acceptance Rate Comparison */}
           <div className="bg-white shadow rounded-lg p-6">
             <h2 className="text-lg font-medium text-gray-900 mb-4">Tasa de Aceptación por Año</h2>
-            <ResponsiveContainer width="100%" height={300}>
-              <BarChart data={comparisonData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="year" />
-                <YAxis domain={[0, 100]} />
-                <Tooltip formatter={(value) => `${Number(value).toFixed(1)}%`} />
-                <Legend />
-                <Bar dataKey="acceptanceRate" fill="#10B981" name="Tasa de Aceptación (%)" />
-              </BarChart>
-            </ResponsiveContainer>
+            <EChart option={acceptanceRateOption} height={300} />
           </div>
         </div>
       )}

--- a/microfrontends/apps/mf-evaluations/App.tsx
+++ b/microfrontends/apps/mf-evaluations/App.tsx
@@ -28,13 +28,14 @@ function App() {
   const legacyRedirects = createLegacyRedirectRoutes();
   const location = useLocation();
   const isLoginPage = location.pathname === '/profesor/login';
+  const isDashboard = !isLoginPage && location.pathname !== '/';
 
   return (
     <ErrorBoundary>
       <AuthProvider>
         <AppProvider>
           <div className="flex min-h-screen flex-col bg-blanco-pureza text-gray-800">
-            {!isLoginPage && <Header />}
+            {!isLoginPage && !isDashboard && <Header />}
             <main className="flex-grow overflow-x-hidden">
               <Suspense fallback={<LoadingFallback />}>
                 <Routes>

--- a/microfrontends/apps/mf-evaluations/components/admin/AnalyticsView.tsx
+++ b/microfrontends/apps/mf-evaluations/components/admin/AnalyticsView.tsx
@@ -6,7 +6,8 @@
 import React, { useState, useEffect } from 'react';
 import { FiTrendingUp, FiUsers, FiAward, FiClock } from 'react-icons/fi';
 import Card from '../ui/Card';
-import { BarChart, Bar, LineChart, Line, RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { dashboardClient } from '../../src/api/dashboard.client';
 
 export const AnalyticsView: React.FC = () => {
@@ -54,7 +55,34 @@ export const AnalyticsView: React.FC = () => {
         );
     }
 
-    const COLORS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899'];
+    const evaluatorPerformanceOption: EChartsOption = {
+        color: ['#10B981', '#F59E0B'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: evaluatorData.map(item => item.name) },
+        yAxis: { type: 'value' },
+        series: [
+            { name: 'Completadas', type: 'bar', data: evaluatorData.map(item => item.completed) },
+            { name: 'Pendientes', type: 'bar', data: evaluatorData.map(item => item.pending) }
+        ]
+    };
+
+    const radarData = evaluatorData.slice(0, 6);
+    const evaluatorWorkloadOption: EChartsOption = {
+        color: ['#3B82F6'],
+        tooltip: {},
+        radar: {
+            indicator: radarData.map(item => ({ name: item.name, max: Math.max(...radarData.map(e => e.total || 0), 1) })),
+            splitArea: { areaStyle: { color: ['rgba(59, 130, 246, 0.04)', 'rgba(59, 130, 246, 0.1)'] } }
+        },
+        series: [{
+            name: 'Evaluaciones',
+            type: 'radar',
+            areaStyle: { opacity: 0.35 },
+            data: [{ name: 'Evaluaciones', value: radarData.map(item => item.total || 0) }]
+        }]
+    };
 
     return (
         <div className="space-y-6">
@@ -136,31 +164,13 @@ export const AnalyticsView: React.FC = () => {
                 {/* Evaluator Performance */}
                 <Card className="p-6">
                     <h3 className="text-lg font-semibold text-gray-900 mb-4">Rendimiento de Evaluadores</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <BarChart data={evaluatorData}>
-                            <CartesianGrid strokeDasharray="3 3" />
-                            <XAxis dataKey="name" />
-                            <YAxis />
-                            <Tooltip />
-                            <Legend />
-                            <Bar dataKey="completed" fill="#10B981" name="Completadas" />
-                            <Bar dataKey="pending" fill="#F59E0B" name="Pendientes" />
-                        </BarChart>
-                    </ResponsiveContainer>
+                    <EChart option={evaluatorPerformanceOption} height={300} />
                 </Card>
 
                 {/* Evaluator Workload Radar */}
                 <Card className="p-6">
                     <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución de Carga de Trabajo</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <RadarChart data={evaluatorData.slice(0, 6)}>
-                            <PolarGrid />
-                            <PolarAngleAxis dataKey="name" />
-                            <PolarRadiusAxis />
-                            <Radar name="Evaluaciones" dataKey="total" stroke="#3B82F6" fill="#3B82F6" fillOpacity={0.6} />
-                            <Tooltip />
-                        </RadarChart>
-                    </ResponsiveContainer>
+                    <EChart option={evaluatorWorkloadOption} height={300} />
                 </Card>
             </div>
 

--- a/microfrontends/apps/mf-evaluations/components/admin/ApplicantMetricsView.tsx
+++ b/microfrontends/apps/mf-evaluations/components/admin/ApplicantMetricsView.tsx
@@ -5,7 +5,8 @@ import Badge from '../ui/Badge';
 import Button from '../ui/Button';
 import { dashboardClient } from '../../src/api/dashboard.client';
 import type { ApplicantMetric, ApplicantMetricsFilters } from '../../src/api/dashboard.types';
-import { PieChart, Pie, BarChart, Bar, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, LabelList } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 
 // Version: 2025-11-11 - Added overallOpinionScore display
 export const ApplicantMetricsView: React.FC = () => {
@@ -178,6 +179,48 @@ export const ApplicantMetricsView: React.FC = () => {
   };
 
   const { performanceData, avgData } = getChartData();
+
+  const performanceDistributionOption: EChartsOption = {
+    color: performanceData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    legend: { bottom: 0 },
+    series: [{
+      type: 'pie',
+      radius: ['42%', '70%'],
+      center: ['50%', '44%'],
+      itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+      label: { formatter: '{d}%' },
+      data: performanceData.map(item => ({ name: item.name, value: item.value }))
+    }]
+  };
+
+  const examAverageOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', valueFormatter: value => `${value}%` },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 24, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: avgData.map(item => item.name) },
+    yAxis: { type: 'value', min: 0, max: 100 },
+    series: [{
+      name: 'Promedio (%)',
+      type: 'bar',
+      data: avgData.map(item => item.promedio),
+      barMaxWidth: 48,
+      label: { show: true, position: 'top', formatter: '{c}%' }
+    }]
+  };
+
+  const subjectDistributionOption: EChartsOption = {
+    color: subjectDistribution.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [{
+      type: 'pie',
+      radius: ['42%', '72%'],
+      itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+      label: { formatter: '{b}: {d}%' },
+      data: subjectDistribution.map(item => ({ name: item.name, value: item.value }))
+    }]
+  };
 
   const uniqueGrades = [...new Set(applicants.map(a => a.gradeApplied))].sort();
   const uniqueStatuses = [...new Set(applicants.map(a => a.applicationStatus))];
@@ -420,56 +463,17 @@ export const ApplicantMetricsView: React.FC = () => {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <Card className="p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución de Rendimiento</h3>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie
-                data={performanceData}
-                cx="50%"
-                cy="50%"
-                labelLine={false}
-                label={({ percent }: { percent?: number }) => `${Math.round((percent || 0) * 100)}%`}
-                outerRadius={80}
-                fill="#8884d8"
-                dataKey="value"
-              >
-                {performanceData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
-                ))}
-              </Pie>
-              <Tooltip />
-              <Legend
-                verticalAlign="bottom"
-                height={36}
-                formatter={(value, entry: any) => entry.payload.name}
-              />
-            </PieChart>
-          </ResponsiveContainer>
+          <EChart option={performanceDistributionOption} height={300} />
         </Card>
 
         <Card className="p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Promedio por Examen</h3>
           <p className="text-sm text-gray-500 mb-2">Haz clic en una barra para ver la distribución detallada</p>
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={avgData} onClick={(data) => {
-              if (data && data.activeLabel) {
-                handleSubjectClick(data.activeLabel);
-              }
-            }}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
-              <YAxis domain={[0, 100]} />
-              <Tooltip />
-              <Legend />
-              <Bar
-                dataKey="promedio"
-                fill="#3B82F6"
-                name="Promedio (%)"
-                cursor="pointer"
-              >
-                <LabelList dataKey="promedio" position="top" formatter={(value: number) => `${value}%`} />
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+          <EChart
+            option={examAverageOption}
+            height={300}
+            onEvents={{ click: params => params.name && handleSubjectClick(String(params.name)) }}
+          />
         </Card>
       </div>
 
@@ -680,27 +684,7 @@ export const ApplicantMetricsView: React.FC = () => {
               </div>
 
               <div className="mb-6">
-                <ResponsiveContainer width="100%" height={350}>
-                  <PieChart>
-                    <Pie
-                      data={subjectDistribution}
-                      cx="50%"
-                      cy="50%"
-                      labelLine={false}
-                      label={({ name, percent }: { name: string, percent?: number }) =>
-                        `${name}: ${Math.round((percent || 0) * 100)}%`
-                      }
-                      outerRadius={120}
-                      fill="#8884d8"
-                      dataKey="value"
-                    >
-                      {subjectDistribution.map((entry, index) => (
-                        <Cell key={`cell-${index}`} fill={entry.color} />
-                      ))}
-                    </Pie>
-                    <Tooltip />
-                  </PieChart>
-                </ResponsiveContainer>
+                <EChart option={subjectDistributionOption} height={350} />
               </div>
 
               <div className="border-t pt-4">

--- a/microfrontends/apps/mf-evaluations/components/admin/ReportsView.tsx
+++ b/microfrontends/apps/mf-evaluations/components/admin/ReportsView.tsx
@@ -7,7 +7,8 @@ import React, { useState, useEffect } from 'react';
 import { FiDownload, FiFilter, FiCalendar, FiBarChart2, FiPieChart, FiTrendingUp } from 'react-icons/fi';
 import Card from '../ui/Card';
 import Button from '../ui/Button';
-import { BarChart, Bar, PieChart, Pie, LineChart, Line, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { dashboardClient } from '../../src/api/dashboard.client';
 
 interface ReportFilters {
@@ -85,6 +86,64 @@ export const ReportsView: React.FC = () => {
     };
 
     const COLORS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899'];
+
+    const statusBarOption: EChartsOption = {
+        color: ['#3B82F6'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: statusData.map(item => item.name) },
+        yAxis: { type: 'value' },
+        series: [{ name: 'Cantidad', type: 'bar', data: statusData.map(item => item.value), barMaxWidth: 44 }]
+    };
+
+    const statusPieOption: EChartsOption = {
+        color: COLORS,
+        tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+        series: [{
+            type: 'pie',
+            radius: ['42%', '70%'],
+            itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+            label: { formatter: '{b}: {c}' },
+            data: statusData.map(item => ({ name: item.name, value: item.value }))
+        }]
+    };
+
+    const gradeBarOption: EChartsOption = {
+        color: ['#10B981'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: gradeData.map(item => item.grade) },
+        yAxis: { type: 'value' },
+        series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 44 }]
+    };
+
+    const gradePieOption: EChartsOption = {
+        color: COLORS,
+        tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+        series: [{
+            type: 'pie',
+            radius: ['42%', '70%'],
+            itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+            label: { formatter: '{b}: {c}' },
+            data: gradeData.map(item => ({ name: item.grade, value: item.count }))
+        }]
+    };
+
+    const temporalOption: EChartsOption = {
+        color: ['#3B82F6', '#10B981', '#EF4444'],
+        tooltip: { trigger: 'axis' },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 24, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: temporalData.map(item => item.month) },
+        yAxis: { type: 'value' },
+        series: [
+            { name: 'Postulaciones', type: 'line', smooth: true, data: temporalData.map(item => item.applications) },
+            { name: 'Aprobadas', type: 'line', smooth: true, data: temporalData.map(item => item.approved) },
+            { name: 'Rechazadas', type: 'line', smooth: true, data: temporalData.map(item => item.rejected) }
+        ]
+    };
 
     if (loading) {
         return (
@@ -196,38 +255,11 @@ export const ReportsView: React.FC = () => {
                     <>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución por Estado (Barras)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <BarChart data={statusData}>
-                                    <CartesianGrid strokeDasharray="3 3" />
-                                    <XAxis dataKey="name" />
-                                    <YAxis />
-                                    <Tooltip />
-                                    <Legend />
-                                    <Bar dataKey="value" fill="#3B82F6" />
-                                </BarChart>
-                            </ResponsiveContainer>
+                            <EChart option={statusBarOption} height={300} />
                         </Card>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución por Estado (Pastel)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <PieChart>
-                                    <Pie
-                                        data={statusData}
-                                        cx="50%"
-                                        cy="50%"
-                                        labelLine={false}
-                                        label={(entry) => `${entry.name}: ${entry.value}`}
-                                        outerRadius={80}
-                                        fill="#8884d8"
-                                        dataKey="value"
-                                    >
-                                        {statusData.map((entry, index) => (
-                                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                        ))}
-                                    </Pie>
-                                    <Tooltip />
-                                </PieChart>
-                            </ResponsiveContainer>
+                            <EChart option={statusPieOption} height={300} />
                         </Card>
                     </>
                 )}
@@ -236,38 +268,11 @@ export const ReportsView: React.FC = () => {
                     <>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Postulaciones por Grado (Barras)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <BarChart data={gradeData}>
-                                    <CartesianGrid strokeDasharray="3 3" />
-                                    <XAxis dataKey="grade" />
-                                    <YAxis />
-                                    <Tooltip />
-                                    <Legend />
-                                    <Bar dataKey="count" fill="#10B981" />
-                                </BarChart>
-                            </ResponsiveContainer>
+                            <EChart option={gradeBarOption} height={300} />
                         </Card>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Postulaciones por Grado (Pastel)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <PieChart>
-                                    <Pie
-                                        data={gradeData}
-                                        cx="50%"
-                                        cy="50%"
-                                        labelLine={false}
-                                        label={(entry) => `${entry.grade}: ${entry.count}`}
-                                        outerRadius={80}
-                                        fill="#8884d8"
-                                        dataKey="count"
-                                    >
-                                        {gradeData.map((entry, index) => (
-                                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                        ))}
-                                    </Pie>
-                                    <Tooltip />
-                                </PieChart>
-                            </ResponsiveContainer>
+                            <EChart option={gradePieOption} height={300} />
                         </Card>
                     </>
                 )}
@@ -275,18 +280,7 @@ export const ReportsView: React.FC = () => {
                 {selectedReport === 'temporal' && (
                     <Card className="p-6 lg:col-span-2">
                         <h3 className="text-lg font-semibold text-gray-900 mb-4">Tendencias Temporales de Postulaciones</h3>
-                        <ResponsiveContainer width="100%" height={400}>
-                            <LineChart data={temporalData}>
-                                <CartesianGrid strokeDasharray="3 3" />
-                                <XAxis dataKey="month" />
-                                <YAxis />
-                                <Tooltip />
-                                <Legend />
-                                <Line type="monotone" dataKey="applications" stroke="#3B82F6" strokeWidth={2} name="Postulaciones" />
-                                <Line type="monotone" dataKey="approved" stroke="#10B981" strokeWidth={2} name="Aprobadas" />
-                                <Line type="monotone" dataKey="rejected" stroke="#EF4444" strokeWidth={2} name="Rechazadas" />
-                            </LineChart>
-                        </ResponsiveContainer>
+                        <EChart option={temporalOption} height={400} />
                     </Card>
                 )}
             </div>

--- a/microfrontends/apps/mf-evaluations/components/auth/ProtectedProfessorRoute.tsx
+++ b/microfrontends/apps/mf-evaluations/components/auth/ProtectedProfessorRoute.tsx
@@ -1,28 +1,46 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
+
+const STAFF_ROLES = new Set([
+    'TEACHER', 'COORDINATOR', 'CYCLE_DIRECTOR', 'PSYCHOLOGIST', 'INTERVIEWER',
+    'TEACHER_EARLY_CYCLE',
+    'TEACHER_LANGUAGE_BASIC', 'TEACHER_MATHEMATICS_BASIC', 'TEACHER_ENGLISH_BASIC',
+    'TEACHER_SCIENCE_BASIC', 'TEACHER_HISTORY_BASIC',
+    'TEACHER_LANGUAGE_HIGH', 'TEACHER_MATHEMATICS_HIGH', 'TEACHER_ENGLISH_HIGH',
+    'TEACHER_SCIENCE_HIGH', 'TEACHER_HISTORY_HIGH',
+    'COORDINATOR_LANGUAGE', 'COORDINATOR_MATHEMATICS', 'COORDINATOR_ENGLISH',
+    'COORDINATOR_SCIENCE', 'COORDINATOR_HISTORY',
+    'TEACHER_LANGUAGE', 'TEACHER_MATHEMATICS', 'TEACHER_ENGLISH',
+]);
 
 interface ProtectedProfessorRouteProps {
     children: React.ReactNode;
 }
 
 const ProtectedProfessorRoute: React.FC<ProtectedProfessorRouteProps> = ({ children }) => {
-    // Verificar si hay un profesor logueado
-    const currentProfessor = localStorage.getItem('currentProfessor');
-    
-    if (!currentProfessor) {
-        // Redirigir al login si no hay profesor autenticado
+    const storageKey = getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR);
+    const raw = localStorage.getItem(storageKey) || localStorage.getItem('currentProfessor');
+
+    if (!raw) {
         return <Navigate to="/profesor/login" replace />;
     }
 
     try {
-        // Verificar que los datos del profesor sean válidos
-        const professorData = JSON.parse(currentProfessor);
-        if (!professorData.id || !professorData.email) {
+        const professorData = JSON.parse(raw);
+        const isValid =
+            professorData.id &&
+            professorData.email &&
+            professorData.role &&
+            STAFF_ROLES.has(professorData.role);
+
+        if (!isValid) {
+            localStorage.removeItem(storageKey);
             localStorage.removeItem('currentProfessor');
             return <Navigate to="/profesor/login" replace />;
         }
-    } catch (error) {
-        // Datos corruptos, limpiar y redirigir
+    } catch {
+        localStorage.removeItem(storageKey);
         localStorage.removeItem('currentProfessor');
         return <Navigate to="/profesor/login" replace />;
     }

--- a/microfrontends/apps/mf-evaluations/components/charts/EChart.tsx
+++ b/microfrontends/apps/mf-evaluations/components/charts/EChart.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactECharts from 'echarts-for-react';
+import type { EChartsOption } from 'echarts';
+
+interface EChartProps {
+  option: EChartsOption;
+  height?: number;
+  onEvents?: Record<string, (params: any) => void>;
+}
+
+const EChart: React.FC<EChartProps> = ({ option, height = 300, onEvents }) => (
+  <ReactECharts
+    option={option}
+    notMerge
+    lazyUpdate
+    onEvents={onEvents}
+    style={{ width: '100%', height }}
+  />
+);
+
+export default EChart;

--- a/microfrontends/apps/mf-evaluations/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-evaluations/components/interviews/InterviewForm.tsx
@@ -1080,7 +1080,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : (
                   <div className="p-4 bg-gray-50 border border-gray-200 rounded-md">
                     <p className="text-sm text-gray-600 text-center">
-                      👆 Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
+                      Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
                     </p>
                   </div>
                 )}

--- a/microfrontends/apps/mf-evaluations/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-evaluations/components/interviews/InterviewForm.tsx
@@ -133,21 +133,18 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
 
         console.log('Array de entrevistadores:', dataArray);
 
-        // El backend ya devuelve el formato correcto con firstName, lastName, role, scheduleCount
+        // El backend puede devolver array directo o envuelto, y nombres separados o name.
         const mappedInterviewers: BackendInterviewer[] = dataArray.map((item: any) => ({
-          id: item.id,
-          name: `${item.firstName} ${item.lastName}`,
-          role: item.role,
-          subject: item.subject,
+          id: Number(item.id),
+          name: item.name || `${item.firstName || ''} ${item.lastName || ''}`.trim() || item.email,
+          role: item.role || '',
+          subject: item.subject || '',
           educationalLevel: item.educationalLevel,
-          scheduleCount: item.scheduleCount || 0
-        }));
+          scheduleCount: Number(item.scheduleCount || 0)
+        })).filter((item) => item.id && item.name);
 
-        // Filtrar solo entrevistadores con horarios configurados
-        const interviewersWithSchedules = mappedInterviewers.filter(i => i.scheduleCount > 0);
-
-        console.log(`Entrevistadores con horarios: ${interviewersWithSchedules.length}/${mappedInterviewers.length}`);
-        setInterviewers(interviewersWithSchedules);
+        console.log(`Entrevistadores cargados: ${mappedInterviewers.length}`);
+        setInterviewers(mappedInterviewers);
       } catch (error: any) {
         console.error('Error cargando entrevistadores:', error);
 
@@ -263,7 +260,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
     // Validación de parámetros requeridos
     if (!formData.interviewerId || !formData.scheduledDate) {
       console.log('[loadAvailableTimeSlots] Faltan parámetros requeridos - abortando');
-      setAvailableTimeSlots(INTERVIEW_CONFIG.DEFAULT_TIME_SLOTS);
+      setAvailableTimeSlots([]);
       return;
     }
 
@@ -350,7 +347,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
 
       // Solo actualizar estado si no fue cancelada
       if (!currentController.signal.aborted) {
-        setAvailableTimeSlots(INTERVIEW_CONFIG.DEFAULT_TIME_SLOTS);
+        setAvailableTimeSlots([]);
       }
     } finally {
       // Solo limpiar loading state si esta es la llamada más reciente
@@ -936,9 +933,8 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                     <option
                       key={interviewer.id}
                       value={interviewer.id}
-                      disabled={interviewer.scheduleCount === 0}
                     >
-                      {interviewer.name} - {interviewer.role} {interviewer.scheduleCount === 0 ? '(Sin horarios)' : `(${interviewer.scheduleCount} horarios)`}
+                      {interviewer.name} - {interviewer.role} {interviewer.scheduleCount > 0 ? `(${interviewer.scheduleCount} horarios)` : ''}
                     </option>
                   ))
                 )}
@@ -969,7 +965,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : interviewersError ? (
                   <option disabled>{interviewersError}</option>
                 ) : interviewers.length === 0 ? (
-                  <option disabled>No hay entrevistadores con horarios configurados</option>
+                  <option disabled>No hay entrevistadores disponibles</option>
                 ) : (
                   (() => {
                     const filteredInterviewers = interviewers.filter(interviewer => {
@@ -988,9 +984,8 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                       <option
                         key={interviewer.id}
                         value={interviewer.id}
-                        disabled={interviewer.scheduleCount === 0}
                       >
-                        {interviewer.name} - {interviewer.role} {interviewer.scheduleCount === 0 ? '(Sin horarios)' : `(${interviewer.scheduleCount} horarios)`}
+                        {interviewer.name} - {interviewer.role} {interviewer.scheduleCount > 0 ? `(${interviewer.scheduleCount} horarios)` : ''}
                       </option>
                     ));
                   })()

--- a/microfrontends/apps/mf-evaluations/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-evaluations/components/interviews/InterviewForm.tsx
@@ -1080,7 +1080,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : (
                   <div className="p-4 bg-gray-50 border border-gray-200 rounded-md">
                     <p className="text-sm text-gray-600 text-center">
-                      Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
+                      👆 Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
                     </p>
                   </div>
                 )}

--- a/microfrontends/apps/mf-evaluations/components/layout/Footer.tsx
+++ b/microfrontends/apps/mf-evaluations/components/layout/Footer.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Facebook, Instagram, Linkedin } from 'lucide-react';
+import { microfrontendUrls } from '../../utils/microfrontendUrls';
 
 const Footer: React.FC = () => {
     const [showModal, setShowModal] = useState(false);
@@ -63,8 +64,9 @@ const Footer: React.FC = () => {
                         </div>
                     </div>
                 </div>
-                <div className="border-t border-blue-800 mt-10 pt-6 text-center text-sm text-gray-400">
+                <div className="border-t border-blue-800 mt-10 pt-6 flex flex-col sm:flex-row items-center justify-between gap-2 text-sm text-gray-400">
                     <p>&copy; {new Date().getFullYear()} Colegio Monte Tabor y Nazaret. Todos los derechos reservados.</p>
+                    <a href={microfrontendUrls.adminLogin} className="text-gray-400 hover:text-dorado-nazaret transition-colors text-xs underline underline-offset-2">Acceso personal MTN</a>
                 </div>
             </div>
             {/* Modal de contacto */}

--- a/microfrontends/apps/mf-evaluations/components/modals/CoordinatorDashboardModal.tsx
+++ b/microfrontends/apps/mf-evaluations/components/modals/CoordinatorDashboardModal.tsx
@@ -7,7 +7,8 @@ import React, { useState, useEffect } from 'react';
 import { FiX, FiRefreshCw } from 'react-icons/fi';
 import { dashboardClient } from '../../src/api/dashboard.client';
 import type { DetailedAdminStats, Alert } from '../../src/api/dashboard.types';
-import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 
 interface CoordinatorDashboardModalProps {
   isOpen: boolean;
@@ -115,6 +116,32 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
   const acceptanceRate = stats && stats.totalApplications > 0
     ? ((stats.statusBreakdown.approved / stats.totalApplications) * 100).toFixed(1)
     : '0.0';
+
+  const statusChartOption: EChartsOption = {
+    color: statusData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [
+      {
+        type: 'pie',
+        radius: ['42%', '70%'],
+        center: ['50%', '50%'],
+        avoidLabelOverlap: true,
+        itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+        label: { formatter: '{b}: {d}%' },
+        data: statusData.map(item => ({ name: item.name, value: item.value }))
+      }
+    ]
+  };
+
+  const gradeChartOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: gradeData.map(item => item.grade), axisTick: { alignWithLabel: true } },
+    yAxis: { type: 'value' },
+    series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 42 }]
+  };
 
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
@@ -348,25 +375,7 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
                   {/* Status Distribution Pie Chart */}
                   <div className="bg-white border border-gray-200 shadow-sm rounded-lg p-6">
                     <h3 className="text-lg font-medium text-gray-900 mb-4">Distribución por Estado</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                      <PieChart>
-                        <Pie
-                          data={statusData}
-                          cx="50%"
-                          cy="50%"
-                          labelLine={false}
-                          label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
-                          outerRadius={80}
-                          fill="#8884d8"
-                          dataKey="value"
-                        >
-                          {statusData.map((entry, index) => (
-                            <Cell key={`cell-${index}`} fill={entry.color} />
-                          ))}
-                        </Pie>
-                        <Tooltip />
-                      </PieChart>
-                    </ResponsiveContainer>
+                    <EChart option={statusChartOption} height={300} />
                     <div className="mt-4 grid grid-cols-2 gap-2 text-sm">
                       {statusData.map((item, index) => (
                         <div key={index} className="flex items-center">
@@ -383,16 +392,7 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
                   {/* Grade Distribution Bar Chart */}
                   <div className="bg-white border border-gray-200 shadow-sm rounded-lg p-6">
                     <h3 className="text-lg font-medium text-gray-900 mb-4">Distribución por Nivel</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                      <BarChart data={gradeData}>
-                        <CartesianGrid strokeDasharray="3 3" />
-                        <XAxis dataKey="grade" />
-                        <YAxis />
-                        <Tooltip />
-                        <Legend />
-                        <Bar dataKey="count" fill="#3B82F6" name="Postulaciones" />
-                      </BarChart>
-                    </ResponsiveContainer>
+                    <EChart option={gradeChartOption} height={300} />
                   </div>
                 </div>
 

--- a/microfrontends/apps/mf-evaluations/components/schedule/WeeklyCalendar.tsx
+++ b/microfrontends/apps/mf-evaluations/components/schedule/WeeklyCalendar.tsx
@@ -100,8 +100,9 @@ const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({
   const loadSchedules = async () => {
     try {
       setLoading(true);
-      console.log(`[WeeklyCalendar] Cargando horarios para userId: ${userId}, año: 2025`);
-      const schedules = await interviewerScheduleService.getInterviewerSchedulesByYear(userId, 2025);
+      const currentYear = new Date().getFullYear();
+      console.log(`[WeeklyCalendar] Cargando horarios para userId: ${userId}, año: ${currentYear}`);
+      const schedules = await interviewerScheduleService.getInterviewerSchedulesByYear(userId, currentYear);
       console.log(`[WeeklyCalendar] Horarios recibidos del backend:`, schedules);
       console.log(`[WeeklyCalendar] Total de horarios: ${schedules.length}`);
 

--- a/microfrontends/apps/mf-evaluations/package.json
+++ b/microfrontends/apps/mf-evaluations/package.json
@@ -14,6 +14,8 @@
     "axios": "^1.11.0",
     "axios-retry": "^4.5.0",
     "date-fns": "^4.1.0",
+    "echarts": "^6.0.0",
+    "echarts-for-react": "^3.0.6",
     "express": "^4.18.2",
     "firebase": "^12.12.1",
     "lucide-react": "^0.540.0",
@@ -23,7 +25,6 @@
     "react-dropzone": "^14.3.8",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.3",
-    "recharts": "^3.2.1",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {

--- a/microfrontends/apps/mf-evaluations/pages/AdminDashboard.tsx
+++ b/microfrontends/apps/mf-evaluations/pages/AdminDashboard.tsx
@@ -61,6 +61,7 @@ import CoordinatorDashboardModal from '../components/modals/CoordinatorDashboard
 import { useAuth } from '../context/AuthContext';
 import ApplicationsTable from '../components/admin/ApplicationsTable';
 import SimpleToast from '../components/ui/SimpleToast';
+import { microfrontendUrls } from '../utils/microfrontendUrls';
 import AdminDataTables from '../components/admin/AdminDataTables';
 import StudentDetailModal from '../components/admin/StudentDetailModal';
 import ApplicationDecisionModal from '../components/admin/ApplicationDecisionModal';
@@ -892,8 +893,8 @@ Esta acción:
         <Button
           variant="primary"
           className="w-full bg-azul-monte-tabor hover:bg-blue-700 text-white font-medium py-3 transition-all duration-200 shadow-md hover:shadow-lg"
-          onClick={() => logout()}
-          ariaLabel="Cerrar sesión y salir del panel de administración"
+          onClick={() => { logout(); window.location.href = microfrontendUrls.home; }}
+          ariaLabel="Cerrar sesión y volver al portal principal"
         >
           Cerrar Sesión
         </Button>

--- a/microfrontends/apps/mf-evaluations/pages/ProfessorDashboard.tsx
+++ b/microfrontends/apps/mf-evaluations/pages/ProfessorDashboard.tsx
@@ -37,6 +37,8 @@ import {
 import { interviewService } from '../services/interviewService';
 import { UserRole, USER_ROLE_LABELS } from '../types/user';
 import api from '../services/api';
+import { microfrontendUrls } from '../utils/microfrontendUrls';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 const baseSections = [
     { key: 'dashboard', label: 'Dashboard General', icon: DashboardIcon },
@@ -50,9 +52,10 @@ const baseSections = [
 const ProfessorDashboard: React.FC = () => {
     const navigate = useNavigate();
 
-    // Obtener profesor actual del localStorage
+    // Obtener profesor actual del localStorage (con namespace de entorno)
     const [currentProfessor, setCurrentProfessor] = useState(() => {
-        const storedProfessor = localStorage.getItem('currentProfessor');
+        const key = getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR);
+        const storedProfessor = localStorage.getItem(key) || localStorage.getItem('currentProfessor');
         const parsed = storedProfessor ? JSON.parse(storedProfessor) : null;
         return parsed;
     });
@@ -151,7 +154,7 @@ const ProfessorDashboard: React.FC = () => {
                         email: professorData.email,
                         role: professorData.role
                     };
-                    localStorage.setItem('currentProfessor', JSON.stringify(updatedProfessor));
+                    localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR), JSON.stringify(updatedProfessor));
                     setCurrentProfessor(updatedProfessor);
                 } else if (!professorData) {
                     console.warn('getCurrentProfessor() retornó null');
@@ -177,26 +180,34 @@ const ProfessorDashboard: React.FC = () => {
         let abortController = new AbortController();
 
         const loadEvaluations = async () => {
-            if (!currentProfessor) {
-                return;
-            }
-
             try {
                 if (isMounted) setIsLoading(true);
+
+                // Fetch fresh professor data to guarantee correct ID regardless of localStorage state
+                const freshProfessor = await professorAuthService.getCurrentProfessor();
+                if (!freshProfessor) {
+                    console.warn('No se pudo obtener el profesor actual');
+                    if (isMounted) setIsLoading(false);
+                    return;
+                }
+
+                if (isMounted && freshProfessor.id !== currentProfessorRef.current?.id) {
+                    const updated = { ...currentProfessorRef.current, ...freshProfessor };
+                    localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR), JSON.stringify(updated));
+                    setCurrentProfessor(updated);
+                }
 
                 const [evaluationsData, statsData, interviewsData] = await Promise.all([
                     professorEvaluationService.getMyEvaluations(),
                     professorEvaluationService.getMyEvaluationStats(),
-                    interviewService.getInterviewsByInterviewer(currentProfessor.id)
+                    interviewService.getInterviewsByInterviewer(freshProfessor.id)
                 ]);
 
                 if (isMounted) {
                     setEvaluations(evaluationsData);
                     setEvaluationStats(statsData);
                     setInterviews(interviewsData);
-                    console.log('Loaded interviews for professor:', interviewsData.length);
-                    console.log('Professor ID:', currentProfessor.id);
-                    console.log('Interview details:', interviewsData);
+                    console.log('Loaded interviews for professor:', interviewsData.length, 'id:', freshProfessor.id);
                 }
 
             } catch (error: any) {
@@ -243,8 +254,8 @@ const ProfessorDashboard: React.FC = () => {
     }, [currentProfessor?.id]);
 
     const handleLogout = () => {
-        localStorage.removeItem('currentProfessor');
-        navigate('/profesor/login');
+        professorAuthService.logout();
+        window.location.href = microfrontendUrls.home;
     };
 
     // Determinar si mostrar sección de administrador
@@ -1591,23 +1602,13 @@ const ProfessorDashboard: React.FC = () => {
                     );
                 })}
             </nav>
-            <div className="mt-8 pt-8 border-t border-blue-700 space-y-2">
-                <Link to="/" onClick={() => onNavigate?.()}>
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        className="w-full text-blanco-pureza border-blanco-pureza hover:bg-blanco-pureza hover:text-azul-monte-tabor"
-                        ariaLabel="Volver al portal principal del sistema"
-                    >
-                        Volver al Portal Principal
-                    </Button>
-                </Link>
+            <div className="mt-8 pt-8 border-t border-blue-700">
                 <Button
                     variant="outline"
                     size="sm"
                     className="w-full text-blanco-pureza border-blanco-pureza hover:bg-red-500 hover:text-blanco-pureza"
                     onClick={handleLogout}
-                    ariaLabel="Cerrar sesión y salir del portal de profesores"
+                    ariaLabel="Cerrar sesión y volver al portal principal"
                 >
                     Cerrar Sesión
                 </Button>

--- a/microfrontends/apps/mf-evaluations/pages/ProfessorLoginPage.tsx
+++ b/microfrontends/apps/mf-evaluations/pages/ProfessorLoginPage.tsx
@@ -9,6 +9,7 @@ import { useNotifications } from '../context/AppContext';
 import { professorAuthService } from '../services/professorAuthService';
 import { useAuth } from '../context/AuthContext';
 import { microfrontendUrls } from '../utils/microfrontendUrls';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 const ProfessorLoginPage: React.FC = () => {
     const navigate = useNavigate();
@@ -95,10 +96,32 @@ const ProfessorLoginPage: React.FC = () => {
                     });
 
                     console.log('Login exitoso, redirigiendo al dashboard...');
-                    
+
                     // Redirigir según el rol del usuario
                     if (respRole === 'ADMIN') {
                         console.log('Usuario admin detectado, redirigiendo al panel de administración...');
+
+                        // Save auth data to cookies for cross-port access (5204 -> 5206)
+                        const adminUser = {
+                            id: String(respId),
+                            email: respEmail,
+                            firstName: respFirstName,
+                            lastName: respLastName,
+                            role: 'ADMIN',
+                        };
+
+                        // Also save to localStorage with environment-aware key (for same-port restore)
+                        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(adminUser));
+                        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), response.token);
+
+                        // Save to cookies for cross-port access (port 5204 to 5206)
+                        const expirationDate = new Date();
+                        expirationDate.setDate(expirationDate.getDate() + 7);
+                        console.log('[EvaluationsLogin] Setting cookies for cross-port admin access');
+                        document.cookie = `auth_user=${encodeURIComponent(JSON.stringify(adminUser))}; path=/; expires=${expirationDate.toUTCString()}`;
+                        document.cookie = `auth_token=${encodeURIComponent(response.token)}; path=/; expires=${expirationDate.toUTCString()}`;
+                        console.log('[EvaluationsLogin] Redirecting to admin dashboard');
+
                         window.location.href = microfrontendUrls.adminDashboard;
                     } else {
                         console.log('Usuario profesor detectado, redirigiendo al dashboard de profesor...');

--- a/microfrontends/apps/mf-evaluations/pages/ProfessorLoginPage.tsx
+++ b/microfrontends/apps/mf-evaluations/pages/ProfessorLoginPage.tsx
@@ -3,18 +3,15 @@ import { useNavigate } from 'react-router-dom';
 import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
-import { LogoIcon } from '../components/icons/Icons';
 import { useFormValidation } from '../hooks/useFormValidation';
 import { useNotifications } from '../context/AppContext';
 import { professorAuthService } from '../services/professorAuthService';
-import { useAuth } from '../context/AuthContext';
 import { microfrontendUrls } from '../utils/microfrontendUrls';
 import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 const ProfessorLoginPage: React.FC = () => {
     const navigate = useNavigate();
     const { addNotification } = useNotifications();
-    const { login: loginWithAuth } = useAuth();
     const [isLoggingIn, setIsLoggingIn] = useState(false);
     const [loginError, setLoginError] = useState<string | null>(null);
 
@@ -68,25 +65,19 @@ const ProfessorLoginPage: React.FC = () => {
             const respSubject   = u?.subject   || (response as any).subject   || null;
 
             if (response.success && response.token) {
-                // Verificar que el rol sea de profesor
+                // Verificar que el rol sea de profesor (ADMIN excluido: tiene su propio portal)
                 if (respRole && professorAuthService.isProfessorRole(respRole)) {
-                    
-                    // Si es admin, registrar en AuthContext principal
-                    if (respRole === 'ADMIN') {
-                        console.log('Usuario admin detectado, registrando en AuthContext principal...');
-                        await loginWithAuth(data.email, data.password, 'ADMIN');
-                    }
-                    
+
                     // Guardar información del profesor en localStorage para compatibilidad
-                    localStorage.setItem('currentProfessor', JSON.stringify({
+                    localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR), JSON.stringify({
                         id: respId,
                         firstName: respFirstName,
                         lastName: respLastName,
                         email: respEmail,
+                        role: respRole,
                         subject: respSubject,
                         subjects: getSubjectsByRole(respRole),
                         assignedGrades: ['prekinder', 'kinder', '1basico', '2basico', '3basico', '4basico', '5basico', '6basico', '7basico', '8basico', '1medio', '2medio', '3medio', '4medio'],
-                        isAdmin: respRole === 'ADMIN'
                     }));
 
                     addNotification({
@@ -95,38 +86,7 @@ const ProfessorLoginPage: React.FC = () => {
                         message: `Hola ${respFirstName} ${respLastName}`
                     });
 
-                    console.log('Login exitoso, redirigiendo al dashboard...');
-
-                    // Redirigir según el rol del usuario
-                    if (respRole === 'ADMIN') {
-                        console.log('Usuario admin detectado, redirigiendo al panel de administración...');
-
-                        // Save auth data to cookies for cross-port access (5204 -> 5206)
-                        const adminUser = {
-                            id: String(respId),
-                            email: respEmail,
-                            firstName: respFirstName,
-                            lastName: respLastName,
-                            role: 'ADMIN',
-                        };
-
-                        // Also save to localStorage with environment-aware key (for same-port restore)
-                        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(adminUser));
-                        localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN), response.token);
-
-                        // Save to cookies for cross-port access (port 5204 to 5206)
-                        const expirationDate = new Date();
-                        expirationDate.setDate(expirationDate.getDate() + 7);
-                        console.log('[EvaluationsLogin] Setting cookies for cross-port admin access');
-                        document.cookie = `auth_user=${encodeURIComponent(JSON.stringify(adminUser))}; path=/; expires=${expirationDate.toUTCString()}`;
-                        document.cookie = `auth_token=${encodeURIComponent(response.token)}; path=/; expires=${expirationDate.toUTCString()}`;
-                        console.log('[EvaluationsLogin] Redirecting to admin dashboard');
-
-                        window.location.href = microfrontendUrls.adminDashboard;
-                    } else {
-                        console.log('Usuario profesor detectado, redirigiendo al dashboard de profesor...');
-                        navigate('/profesor');
-                    }
+                    navigate('/profesor');
                     
                 } else {
                     const msg = 'Su cuenta no tiene acceso a este portal. Contacte al administrador.';
@@ -148,19 +108,9 @@ const ProfessorLoginPage: React.FC = () => {
         }
     };
 
-    const handleKeyPress = (e: React.KeyboardEvent) => {
-        if (e.key === 'Enter') {
-            handleLogin();
-        }
-    };
-
     // Función para obtener las asignaturas según el rol
     const getSubjectsByRole = (role: string): string[] => {
         switch (role) {
-            // Administración
-            case 'ADMIN':
-                return ['MATH', 'SPANISH', 'ENGLISH', 'SCIENCE', 'HISTORY', 'PSYCHOLOGY'];
-            
             // Profesores ciclo inicial (pueden evaluar todo en su ciclo)
             case 'TEACHER_EARLY_CYCLE':
                 return ['MATH', 'SPANISH'];

--- a/microfrontends/apps/mf-evaluations/pages/ProfessorLoginPage.tsx
+++ b/microfrontends/apps/mf-evaluations/pages/ProfessorLoginPage.tsx
@@ -7,7 +7,7 @@ import { useFormValidation } from '../hooks/useFormValidation';
 import { useNotifications } from '../context/AppContext';
 import { professorAuthService } from '../services/professorAuthService';
 import { microfrontendUrls } from '../utils/microfrontendUrls';
-import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
+import { getStorageKey, BASE_STORAGE_KEYS, clearAllSessions } from '../../../packages/backend-sdk/src/index';
 
 const ProfessorLoginPage: React.FC = () => {
     const navigate = useNavigate();
@@ -68,7 +68,7 @@ const ProfessorLoginPage: React.FC = () => {
                 // Verificar que el rol sea de profesor (ADMIN excluido: tiene su propio portal)
                 if (respRole && professorAuthService.isProfessorRole(respRole)) {
 
-                    // Guardar información del profesor en localStorage para compatibilidad
+                    clearAllSessions();
                     localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR), JSON.stringify({
                         id: respId,
                         firstName: respFirstName,

--- a/microfrontends/apps/mf-evaluations/services/api.ts
+++ b/microfrontends/apps/mf-evaluations/services/api.ts
@@ -56,18 +56,25 @@ api.interceptors.request.use(
 
         // Add auth token if not a public route
         if (!isPublic) {
-            const currentUser = auth.currentUser;
-            if (currentUser) {
-                try {
-                    const idToken = await currentUser.getIdToken();
-                    config.headers.Authorization = `Bearer ${idToken}`;
-                } catch {
+            // PROFESSOR_TOKEN takes priority: professor portal uses BFF login (not Firebase),
+            // so auth.currentUser may hold a stale session from a different user.
+            const professorToken = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
+            if (professorToken) {
+                config.headers.Authorization = `Bearer ${professorToken}`;
+            } else {
+                const currentUser = auth.currentUser;
+                if (currentUser) {
+                    try {
+                        const idToken = await currentUser.getIdToken();
+                        config.headers.Authorization = `Bearer ${idToken}`;
+                    } catch {
+                        const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                        if (token) config.headers.Authorization = `Bearer ${token}`;
+                    }
+                } else {
                     const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
                     if (token) config.headers.Authorization = `Bearer ${token}`;
                 }
-            } else {
-                const token = localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN)) || localStorage.getItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN));
-                if (token) config.headers.Authorization = `Bearer ${token}`;
             }
         }
 

--- a/microfrontends/apps/mf-evaluations/services/interviewService.ts
+++ b/microfrontends/apps/mf-evaluations/services/interviewService.ts
@@ -796,14 +796,14 @@ class InterviewService {
       const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
       if (!dateRegex.test(date)) {
         console.error(`getAvailableTimeSlots: Formato de fecha inválido "${date}". Se esperaba YYYY-MM-DD`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Verificar que el año sea razonable
       const year = parseInt(date.split('-')[0]);
       if (year < 2020 || year > 2100) {
         console.error(`getAvailableTimeSlots: Año inválido ${year}. Debe estar entre 2020 y 2100`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Validar y usar duración por defecto si es inválida
@@ -825,8 +825,8 @@ class InterviewService {
 
       // Verificar si la respuesta es del placeholder (microservicio no implementado)
       if (response.data && typeof response.data === 'object' && 'error' in response.data) {
-        console.log('Available slots service no implementado, usando horarios por defecto');
-        return this.getDefaultTimeSlots();
+        console.log('Available slots service no implementado, devolviendo horarios vacíos');
+        return [];
       }
 
       // CASO 1: Backend devuelve estructura { success: true, data: { availableSlots: [...] } }
@@ -878,13 +878,12 @@ class InterviewService {
         }
       }
 
-      console.log('Estructura de respuesta inesperada para available slots, usando horarios por defecto');
+      console.log('Estructura de respuesta inesperada para available slots, devolviendo horarios vacíos');
       console.log('Data recibida:', response.data);
-      return this.getDefaultTimeSlots();
+      return [];
     } catch (error) {
       console.error('Error fetching available slots:', error);
-      // Fallback: horarios estándar si el backend no los tiene configurados
-      return this.getDefaultTimeSlots();
+      return [];
     }
   }
 
@@ -979,14 +978,14 @@ class InterviewService {
       const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
       if (!dateRegex.test(date)) {
         console.error(`getCommonTimeSlots: Formato de fecha inválido "${date}". Se esperaba YYYY-MM-DD`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Verificar que el año sea razonable
       const year = parseInt(date.split('-')[0]);
       if (year < 2020 || year > 2100) {
         console.error(`getCommonTimeSlots: Año inválido ${year}. Debe estar entre 2020 y 2100`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Obtener los horarios disponibles de ambos entrevistadores
@@ -1006,8 +1005,7 @@ class InterviewService {
       return commonSlots;
     } catch (error) {
       console.error('Error obteniendo horarios comunes:', error);
-      // Fallback: horarios por defecto
-      return this.getDefaultTimeSlots();
+      return [];
     }
   }
 

--- a/microfrontends/apps/mf-evaluations/services/interviewService.ts
+++ b/microfrontends/apps/mf-evaluations/services/interviewService.ts
@@ -499,34 +499,24 @@ class InterviewService {
 
   async getInterviewsByInterviewer(interviewerId: number): Promise<Interview[]> {
     try {
-      // Add cache-busting headers and timestamp to force fresh data
       const timestamp = Date.now();
-      console.log(`[getInterviewsByInterviewer] Fetching with timestamp: ${timestamp} for interviewer ${interviewerId}`);
+      console.log(`[getInterviewsByInterviewer] Fetching for interviewer ${interviewerId}`);
 
-      const response = await api.get<InterviewResponse[]>(
-        `${this.baseUrl}/interviewer/${interviewerId}?_t=${timestamp}`,
-        {
-          headers: {
-            'Cache-Control': 'no-cache, no-store, must-revalidate',
-            'Pragma': 'no-cache',
-            'Expires': '0'
-          }
-        }
+      const response = await api.get<any>(
+        `${this.baseUrl}/interviewer/${interviewerId}?_t=${timestamp}`
       );
 
-      // Verificar si la respuesta es del placeholder (microservicio no implementado)
-      if (response.data && typeof response.data === 'object' && 'error' in response.data) {
-        console.log('Interviews by interviewer service no implementado, devolviendo array vacío');
-        return [];
+      // Backend returns { success: true, data: [...], count: n }
+      if (response.data?.success && Array.isArray(response.data.data)) {
+        console.log(`[getInterviewsByInterviewer] Received ${response.data.data.length} interviews`);
+        return response.data.data.map((item: any) => this.mapBackendResponse(item));
       }
 
-      // Verificar si es un array válido
+      // Fallback: bare array (legacy)
       if (Array.isArray(response.data)) {
-        console.log(`[getInterviewsByInterviewer] Received ${response.data.length} interviews for interviewer ${interviewerId}`);
-        return response.data.map(item => this.mapInterviewResponse(item));
+        return response.data.map((item: any) => this.mapBackendResponse(item));
       }
 
-      console.log('Estructura de respuesta inesperada para interviews by interviewer');
       return [];
     } catch (error) {
       console.error('Error fetching interviews by interviewer:', error);

--- a/microfrontends/apps/mf-evaluations/services/interviewerScheduleService.ts
+++ b/microfrontends/apps/mf-evaluations/services/interviewerScheduleService.ts
@@ -191,10 +191,7 @@ export class InterviewerScheduleService {
      */
     async getInterviewerSchedulesByYear(interviewerId: number, year: number): Promise<InterviewerSchedule[]> {
         try {
-            const response = await axios.get(`${this.baseURL}/interviewer/${interviewerId}/year/${year}`, {
-                headers: this.getAuthHeaders()
-            });
-            return response.data;
+            return await httpClient.get(`/v1/interviewer-schedules/interviewer/${interviewerId}/year/${year}`);
         } catch (error) {
             console.error('Error fetching schedules by year:', error);
             throw new Error(axios.isAxiosError(error) ? 

--- a/microfrontends/apps/mf-evaluations/services/professorAuthService.ts
+++ b/microfrontends/apps/mf-evaluations/services/professorAuthService.ts
@@ -39,7 +39,7 @@ class ProfessorAuthService {
 
             // Send credentials directly over HTTPS (no RSA encryption)
             console.log('[Professor Auth] Sending credentials over HTTPS');
-            const response = await api.post('/v1/auth/login', request);
+            const response = await api.post('/v1/auth/login', { ...request, portalType: 'STAFF' });
             const data = response.data;
 
             console.log('Login exitoso para profesor:', data);
@@ -64,8 +64,10 @@ class ProfessorAuthService {
             
             if (error.response?.status === 401) {
                 throw new Error('Credenciales inválidas');
+            } else if (error.response?.status === 403) {
+                throw new Error(error.response?.data?.error?.message || 'Su cuenta no tiene acceso al portal de profesores. Use el portal correspondiente a su rol.');
             } else if (error.response?.status === 400) {
-                throw new Error('Datos de login inválidos');
+                throw new Error(error.response?.data?.error?.message || 'Datos de login inválidos');
             } else if (error.response?.status === 500) {
                 throw new Error('Error del servidor');
             }
@@ -119,9 +121,6 @@ class ProfessorAuthService {
     // Método para verificar si el usuario es un profesor válido
     isProfessorRole(role: string): boolean {
         const professorRoles = [
-            // Administración
-            'ADMIN',
-
             // Roles del backend (actuales)
             'TEACHER',
             'COORDINATOR',

--- a/microfrontends/apps/mf-evaluations/services/professorAuthService.ts
+++ b/microfrontends/apps/mf-evaluations/services/professorAuthService.ts
@@ -1,5 +1,5 @@
 import api from './api';
-import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
+import { getStorageKey, BASE_STORAGE_KEYS, clearAllSessions } from '../../../packages/backend-sdk/src/index';
 // RSA encryption removed - credentials sent over HTTPS only
 // import encryptionService from './encryptionService';
 
@@ -44,8 +44,9 @@ class ProfessorAuthService {
 
             console.log('Login exitoso para profesor:', data);
 
-            // Guardar token en localStorage
+            // Limpiar sesiones previas y guardar nuevo token
             if (data.token) {
+                clearAllSessions();
                 localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_TOKEN), data.token);
                 const u = data.user;
                 localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.PROFESSOR_USER), JSON.stringify({

--- a/microfrontends/apps/mf-evaluations/src/components/charts/EChart.tsx
+++ b/microfrontends/apps/mf-evaluations/src/components/charts/EChart.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactECharts from 'echarts-for-react';
+import type { EChartsOption } from 'echarts';
+
+interface EChartProps {
+  option: EChartsOption;
+  height?: number;
+  onEvents?: Record<string, (params: any) => void>;
+}
+
+const EChart: React.FC<EChartProps> = ({ option, height = 300, onEvents }) => (
+  <ReactECharts
+    option={option}
+    notMerge
+    lazyUpdate
+    onEvents={onEvents}
+    style={{ width: '100%', height }}
+  />
+);
+
+export default EChart;

--- a/microfrontends/apps/mf-evaluations/src/components/coordinator/CoordinatorDashboard.tsx
+++ b/microfrontends/apps/mf-evaluations/src/components/coordinator/CoordinatorDashboard.tsx
@@ -9,7 +9,8 @@
 import React, { useState, useEffect } from 'react';
 import { dashboardClient } from '../../api/dashboard.client';
 import type { DetailedAdminStats, Alert } from '../../api/dashboard.types';
-import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { ApplicantMetricsModal } from '../../../components/modals/ApplicantMetricsModal';
 
 export const CoordinatorDashboard: React.FC = () => {
@@ -143,6 +144,32 @@ export const CoordinatorDashboard: React.FC = () => {
   const acceptanceRate = stats.totalApplications > 0
     ? ((stats.statusBreakdown.approved / stats.totalApplications) * 100).toFixed(1)
     : '0.0';
+
+  const statusChartOption: EChartsOption = {
+    color: statusData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [
+      {
+        type: 'pie',
+        radius: ['42%', '70%'],
+        center: ['50%', '50%'],
+        avoidLabelOverlap: true,
+        itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+        label: { formatter: '{b}: {d}%' },
+        data: statusData.map(item => ({ name: item.name, value: item.value }))
+      }
+    ]
+  };
+
+  const gradeChartOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: gradeData.map(item => item.grade), axisTick: { alignWithLabel: true } },
+    yAxis: { type: 'value' },
+    series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 42 }]
+  };
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -336,25 +363,7 @@ export const CoordinatorDashboard: React.FC = () => {
         {/* Status Distribution Pie Chart */}
         <div className="bg-white shadow rounded-lg p-6">
           <h2 className="text-lg font-medium text-gray-900 mb-4">Distribución por Estado</h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie
-                data={statusData}
-                cx="50%"
-                cy="50%"
-                labelLine={false}
-                label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
-                outerRadius={80}
-                fill="#8884d8"
-                dataKey="value"
-              >
-                {statusData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
-                ))}
-              </Pie>
-              <Tooltip />
-            </PieChart>
-          </ResponsiveContainer>
+          <EChart option={statusChartOption} height={300} />
           <div className="mt-4 grid grid-cols-2 gap-2 text-sm">
             {statusData.map((item, index) => (
               <div key={index} className="flex items-center">
@@ -371,16 +380,7 @@ export const CoordinatorDashboard: React.FC = () => {
         {/* Grade Distribution Bar Chart */}
         <div className="bg-white shadow rounded-lg p-6">
           <h2 className="text-lg font-medium text-gray-900 mb-4">Distribución por Nivel</h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={gradeData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="grade" />
-              <YAxis />
-              <Tooltip />
-              <Legend />
-              <Bar dataKey="count" fill="#3B82F6" name="Postulaciones" />
-            </BarChart>
-          </ResponsiveContainer>
+          <EChart option={gradeChartOption} height={300} />
         </div>
       </div>
 

--- a/microfrontends/apps/mf-evaluations/src/components/coordinator/TemporalTrendsView.tsx
+++ b/microfrontends/apps/mf-evaluations/src/components/coordinator/TemporalTrendsView.tsx
@@ -8,7 +8,8 @@
 import React, { useState, useEffect } from 'react';
 import { dashboardClient } from '../../api/dashboard.client';
 import type { TemporalTrend, DetailedAdminStats } from '../../api/dashboard.types';
-import { LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { format } from 'date-fns';
 
 export const TemporalTrendsView: React.FC = () => {
@@ -114,6 +115,52 @@ export const TemporalTrendsView: React.FC = () => {
     };
   }).filter(Boolean);
 
+  const monthlyTrendsOption: EChartsOption = {
+    color: ['#3B82F6', '#10B981', '#EF4444', '#F59E0B'],
+    tooltip: { trigger: 'axis' },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 48, top: 24, bottom: 80, containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: monthlyTrendsData.map(item => item.month),
+      axisLabel: { rotate: 45 }
+    },
+    yAxis: [
+      { type: 'value', name: 'Postulaciones' },
+      { type: 'value', name: '%' }
+    ],
+    series: [
+      { name: 'Total Postulaciones', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.total) },
+      { name: 'Aprobadas', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.approved) },
+      { name: 'Rechazadas', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.rejected) },
+      { name: 'Tasa de Crecimiento (%)', type: 'line', smooth: true, yAxisIndex: 1, lineStyle: { type: 'dashed' }, data: monthlyTrendsData.map(item => item.growthRate) }
+    ]
+  };
+
+  const comparisonOption: EChartsOption = {
+    color: ['#3B82F6', '#10B981', '#EF4444'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: comparisonData.map((item: any) => item.year) },
+    yAxis: { type: 'value' },
+    series: [
+      { name: 'Total', type: 'bar', data: comparisonData.map((item: any) => item.total) },
+      { name: 'Aprobadas', type: 'bar', data: comparisonData.map((item: any) => item.approved) },
+      { name: 'Rechazadas', type: 'bar', data: comparisonData.map((item: any) => item.rejected) }
+    ]
+  };
+
+  const acceptanceRateOption: EChartsOption = {
+    color: ['#10B981'],
+    tooltip: { trigger: 'axis', valueFormatter: value => `${Number(value).toFixed(1)}%` },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: comparisonData.map((item: any) => item.year) },
+    yAxis: { type: 'value', min: 0, max: 100 },
+    series: [{ name: 'Tasa de Aceptación (%)', type: 'bar', data: comparisonData.map((item: any) => item.acceptanceRate), barMaxWidth: 48 }]
+  };
+
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       {/* Header */}
@@ -147,50 +194,7 @@ export const TemporalTrendsView: React.FC = () => {
       {/* Monthly Trends Chart */}
       <div className="bg-white shadow rounded-lg p-6 mb-6">
         <h2 className="text-lg font-medium text-gray-900 mb-4">Tendencia Mensual (Últimos 12 meses)</h2>
-        <ResponsiveContainer width="100%" height={400}>
-          <LineChart data={monthlyTrendsData}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="month" angle={-45} textAnchor="end" height={80} />
-            <YAxis yAxisId="left" />
-            <YAxis yAxisId="right" orientation="right" />
-            <Tooltip />
-            <Legend />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="total"
-              stroke="#3B82F6"
-              strokeWidth={2}
-              name="Total Postulaciones"
-              dot={{ r: 4 }}
-            />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="approved"
-              stroke="#10B981"
-              strokeWidth={2}
-              name="Aprobadas"
-            />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="rejected"
-              stroke="#EF4444"
-              strokeWidth={2}
-              name="Rechazadas"
-            />
-            <Line
-              yAxisId="right"
-              type="monotone"
-              dataKey="growthRate"
-              stroke="#F59E0B"
-              strokeWidth={2}
-              name="Tasa de Crecimiento (%)"
-              strokeDasharray="5 5"
-            />
-          </LineChart>
-        </ResponsiveContainer>
+        <EChart option={monthlyTrendsOption} height={400} />
       </div>
 
       {/* Year Comparison */}
@@ -199,33 +203,13 @@ export const TemporalTrendsView: React.FC = () => {
           {/* Total Applications Comparison */}
           <div className="bg-white shadow rounded-lg p-6">
             <h2 className="text-lg font-medium text-gray-900 mb-4">Comparativa de Postulaciones</h2>
-            <ResponsiveContainer width="100%" height={300}>
-              <BarChart data={comparisonData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="year" />
-                <YAxis />
-                <Tooltip />
-                <Legend />
-                <Bar dataKey="total" fill="#3B82F6" name="Total" />
-                <Bar dataKey="approved" fill="#10B981" name="Aprobadas" />
-                <Bar dataKey="rejected" fill="#EF4444" name="Rechazadas" />
-              </BarChart>
-            </ResponsiveContainer>
+            <EChart option={comparisonOption} height={300} />
           </div>
 
           {/* Acceptance Rate Comparison */}
           <div className="bg-white shadow rounded-lg p-6">
             <h2 className="text-lg font-medium text-gray-900 mb-4">Tasa de Aceptación por Año</h2>
-            <ResponsiveContainer width="100%" height={300}>
-              <BarChart data={comparisonData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="year" />
-                <YAxis domain={[0, 100]} />
-                <Tooltip formatter={(value) => `${Number(value).toFixed(1)}%`} />
-                <Legend />
-                <Bar dataKey="acceptanceRate" fill="#10B981" name="Tasa de Aceptación (%)" />
-              </BarChart>
-            </ResponsiveContainer>
+            <EChart option={acceptanceRateOption} height={300} />
           </div>
         </div>
       )}

--- a/microfrontends/apps/mf-guardian/App.tsx
+++ b/microfrontends/apps/mf-guardian/App.tsx
@@ -21,6 +21,7 @@ const LoadingFallback = () => (
 function App() {
   const legacyRedirects = createLegacyRedirectRoutes();
   const location = useLocation();
+  const isDashboard = location.pathname.startsWith('/familia') || location.pathname.startsWith('/dashboard-apoderado');
   const isLoginPage = location.pathname === '/apoderado/login';
 
   return (
@@ -28,7 +29,7 @@ function App() {
       <AuthProvider>
         <AppProvider>
           <div className="flex min-h-screen flex-col bg-blanco-pureza text-gray-800">
-            {!isLoginPage && <Header />}
+            {!isLoginPage && !isDashboard && <Header />}
             <main className="flex-grow overflow-x-hidden">
               <Suspense fallback={<LoadingFallback />}>
                 <Routes>

--- a/microfrontends/apps/mf-guardian/components/admin/AnalyticsView.tsx
+++ b/microfrontends/apps/mf-guardian/components/admin/AnalyticsView.tsx
@@ -6,7 +6,8 @@
 import React, { useState, useEffect } from 'react';
 import { FiTrendingUp, FiUsers, FiAward, FiClock } from 'react-icons/fi';
 import Card from '../ui/Card';
-import { BarChart, Bar, LineChart, Line, RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { dashboardClient } from '../../src/api/dashboard.client';
 
 export const AnalyticsView: React.FC = () => {
@@ -54,7 +55,34 @@ export const AnalyticsView: React.FC = () => {
         );
     }
 
-    const COLORS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899'];
+    const evaluatorPerformanceOption: EChartsOption = {
+        color: ['#10B981', '#F59E0B'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: evaluatorData.map(item => item.name) },
+        yAxis: { type: 'value' },
+        series: [
+            { name: 'Completadas', type: 'bar', data: evaluatorData.map(item => item.completed) },
+            { name: 'Pendientes', type: 'bar', data: evaluatorData.map(item => item.pending) }
+        ]
+    };
+
+    const radarData = evaluatorData.slice(0, 6);
+    const evaluatorWorkloadOption: EChartsOption = {
+        color: ['#3B82F6'],
+        tooltip: {},
+        radar: {
+            indicator: radarData.map(item => ({ name: item.name, max: Math.max(...radarData.map(e => e.total || 0), 1) })),
+            splitArea: { areaStyle: { color: ['rgba(59, 130, 246, 0.04)', 'rgba(59, 130, 246, 0.1)'] } }
+        },
+        series: [{
+            name: 'Evaluaciones',
+            type: 'radar',
+            areaStyle: { opacity: 0.35 },
+            data: [{ name: 'Evaluaciones', value: radarData.map(item => item.total || 0) }]
+        }]
+    };
 
     return (
         <div className="space-y-6">
@@ -136,31 +164,13 @@ export const AnalyticsView: React.FC = () => {
                 {/* Evaluator Performance */}
                 <Card className="p-6">
                     <h3 className="text-lg font-semibold text-gray-900 mb-4">Rendimiento de Evaluadores</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <BarChart data={evaluatorData}>
-                            <CartesianGrid strokeDasharray="3 3" />
-                            <XAxis dataKey="name" />
-                            <YAxis />
-                            <Tooltip />
-                            <Legend />
-                            <Bar dataKey="completed" fill="#10B981" name="Completadas" />
-                            <Bar dataKey="pending" fill="#F59E0B" name="Pendientes" />
-                        </BarChart>
-                    </ResponsiveContainer>
+                    <EChart option={evaluatorPerformanceOption} height={300} />
                 </Card>
 
                 {/* Evaluator Workload Radar */}
                 <Card className="p-6">
                     <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución de Carga de Trabajo</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <RadarChart data={evaluatorData.slice(0, 6)}>
-                            <PolarGrid />
-                            <PolarAngleAxis dataKey="name" />
-                            <PolarRadiusAxis />
-                            <Radar name="Evaluaciones" dataKey="total" stroke="#3B82F6" fill="#3B82F6" fillOpacity={0.6} />
-                            <Tooltip />
-                        </RadarChart>
-                    </ResponsiveContainer>
+                    <EChart option={evaluatorWorkloadOption} height={300} />
                 </Card>
             </div>
 

--- a/microfrontends/apps/mf-guardian/components/admin/ApplicantMetricsView.tsx
+++ b/microfrontends/apps/mf-guardian/components/admin/ApplicantMetricsView.tsx
@@ -5,7 +5,8 @@ import Badge from '../ui/Badge';
 import Button from '../ui/Button';
 import { dashboardClient } from '../../src/api/dashboard.client';
 import type { ApplicantMetric, ApplicantMetricsFilters } from '../../src/api/dashboard.types';
-import { PieChart, Pie, BarChart, Bar, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, LabelList } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 
 // Version: 2025-11-11 - Added overallOpinionScore display
 export const ApplicantMetricsView: React.FC = () => {
@@ -178,6 +179,48 @@ export const ApplicantMetricsView: React.FC = () => {
   };
 
   const { performanceData, avgData } = getChartData();
+
+  const performanceDistributionOption: EChartsOption = {
+    color: performanceData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    legend: { bottom: 0 },
+    series: [{
+      type: 'pie',
+      radius: ['42%', '70%'],
+      center: ['50%', '44%'],
+      itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+      label: { formatter: '{d}%' },
+      data: performanceData.map(item => ({ name: item.name, value: item.value }))
+    }]
+  };
+
+  const examAverageOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', valueFormatter: value => `${value}%` },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 24, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: avgData.map(item => item.name) },
+    yAxis: { type: 'value', min: 0, max: 100 },
+    series: [{
+      name: 'Promedio (%)',
+      type: 'bar',
+      data: avgData.map(item => item.promedio),
+      barMaxWidth: 48,
+      label: { show: true, position: 'top', formatter: '{c}%' }
+    }]
+  };
+
+  const subjectDistributionOption: EChartsOption = {
+    color: subjectDistribution.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [{
+      type: 'pie',
+      radius: ['42%', '72%'],
+      itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+      label: { formatter: '{b}: {d}%' },
+      data: subjectDistribution.map(item => ({ name: item.name, value: item.value }))
+    }]
+  };
 
   const uniqueGrades = [...new Set(applicants.map(a => a.gradeApplied))].sort();
   const uniqueStatuses = [...new Set(applicants.map(a => a.applicationStatus))];
@@ -420,56 +463,17 @@ export const ApplicantMetricsView: React.FC = () => {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <Card className="p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución de Rendimiento</h3>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie
-                data={performanceData}
-                cx="50%"
-                cy="50%"
-                labelLine={false}
-                label={({ percent }: { percent?: number }) => `${Math.round((percent || 0) * 100)}%`}
-                outerRadius={80}
-                fill="#8884d8"
-                dataKey="value"
-              >
-                {performanceData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
-                ))}
-              </Pie>
-              <Tooltip />
-              <Legend
-                verticalAlign="bottom"
-                height={36}
-                formatter={(value, entry: any) => entry.payload.name}
-              />
-            </PieChart>
-          </ResponsiveContainer>
+          <EChart option={performanceDistributionOption} height={300} />
         </Card>
 
         <Card className="p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Promedio por Examen</h3>
           <p className="text-sm text-gray-500 mb-2">Haz clic en una barra para ver la distribución detallada</p>
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={avgData} onClick={(data) => {
-              if (data && data.activeLabel) {
-                handleSubjectClick(data.activeLabel);
-              }
-            }}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
-              <YAxis domain={[0, 100]} />
-              <Tooltip />
-              <Legend />
-              <Bar
-                dataKey="promedio"
-                fill="#3B82F6"
-                name="Promedio (%)"
-                cursor="pointer"
-              >
-                <LabelList dataKey="promedio" position="top" formatter={(value: number) => `${value}%`} />
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+          <EChart
+            option={examAverageOption}
+            height={300}
+            onEvents={{ click: params => params.name && handleSubjectClick(String(params.name)) }}
+          />
         </Card>
       </div>
 
@@ -680,27 +684,7 @@ export const ApplicantMetricsView: React.FC = () => {
               </div>
 
               <div className="mb-6">
-                <ResponsiveContainer width="100%" height={350}>
-                  <PieChart>
-                    <Pie
-                      data={subjectDistribution}
-                      cx="50%"
-                      cy="50%"
-                      labelLine={false}
-                      label={({ name, percent }: { name: string, percent?: number }) =>
-                        `${name}: ${Math.round((percent || 0) * 100)}%`
-                      }
-                      outerRadius={120}
-                      fill="#8884d8"
-                      dataKey="value"
-                    >
-                      {subjectDistribution.map((entry, index) => (
-                        <Cell key={`cell-${index}`} fill={entry.color} />
-                      ))}
-                    </Pie>
-                    <Tooltip />
-                  </PieChart>
-                </ResponsiveContainer>
+                <EChart option={subjectDistributionOption} height={350} />
               </div>
 
               <div className="border-t pt-4">

--- a/microfrontends/apps/mf-guardian/components/admin/ReportsView.tsx
+++ b/microfrontends/apps/mf-guardian/components/admin/ReportsView.tsx
@@ -7,7 +7,8 @@ import React, { useState, useEffect } from 'react';
 import { FiDownload, FiFilter, FiCalendar, FiBarChart2, FiPieChart, FiTrendingUp } from 'react-icons/fi';
 import Card from '../ui/Card';
 import Button from '../ui/Button';
-import { BarChart, Bar, PieChart, Pie, LineChart, Line, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { dashboardClient } from '../../src/api/dashboard.client';
 
 interface ReportFilters {
@@ -85,6 +86,64 @@ export const ReportsView: React.FC = () => {
     };
 
     const COLORS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899'];
+
+    const statusBarOption: EChartsOption = {
+        color: ['#3B82F6'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: statusData.map(item => item.name) },
+        yAxis: { type: 'value' },
+        series: [{ name: 'Cantidad', type: 'bar', data: statusData.map(item => item.value), barMaxWidth: 44 }]
+    };
+
+    const statusPieOption: EChartsOption = {
+        color: COLORS,
+        tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+        series: [{
+            type: 'pie',
+            radius: ['42%', '70%'],
+            itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+            label: { formatter: '{b}: {c}' },
+            data: statusData.map(item => ({ name: item.name, value: item.value }))
+        }]
+    };
+
+    const gradeBarOption: EChartsOption = {
+        color: ['#10B981'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: gradeData.map(item => item.grade) },
+        yAxis: { type: 'value' },
+        series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 44 }]
+    };
+
+    const gradePieOption: EChartsOption = {
+        color: COLORS,
+        tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+        series: [{
+            type: 'pie',
+            radius: ['42%', '70%'],
+            itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+            label: { formatter: '{b}: {c}' },
+            data: gradeData.map(item => ({ name: item.grade, value: item.count }))
+        }]
+    };
+
+    const temporalOption: EChartsOption = {
+        color: ['#3B82F6', '#10B981', '#EF4444'],
+        tooltip: { trigger: 'axis' },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 24, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: temporalData.map(item => item.month) },
+        yAxis: { type: 'value' },
+        series: [
+            { name: 'Postulaciones', type: 'line', smooth: true, data: temporalData.map(item => item.applications) },
+            { name: 'Aprobadas', type: 'line', smooth: true, data: temporalData.map(item => item.approved) },
+            { name: 'Rechazadas', type: 'line', smooth: true, data: temporalData.map(item => item.rejected) }
+        ]
+    };
 
     if (loading) {
         return (
@@ -196,38 +255,11 @@ export const ReportsView: React.FC = () => {
                     <>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución por Estado (Barras)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <BarChart data={statusData}>
-                                    <CartesianGrid strokeDasharray="3 3" />
-                                    <XAxis dataKey="name" />
-                                    <YAxis />
-                                    <Tooltip />
-                                    <Legend />
-                                    <Bar dataKey="value" fill="#3B82F6" />
-                                </BarChart>
-                            </ResponsiveContainer>
+                            <EChart option={statusBarOption} height={300} />
                         </Card>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución por Estado (Pastel)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <PieChart>
-                                    <Pie
-                                        data={statusData}
-                                        cx="50%"
-                                        cy="50%"
-                                        labelLine={false}
-                                        label={(entry) => `${entry.name}: ${entry.value}`}
-                                        outerRadius={80}
-                                        fill="#8884d8"
-                                        dataKey="value"
-                                    >
-                                        {statusData.map((entry, index) => (
-                                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                        ))}
-                                    </Pie>
-                                    <Tooltip />
-                                </PieChart>
-                            </ResponsiveContainer>
+                            <EChart option={statusPieOption} height={300} />
                         </Card>
                     </>
                 )}
@@ -236,38 +268,11 @@ export const ReportsView: React.FC = () => {
                     <>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Postulaciones por Grado (Barras)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <BarChart data={gradeData}>
-                                    <CartesianGrid strokeDasharray="3 3" />
-                                    <XAxis dataKey="grade" />
-                                    <YAxis />
-                                    <Tooltip />
-                                    <Legend />
-                                    <Bar dataKey="count" fill="#10B981" />
-                                </BarChart>
-                            </ResponsiveContainer>
+                            <EChart option={gradeBarOption} height={300} />
                         </Card>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Postulaciones por Grado (Pastel)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <PieChart>
-                                    <Pie
-                                        data={gradeData}
-                                        cx="50%"
-                                        cy="50%"
-                                        labelLine={false}
-                                        label={(entry) => `${entry.grade}: ${entry.count}`}
-                                        outerRadius={80}
-                                        fill="#8884d8"
-                                        dataKey="count"
-                                    >
-                                        {gradeData.map((entry, index) => (
-                                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                        ))}
-                                    </Pie>
-                                    <Tooltip />
-                                </PieChart>
-                            </ResponsiveContainer>
+                            <EChart option={gradePieOption} height={300} />
                         </Card>
                     </>
                 )}
@@ -275,18 +280,7 @@ export const ReportsView: React.FC = () => {
                 {selectedReport === 'temporal' && (
                     <Card className="p-6 lg:col-span-2">
                         <h3 className="text-lg font-semibold text-gray-900 mb-4">Tendencias Temporales de Postulaciones</h3>
-                        <ResponsiveContainer width="100%" height={400}>
-                            <LineChart data={temporalData}>
-                                <CartesianGrid strokeDasharray="3 3" />
-                                <XAxis dataKey="month" />
-                                <YAxis />
-                                <Tooltip />
-                                <Legend />
-                                <Line type="monotone" dataKey="applications" stroke="#3B82F6" strokeWidth={2} name="Postulaciones" />
-                                <Line type="monotone" dataKey="approved" stroke="#10B981" strokeWidth={2} name="Aprobadas" />
-                                <Line type="monotone" dataKey="rejected" stroke="#EF4444" strokeWidth={2} name="Rechazadas" />
-                            </LineChart>
-                        </ResponsiveContainer>
+                        <EChart option={temporalOption} height={400} />
                     </Card>
                 )}
             </div>

--- a/microfrontends/apps/mf-guardian/components/charts/EChart.tsx
+++ b/microfrontends/apps/mf-guardian/components/charts/EChart.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactECharts from 'echarts-for-react';
+import type { EChartsOption } from 'echarts';
+
+interface EChartProps {
+  option: EChartsOption;
+  height?: number;
+  onEvents?: Record<string, (params: any) => void>;
+}
+
+const EChart: React.FC<EChartProps> = ({ option, height = 300, onEvents }) => (
+  <ReactECharts
+    option={option}
+    notMerge
+    lazyUpdate
+    onEvents={onEvents}
+    style={{ width: '100%', height }}
+  />
+);
+
+export default EChart;

--- a/microfrontends/apps/mf-guardian/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-guardian/components/interviews/InterviewForm.tsx
@@ -1080,7 +1080,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : (
                   <div className="p-4 bg-gray-50 border border-gray-200 rounded-md">
                     <p className="text-sm text-gray-600 text-center">
-                      👆 Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
+                      Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
                     </p>
                   </div>
                 )}

--- a/microfrontends/apps/mf-guardian/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-guardian/components/interviews/InterviewForm.tsx
@@ -133,21 +133,18 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
 
         console.log('Array de entrevistadores:', dataArray);
 
-        // El backend ya devuelve el formato correcto con firstName, lastName, role, scheduleCount
+        // El backend puede devolver array directo o envuelto, y nombres separados o name.
         const mappedInterviewers: BackendInterviewer[] = dataArray.map((item: any) => ({
-          id: item.id,
-          name: `${item.firstName} ${item.lastName}`,
-          role: item.role,
-          subject: item.subject,
+          id: Number(item.id),
+          name: item.name || `${item.firstName || ''} ${item.lastName || ''}`.trim() || item.email,
+          role: item.role || '',
+          subject: item.subject || '',
           educationalLevel: item.educationalLevel,
-          scheduleCount: item.scheduleCount || 0
-        }));
+          scheduleCount: Number(item.scheduleCount || 0)
+        })).filter((item) => item.id && item.name);
 
-        // Filtrar solo entrevistadores con horarios configurados
-        const interviewersWithSchedules = mappedInterviewers.filter(i => i.scheduleCount > 0);
-
-        console.log(`Entrevistadores con horarios: ${interviewersWithSchedules.length}/${mappedInterviewers.length}`);
-        setInterviewers(interviewersWithSchedules);
+        console.log(`Entrevistadores cargados: ${mappedInterviewers.length}`);
+        setInterviewers(mappedInterviewers);
       } catch (error: any) {
         console.error('Error cargando entrevistadores:', error);
 
@@ -263,7 +260,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
     // Validación de parámetros requeridos
     if (!formData.interviewerId || !formData.scheduledDate) {
       console.log('[loadAvailableTimeSlots] Faltan parámetros requeridos - abortando');
-      setAvailableTimeSlots(INTERVIEW_CONFIG.DEFAULT_TIME_SLOTS);
+      setAvailableTimeSlots([]);
       return;
     }
 
@@ -350,7 +347,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
 
       // Solo actualizar estado si no fue cancelada
       if (!currentController.signal.aborted) {
-        setAvailableTimeSlots(INTERVIEW_CONFIG.DEFAULT_TIME_SLOTS);
+        setAvailableTimeSlots([]);
       }
     } finally {
       // Solo limpiar loading state si esta es la llamada más reciente
@@ -936,9 +933,8 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                     <option
                       key={interviewer.id}
                       value={interviewer.id}
-                      disabled={interviewer.scheduleCount === 0}
                     >
-                      {interviewer.name} - {interviewer.role} {interviewer.scheduleCount === 0 ? '(Sin horarios)' : `(${interviewer.scheduleCount} horarios)`}
+                      {interviewer.name} - {interviewer.role} {interviewer.scheduleCount > 0 ? `(${interviewer.scheduleCount} horarios)` : ''}
                     </option>
                   ))
                 )}
@@ -969,7 +965,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : interviewersError ? (
                   <option disabled>{interviewersError}</option>
                 ) : interviewers.length === 0 ? (
-                  <option disabled>No hay entrevistadores con horarios configurados</option>
+                  <option disabled>No hay entrevistadores disponibles</option>
                 ) : (
                   (() => {
                     const filteredInterviewers = interviewers.filter(interviewer => {
@@ -988,9 +984,8 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                       <option
                         key={interviewer.id}
                         value={interviewer.id}
-                        disabled={interviewer.scheduleCount === 0}
                       >
-                        {interviewer.name} - {interviewer.role} {interviewer.scheduleCount === 0 ? '(Sin horarios)' : `(${interviewer.scheduleCount} horarios)`}
+                        {interviewer.name} - {interviewer.role} {interviewer.scheduleCount > 0 ? `(${interviewer.scheduleCount} horarios)` : ''}
                       </option>
                     ));
                   })()

--- a/microfrontends/apps/mf-guardian/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-guardian/components/interviews/InterviewForm.tsx
@@ -1080,7 +1080,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : (
                   <div className="p-4 bg-gray-50 border border-gray-200 rounded-md">
                     <p className="text-sm text-gray-600 text-center">
-                      Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
+                      👆 Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
                     </p>
                   </div>
                 )}

--- a/microfrontends/apps/mf-guardian/components/layout/Footer.tsx
+++ b/microfrontends/apps/mf-guardian/components/layout/Footer.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Facebook, Instagram, Linkedin } from 'lucide-react';
+import { microfrontendUrls } from '../../utils/microfrontendUrls';
 
 const Footer: React.FC = () => {
     const [showModal, setShowModal] = useState(false);
@@ -63,8 +64,9 @@ const Footer: React.FC = () => {
                         </div>
                     </div>
                 </div>
-                <div className="border-t border-blue-800 mt-10 pt-6 text-center text-sm text-gray-400">
+                <div className="border-t border-blue-800 mt-10 pt-6 flex flex-col sm:flex-row items-center justify-between gap-2 text-sm text-gray-400">
                     <p>&copy; {new Date().getFullYear()} Colegio Monte Tabor y Nazaret. Todos los derechos reservados.</p>
+                    <a href={microfrontendUrls.adminLogin} className="text-gray-400 hover:text-dorado-nazaret transition-colors text-xs underline underline-offset-2">Acceso personal MTN</a>
                 </div>
             </div>
             {/* Modal de contacto */}

--- a/microfrontends/apps/mf-guardian/components/modals/CoordinatorDashboardModal.tsx
+++ b/microfrontends/apps/mf-guardian/components/modals/CoordinatorDashboardModal.tsx
@@ -7,7 +7,8 @@ import React, { useState, useEffect } from 'react';
 import { FiX, FiRefreshCw } from 'react-icons/fi';
 import { dashboardClient } from '../../src/api/dashboard.client';
 import type { DetailedAdminStats, Alert } from '../../src/api/dashboard.types';
-import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 
 interface CoordinatorDashboardModalProps {
   isOpen: boolean;
@@ -115,6 +116,32 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
   const acceptanceRate = stats && stats.totalApplications > 0
     ? ((stats.statusBreakdown.approved / stats.totalApplications) * 100).toFixed(1)
     : '0.0';
+
+  const statusChartOption: EChartsOption = {
+    color: statusData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [
+      {
+        type: 'pie',
+        radius: ['42%', '70%'],
+        center: ['50%', '50%'],
+        avoidLabelOverlap: true,
+        itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+        label: { formatter: '{b}: {d}%' },
+        data: statusData.map(item => ({ name: item.name, value: item.value }))
+      }
+    ]
+  };
+
+  const gradeChartOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: gradeData.map(item => item.grade), axisTick: { alignWithLabel: true } },
+    yAxis: { type: 'value' },
+    series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 42 }]
+  };
 
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
@@ -348,25 +375,7 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
                   {/* Status Distribution Pie Chart */}
                   <div className="bg-white border border-gray-200 shadow-sm rounded-lg p-6">
                     <h3 className="text-lg font-medium text-gray-900 mb-4">Distribución por Estado</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                      <PieChart>
-                        <Pie
-                          data={statusData}
-                          cx="50%"
-                          cy="50%"
-                          labelLine={false}
-                          label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
-                          outerRadius={80}
-                          fill="#8884d8"
-                          dataKey="value"
-                        >
-                          {statusData.map((entry, index) => (
-                            <Cell key={`cell-${index}`} fill={entry.color} />
-                          ))}
-                        </Pie>
-                        <Tooltip />
-                      </PieChart>
-                    </ResponsiveContainer>
+                    <EChart option={statusChartOption} height={300} />
                     <div className="mt-4 grid grid-cols-2 gap-2 text-sm">
                       {statusData.map((item, index) => (
                         <div key={index} className="flex items-center">
@@ -383,16 +392,7 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
                   {/* Grade Distribution Bar Chart */}
                   <div className="bg-white border border-gray-200 shadow-sm rounded-lg p-6">
                     <h3 className="text-lg font-medium text-gray-900 mb-4">Distribución por Nivel</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                      <BarChart data={gradeData}>
-                        <CartesianGrid strokeDasharray="3 3" />
-                        <XAxis dataKey="grade" />
-                        <YAxis />
-                        <Tooltip />
-                        <Legend />
-                        <Bar dataKey="count" fill="#3B82F6" name="Postulaciones" />
-                      </BarChart>
-                    </ResponsiveContainer>
+                    <EChart option={gradeChartOption} height={300} />
                   </div>
                 </div>
 

--- a/microfrontends/apps/mf-guardian/package.json
+++ b/microfrontends/apps/mf-guardian/package.json
@@ -14,6 +14,8 @@
     "axios": "^1.11.0",
     "axios-retry": "^4.5.0",
     "date-fns": "^4.1.0",
+    "echarts": "^6.0.0",
+    "echarts-for-react": "^3.0.6",
     "express": "^4.18.2",
     "firebase": "^12.12.1",
     "lucide-react": "^0.540.0",
@@ -23,7 +25,6 @@
     "react-dropzone": "^14.3.8",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.3",
-    "recharts": "^3.2.1",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {

--- a/microfrontends/apps/mf-guardian/pages/AdminDashboard.tsx
+++ b/microfrontends/apps/mf-guardian/pages/AdminDashboard.tsx
@@ -61,6 +61,7 @@ import CoordinatorDashboardModal from '../components/modals/CoordinatorDashboard
 import { useAuth } from '../context/AuthContext';
 import ApplicationsTable from '../components/admin/ApplicationsTable';
 import SimpleToast from '../components/ui/SimpleToast';
+import { microfrontendUrls } from '../utils/microfrontendUrls';
 import AdminDataTables from '../components/admin/AdminDataTables';
 import StudentDetailModal from '../components/admin/StudentDetailModal';
 import ApplicationDecisionModal from '../components/admin/ApplicationDecisionModal';
@@ -892,8 +893,8 @@ Esta acción:
         <Button
           variant="primary"
           className="w-full bg-azul-monte-tabor hover:bg-blue-700 text-white font-medium py-3 transition-all duration-200 shadow-md hover:shadow-lg"
-          onClick={() => logout()}
-          ariaLabel="Cerrar sesión y salir del panel de administración"
+          onClick={() => { logout(); window.location.href = microfrontendUrls.home; }}
+          ariaLabel="Cerrar sesión y volver al portal principal"
         >
           Cerrar Sesión
         </Button>

--- a/microfrontends/apps/mf-guardian/pages/ProfessorDashboard.tsx
+++ b/microfrontends/apps/mf-guardian/pages/ProfessorDashboard.tsx
@@ -37,6 +37,7 @@ import {
 import { interviewService } from '../services/interviewService';
 import { UserRole, USER_ROLE_LABELS } from '../types/user';
 import api from '../services/api';
+import { microfrontendUrls } from '../utils/microfrontendUrls';
 
 const baseSections = [
     { key: 'dashboard', label: 'Dashboard General', icon: DashboardIcon },
@@ -243,8 +244,8 @@ const ProfessorDashboard: React.FC = () => {
     }, [currentProfessor?.id]);
 
     const handleLogout = () => {
-        localStorage.removeItem('currentProfessor');
-        navigate('/profesor/login');
+        professorAuthService.logout();
+        window.location.href = microfrontendUrls.home;
     };
 
     // Determinar si mostrar sección de administrador
@@ -1591,23 +1592,13 @@ const ProfessorDashboard: React.FC = () => {
                     );
                 })}
             </nav>
-            <div className="mt-8 pt-8 border-t border-blue-700 space-y-2">
-                <Link to="/" onClick={() => onNavigate?.()}>
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        className="w-full text-blanco-pureza border-blanco-pureza hover:bg-blanco-pureza hover:text-azul-monte-tabor"
-                        ariaLabel="Volver al portal principal del sistema"
-                    >
-                        Volver al Portal Principal
-                    </Button>
-                </Link>
+            <div className="mt-8 pt-8 border-t border-blue-700">
                 <Button
                     variant="outline"
                     size="sm"
                     className="w-full text-blanco-pureza border-blanco-pureza hover:bg-red-500 hover:text-blanco-pureza"
                     onClick={handleLogout}
-                    ariaLabel="Cerrar sesión y salir del portal de profesores"
+                    ariaLabel="Cerrar sesión y volver al portal principal"
                 >
                     Cerrar Sesión
                 </Button>

--- a/microfrontends/apps/mf-guardian/services/interviewService.ts
+++ b/microfrontends/apps/mf-guardian/services/interviewService.ts
@@ -796,14 +796,14 @@ class InterviewService {
       const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
       if (!dateRegex.test(date)) {
         console.error(`getAvailableTimeSlots: Formato de fecha inválido "${date}". Se esperaba YYYY-MM-DD`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Verificar que el año sea razonable
       const year = parseInt(date.split('-')[0]);
       if (year < 2020 || year > 2100) {
         console.error(`getAvailableTimeSlots: Año inválido ${year}. Debe estar entre 2020 y 2100`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Validar y usar duración por defecto si es inválida
@@ -825,8 +825,8 @@ class InterviewService {
 
       // Verificar si la respuesta es del placeholder (microservicio no implementado)
       if (response.data && typeof response.data === 'object' && 'error' in response.data) {
-        console.log('Available slots service no implementado, usando horarios por defecto');
-        return this.getDefaultTimeSlots();
+        console.log('Available slots service no implementado, devolviendo horarios vacíos');
+        return [];
       }
 
       // CASO 1: Backend devuelve estructura { success: true, data: { availableSlots: [...] } }
@@ -878,13 +878,12 @@ class InterviewService {
         }
       }
 
-      console.log('Estructura de respuesta inesperada para available slots, usando horarios por defecto');
+      console.log('Estructura de respuesta inesperada para available slots, devolviendo horarios vacíos');
       console.log('Data recibida:', response.data);
-      return this.getDefaultTimeSlots();
+      return [];
     } catch (error) {
       console.error('Error fetching available slots:', error);
-      // Fallback: horarios estándar si el backend no los tiene configurados
-      return this.getDefaultTimeSlots();
+      return [];
     }
   }
 
@@ -979,14 +978,14 @@ class InterviewService {
       const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
       if (!dateRegex.test(date)) {
         console.error(`getCommonTimeSlots: Formato de fecha inválido "${date}". Se esperaba YYYY-MM-DD`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Verificar que el año sea razonable
       const year = parseInt(date.split('-')[0]);
       if (year < 2020 || year > 2100) {
         console.error(`getCommonTimeSlots: Año inválido ${year}. Debe estar entre 2020 y 2100`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Obtener los horarios disponibles de ambos entrevistadores
@@ -1006,8 +1005,7 @@ class InterviewService {
       return commonSlots;
     } catch (error) {
       console.error('Error obteniendo horarios comunes:', error);
-      // Fallback: horarios por defecto
-      return this.getDefaultTimeSlots();
+      return [];
     }
   }
 

--- a/microfrontends/apps/mf-guardian/src/components/charts/EChart.tsx
+++ b/microfrontends/apps/mf-guardian/src/components/charts/EChart.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactECharts from 'echarts-for-react';
+import type { EChartsOption } from 'echarts';
+
+interface EChartProps {
+  option: EChartsOption;
+  height?: number;
+  onEvents?: Record<string, (params: any) => void>;
+}
+
+const EChart: React.FC<EChartProps> = ({ option, height = 300, onEvents }) => (
+  <ReactECharts
+    option={option}
+    notMerge
+    lazyUpdate
+    onEvents={onEvents}
+    style={{ width: '100%', height }}
+  />
+);
+
+export default EChart;

--- a/microfrontends/apps/mf-guardian/src/components/coordinator/CoordinatorDashboard.tsx
+++ b/microfrontends/apps/mf-guardian/src/components/coordinator/CoordinatorDashboard.tsx
@@ -9,7 +9,8 @@
 import React, { useState, useEffect } from 'react';
 import { dashboardClient } from '../../api/dashboard.client';
 import type { DetailedAdminStats, Alert } from '../../api/dashboard.types';
-import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { ApplicantMetricsModal } from '../../../components/modals/ApplicantMetricsModal';
 
 export const CoordinatorDashboard: React.FC = () => {
@@ -143,6 +144,32 @@ export const CoordinatorDashboard: React.FC = () => {
   const acceptanceRate = stats.totalApplications > 0
     ? ((stats.statusBreakdown.approved / stats.totalApplications) * 100).toFixed(1)
     : '0.0';
+
+  const statusChartOption: EChartsOption = {
+    color: statusData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [
+      {
+        type: 'pie',
+        radius: ['42%', '70%'],
+        center: ['50%', '50%'],
+        avoidLabelOverlap: true,
+        itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+        label: { formatter: '{b}: {d}%' },
+        data: statusData.map(item => ({ name: item.name, value: item.value }))
+      }
+    ]
+  };
+
+  const gradeChartOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: gradeData.map(item => item.grade), axisTick: { alignWithLabel: true } },
+    yAxis: { type: 'value' },
+    series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 42 }]
+  };
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -336,25 +363,7 @@ export const CoordinatorDashboard: React.FC = () => {
         {/* Status Distribution Pie Chart */}
         <div className="bg-white shadow rounded-lg p-6">
           <h2 className="text-lg font-medium text-gray-900 mb-4">Distribución por Estado</h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie
-                data={statusData}
-                cx="50%"
-                cy="50%"
-                labelLine={false}
-                label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
-                outerRadius={80}
-                fill="#8884d8"
-                dataKey="value"
-              >
-                {statusData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
-                ))}
-              </Pie>
-              <Tooltip />
-            </PieChart>
-          </ResponsiveContainer>
+          <EChart option={statusChartOption} height={300} />
           <div className="mt-4 grid grid-cols-2 gap-2 text-sm">
             {statusData.map((item, index) => (
               <div key={index} className="flex items-center">
@@ -371,16 +380,7 @@ export const CoordinatorDashboard: React.FC = () => {
         {/* Grade Distribution Bar Chart */}
         <div className="bg-white shadow rounded-lg p-6">
           <h2 className="text-lg font-medium text-gray-900 mb-4">Distribución por Nivel</h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={gradeData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="grade" />
-              <YAxis />
-              <Tooltip />
-              <Legend />
-              <Bar dataKey="count" fill="#3B82F6" name="Postulaciones" />
-            </BarChart>
-          </ResponsiveContainer>
+          <EChart option={gradeChartOption} height={300} />
         </div>
       </div>
 

--- a/microfrontends/apps/mf-guardian/src/components/coordinator/TemporalTrendsView.tsx
+++ b/microfrontends/apps/mf-guardian/src/components/coordinator/TemporalTrendsView.tsx
@@ -8,7 +8,8 @@
 import React, { useState, useEffect } from 'react';
 import { dashboardClient } from '../../api/dashboard.client';
 import type { TemporalTrend, DetailedAdminStats } from '../../api/dashboard.types';
-import { LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { format } from 'date-fns';
 
 export const TemporalTrendsView: React.FC = () => {
@@ -114,6 +115,52 @@ export const TemporalTrendsView: React.FC = () => {
     };
   }).filter(Boolean);
 
+  const monthlyTrendsOption: EChartsOption = {
+    color: ['#3B82F6', '#10B981', '#EF4444', '#F59E0B'],
+    tooltip: { trigger: 'axis' },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 48, top: 24, bottom: 80, containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: monthlyTrendsData.map(item => item.month),
+      axisLabel: { rotate: 45 }
+    },
+    yAxis: [
+      { type: 'value', name: 'Postulaciones' },
+      { type: 'value', name: '%' }
+    ],
+    series: [
+      { name: 'Total Postulaciones', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.total) },
+      { name: 'Aprobadas', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.approved) },
+      { name: 'Rechazadas', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.rejected) },
+      { name: 'Tasa de Crecimiento (%)', type: 'line', smooth: true, yAxisIndex: 1, lineStyle: { type: 'dashed' }, data: monthlyTrendsData.map(item => item.growthRate) }
+    ]
+  };
+
+  const comparisonOption: EChartsOption = {
+    color: ['#3B82F6', '#10B981', '#EF4444'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: comparisonData.map((item: any) => item.year) },
+    yAxis: { type: 'value' },
+    series: [
+      { name: 'Total', type: 'bar', data: comparisonData.map((item: any) => item.total) },
+      { name: 'Aprobadas', type: 'bar', data: comparisonData.map((item: any) => item.approved) },
+      { name: 'Rechazadas', type: 'bar', data: comparisonData.map((item: any) => item.rejected) }
+    ]
+  };
+
+  const acceptanceRateOption: EChartsOption = {
+    color: ['#10B981'],
+    tooltip: { trigger: 'axis', valueFormatter: value => `${Number(value).toFixed(1)}%` },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: comparisonData.map((item: any) => item.year) },
+    yAxis: { type: 'value', min: 0, max: 100 },
+    series: [{ name: 'Tasa de Aceptación (%)', type: 'bar', data: comparisonData.map((item: any) => item.acceptanceRate), barMaxWidth: 48 }]
+  };
+
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       {/* Header */}
@@ -147,50 +194,7 @@ export const TemporalTrendsView: React.FC = () => {
       {/* Monthly Trends Chart */}
       <div className="bg-white shadow rounded-lg p-6 mb-6">
         <h2 className="text-lg font-medium text-gray-900 mb-4">Tendencia Mensual (Últimos 12 meses)</h2>
-        <ResponsiveContainer width="100%" height={400}>
-          <LineChart data={monthlyTrendsData}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="month" angle={-45} textAnchor="end" height={80} />
-            <YAxis yAxisId="left" />
-            <YAxis yAxisId="right" orientation="right" />
-            <Tooltip />
-            <Legend />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="total"
-              stroke="#3B82F6"
-              strokeWidth={2}
-              name="Total Postulaciones"
-              dot={{ r: 4 }}
-            />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="approved"
-              stroke="#10B981"
-              strokeWidth={2}
-              name="Aprobadas"
-            />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="rejected"
-              stroke="#EF4444"
-              strokeWidth={2}
-              name="Rechazadas"
-            />
-            <Line
-              yAxisId="right"
-              type="monotone"
-              dataKey="growthRate"
-              stroke="#F59E0B"
-              strokeWidth={2}
-              name="Tasa de Crecimiento (%)"
-              strokeDasharray="5 5"
-            />
-          </LineChart>
-        </ResponsiveContainer>
+        <EChart option={monthlyTrendsOption} height={400} />
       </div>
 
       {/* Year Comparison */}
@@ -199,33 +203,13 @@ export const TemporalTrendsView: React.FC = () => {
           {/* Total Applications Comparison */}
           <div className="bg-white shadow rounded-lg p-6">
             <h2 className="text-lg font-medium text-gray-900 mb-4">Comparativa de Postulaciones</h2>
-            <ResponsiveContainer width="100%" height={300}>
-              <BarChart data={comparisonData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="year" />
-                <YAxis />
-                <Tooltip />
-                <Legend />
-                <Bar dataKey="total" fill="#3B82F6" name="Total" />
-                <Bar dataKey="approved" fill="#10B981" name="Aprobadas" />
-                <Bar dataKey="rejected" fill="#EF4444" name="Rechazadas" />
-              </BarChart>
-            </ResponsiveContainer>
+            <EChart option={comparisonOption} height={300} />
           </div>
 
           {/* Acceptance Rate Comparison */}
           <div className="bg-white shadow rounded-lg p-6">
             <h2 className="text-lg font-medium text-gray-900 mb-4">Tasa de Aceptación por Año</h2>
-            <ResponsiveContainer width="100%" height={300}>
-              <BarChart data={comparisonData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="year" />
-                <YAxis domain={[0, 100]} />
-                <Tooltip formatter={(value) => `${Number(value).toFixed(1)}%`} />
-                <Legend />
-                <Bar dataKey="acceptanceRate" fill="#10B981" name="Tasa de Aceptación (%)" />
-              </BarChart>
-            </ResponsiveContainer>
+            <EChart option={acceptanceRateOption} height={300} />
           </div>
         </div>
       )}

--- a/microfrontends/apps/mf-interviews/components/admin/AnalyticsView.tsx
+++ b/microfrontends/apps/mf-interviews/components/admin/AnalyticsView.tsx
@@ -6,7 +6,8 @@
 import React, { useState, useEffect } from 'react';
 import { FiTrendingUp, FiUsers, FiAward, FiClock } from 'react-icons/fi';
 import Card from '../ui/Card';
-import { BarChart, Bar, LineChart, Line, RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { dashboardClient } from '../../src/api/dashboard.client';
 
 export const AnalyticsView: React.FC = () => {
@@ -54,7 +55,34 @@ export const AnalyticsView: React.FC = () => {
         );
     }
 
-    const COLORS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899'];
+    const evaluatorPerformanceOption: EChartsOption = {
+        color: ['#10B981', '#F59E0B'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: evaluatorData.map(item => item.name) },
+        yAxis: { type: 'value' },
+        series: [
+            { name: 'Completadas', type: 'bar', data: evaluatorData.map(item => item.completed) },
+            { name: 'Pendientes', type: 'bar', data: evaluatorData.map(item => item.pending) }
+        ]
+    };
+
+    const radarData = evaluatorData.slice(0, 6);
+    const evaluatorWorkloadOption: EChartsOption = {
+        color: ['#3B82F6'],
+        tooltip: {},
+        radar: {
+            indicator: radarData.map(item => ({ name: item.name, max: Math.max(...radarData.map(e => e.total || 0), 1) })),
+            splitArea: { areaStyle: { color: ['rgba(59, 130, 246, 0.04)', 'rgba(59, 130, 246, 0.1)'] } }
+        },
+        series: [{
+            name: 'Evaluaciones',
+            type: 'radar',
+            areaStyle: { opacity: 0.35 },
+            data: [{ name: 'Evaluaciones', value: radarData.map(item => item.total || 0) }]
+        }]
+    };
 
     return (
         <div className="space-y-6">
@@ -136,31 +164,13 @@ export const AnalyticsView: React.FC = () => {
                 {/* Evaluator Performance */}
                 <Card className="p-6">
                     <h3 className="text-lg font-semibold text-gray-900 mb-4">Rendimiento de Evaluadores</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <BarChart data={evaluatorData}>
-                            <CartesianGrid strokeDasharray="3 3" />
-                            <XAxis dataKey="name" />
-                            <YAxis />
-                            <Tooltip />
-                            <Legend />
-                            <Bar dataKey="completed" fill="#10B981" name="Completadas" />
-                            <Bar dataKey="pending" fill="#F59E0B" name="Pendientes" />
-                        </BarChart>
-                    </ResponsiveContainer>
+                    <EChart option={evaluatorPerformanceOption} height={300} />
                 </Card>
 
                 {/* Evaluator Workload Radar */}
                 <Card className="p-6">
                     <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución de Carga de Trabajo</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <RadarChart data={evaluatorData.slice(0, 6)}>
-                            <PolarGrid />
-                            <PolarAngleAxis dataKey="name" />
-                            <PolarRadiusAxis />
-                            <Radar name="Evaluaciones" dataKey="total" stroke="#3B82F6" fill="#3B82F6" fillOpacity={0.6} />
-                            <Tooltip />
-                        </RadarChart>
-                    </ResponsiveContainer>
+                    <EChart option={evaluatorWorkloadOption} height={300} />
                 </Card>
             </div>
 

--- a/microfrontends/apps/mf-interviews/components/admin/ApplicantMetricsView.tsx
+++ b/microfrontends/apps/mf-interviews/components/admin/ApplicantMetricsView.tsx
@@ -5,7 +5,8 @@ import Badge from '../ui/Badge';
 import Button from '../ui/Button';
 import { dashboardClient } from '../../src/api/dashboard.client';
 import type { ApplicantMetric, ApplicantMetricsFilters } from '../../src/api/dashboard.types';
-import { PieChart, Pie, BarChart, Bar, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, LabelList } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 
 // Version: 2025-11-11 - Added overallOpinionScore display
 export const ApplicantMetricsView: React.FC = () => {
@@ -178,6 +179,48 @@ export const ApplicantMetricsView: React.FC = () => {
   };
 
   const { performanceData, avgData } = getChartData();
+
+  const performanceDistributionOption: EChartsOption = {
+    color: performanceData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    legend: { bottom: 0 },
+    series: [{
+      type: 'pie',
+      radius: ['42%', '70%'],
+      center: ['50%', '44%'],
+      itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+      label: { formatter: '{d}%' },
+      data: performanceData.map(item => ({ name: item.name, value: item.value }))
+    }]
+  };
+
+  const examAverageOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', valueFormatter: value => `${value}%` },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 24, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: avgData.map(item => item.name) },
+    yAxis: { type: 'value', min: 0, max: 100 },
+    series: [{
+      name: 'Promedio (%)',
+      type: 'bar',
+      data: avgData.map(item => item.promedio),
+      barMaxWidth: 48,
+      label: { show: true, position: 'top', formatter: '{c}%' }
+    }]
+  };
+
+  const subjectDistributionOption: EChartsOption = {
+    color: subjectDistribution.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [{
+      type: 'pie',
+      radius: ['42%', '72%'],
+      itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+      label: { formatter: '{b}: {d}%' },
+      data: subjectDistribution.map(item => ({ name: item.name, value: item.value }))
+    }]
+  };
 
   const uniqueGrades = [...new Set(applicants.map(a => a.gradeApplied))].sort();
   const uniqueStatuses = [...new Set(applicants.map(a => a.applicationStatus))];
@@ -420,56 +463,17 @@ export const ApplicantMetricsView: React.FC = () => {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <Card className="p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución de Rendimiento</h3>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie
-                data={performanceData}
-                cx="50%"
-                cy="50%"
-                labelLine={false}
-                label={({ percent }: { percent?: number }) => `${Math.round((percent || 0) * 100)}%`}
-                outerRadius={80}
-                fill="#8884d8"
-                dataKey="value"
-              >
-                {performanceData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
-                ))}
-              </Pie>
-              <Tooltip />
-              <Legend
-                verticalAlign="bottom"
-                height={36}
-                formatter={(value, entry: any) => entry.payload.name}
-              />
-            </PieChart>
-          </ResponsiveContainer>
+          <EChart option={performanceDistributionOption} height={300} />
         </Card>
 
         <Card className="p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Promedio por Examen</h3>
           <p className="text-sm text-gray-500 mb-2">Haz clic en una barra para ver la distribución detallada</p>
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={avgData} onClick={(data) => {
-              if (data && data.activeLabel) {
-                handleSubjectClick(data.activeLabel);
-              }
-            }}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
-              <YAxis domain={[0, 100]} />
-              <Tooltip />
-              <Legend />
-              <Bar
-                dataKey="promedio"
-                fill="#3B82F6"
-                name="Promedio (%)"
-                cursor="pointer"
-              >
-                <LabelList dataKey="promedio" position="top" formatter={(value: number) => `${value}%`} />
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+          <EChart
+            option={examAverageOption}
+            height={300}
+            onEvents={{ click: params => params.name && handleSubjectClick(String(params.name)) }}
+          />
         </Card>
       </div>
 
@@ -680,27 +684,7 @@ export const ApplicantMetricsView: React.FC = () => {
               </div>
 
               <div className="mb-6">
-                <ResponsiveContainer width="100%" height={350}>
-                  <PieChart>
-                    <Pie
-                      data={subjectDistribution}
-                      cx="50%"
-                      cy="50%"
-                      labelLine={false}
-                      label={({ name, percent }: { name: string, percent?: number }) =>
-                        `${name}: ${Math.round((percent || 0) * 100)}%`
-                      }
-                      outerRadius={120}
-                      fill="#8884d8"
-                      dataKey="value"
-                    >
-                      {subjectDistribution.map((entry, index) => (
-                        <Cell key={`cell-${index}`} fill={entry.color} />
-                      ))}
-                    </Pie>
-                    <Tooltip />
-                  </PieChart>
-                </ResponsiveContainer>
+                <EChart option={subjectDistributionOption} height={350} />
               </div>
 
               <div className="border-t pt-4">

--- a/microfrontends/apps/mf-interviews/components/admin/ReportsView.tsx
+++ b/microfrontends/apps/mf-interviews/components/admin/ReportsView.tsx
@@ -7,7 +7,8 @@ import React, { useState, useEffect } from 'react';
 import { FiDownload, FiFilter, FiCalendar, FiBarChart2, FiPieChart, FiTrendingUp } from 'react-icons/fi';
 import Card from '../ui/Card';
 import Button from '../ui/Button';
-import { BarChart, Bar, PieChart, Pie, LineChart, Line, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { dashboardClient } from '../../src/api/dashboard.client';
 
 interface ReportFilters {
@@ -85,6 +86,64 @@ export const ReportsView: React.FC = () => {
     };
 
     const COLORS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899'];
+
+    const statusBarOption: EChartsOption = {
+        color: ['#3B82F6'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: statusData.map(item => item.name) },
+        yAxis: { type: 'value' },
+        series: [{ name: 'Cantidad', type: 'bar', data: statusData.map(item => item.value), barMaxWidth: 44 }]
+    };
+
+    const statusPieOption: EChartsOption = {
+        color: COLORS,
+        tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+        series: [{
+            type: 'pie',
+            radius: ['42%', '70%'],
+            itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+            label: { formatter: '{b}: {c}' },
+            data: statusData.map(item => ({ name: item.name, value: item.value }))
+        }]
+    };
+
+    const gradeBarOption: EChartsOption = {
+        color: ['#10B981'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: gradeData.map(item => item.grade) },
+        yAxis: { type: 'value' },
+        series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 44 }]
+    };
+
+    const gradePieOption: EChartsOption = {
+        color: COLORS,
+        tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+        series: [{
+            type: 'pie',
+            radius: ['42%', '70%'],
+            itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+            label: { formatter: '{b}: {c}' },
+            data: gradeData.map(item => ({ name: item.grade, value: item.count }))
+        }]
+    };
+
+    const temporalOption: EChartsOption = {
+        color: ['#3B82F6', '#10B981', '#EF4444'],
+        tooltip: { trigger: 'axis' },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 24, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: temporalData.map(item => item.month) },
+        yAxis: { type: 'value' },
+        series: [
+            { name: 'Postulaciones', type: 'line', smooth: true, data: temporalData.map(item => item.applications) },
+            { name: 'Aprobadas', type: 'line', smooth: true, data: temporalData.map(item => item.approved) },
+            { name: 'Rechazadas', type: 'line', smooth: true, data: temporalData.map(item => item.rejected) }
+        ]
+    };
 
     if (loading) {
         return (
@@ -196,38 +255,11 @@ export const ReportsView: React.FC = () => {
                     <>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución por Estado (Barras)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <BarChart data={statusData}>
-                                    <CartesianGrid strokeDasharray="3 3" />
-                                    <XAxis dataKey="name" />
-                                    <YAxis />
-                                    <Tooltip />
-                                    <Legend />
-                                    <Bar dataKey="value" fill="#3B82F6" />
-                                </BarChart>
-                            </ResponsiveContainer>
+                            <EChart option={statusBarOption} height={300} />
                         </Card>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución por Estado (Pastel)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <PieChart>
-                                    <Pie
-                                        data={statusData}
-                                        cx="50%"
-                                        cy="50%"
-                                        labelLine={false}
-                                        label={(entry) => `${entry.name}: ${entry.value}`}
-                                        outerRadius={80}
-                                        fill="#8884d8"
-                                        dataKey="value"
-                                    >
-                                        {statusData.map((entry, index) => (
-                                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                        ))}
-                                    </Pie>
-                                    <Tooltip />
-                                </PieChart>
-                            </ResponsiveContainer>
+                            <EChart option={statusPieOption} height={300} />
                         </Card>
                     </>
                 )}
@@ -236,38 +268,11 @@ export const ReportsView: React.FC = () => {
                     <>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Postulaciones por Grado (Barras)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <BarChart data={gradeData}>
-                                    <CartesianGrid strokeDasharray="3 3" />
-                                    <XAxis dataKey="grade" />
-                                    <YAxis />
-                                    <Tooltip />
-                                    <Legend />
-                                    <Bar dataKey="count" fill="#10B981" />
-                                </BarChart>
-                            </ResponsiveContainer>
+                            <EChart option={gradeBarOption} height={300} />
                         </Card>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Postulaciones por Grado (Pastel)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <PieChart>
-                                    <Pie
-                                        data={gradeData}
-                                        cx="50%"
-                                        cy="50%"
-                                        labelLine={false}
-                                        label={(entry) => `${entry.grade}: ${entry.count}`}
-                                        outerRadius={80}
-                                        fill="#8884d8"
-                                        dataKey="count"
-                                    >
-                                        {gradeData.map((entry, index) => (
-                                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                        ))}
-                                    </Pie>
-                                    <Tooltip />
-                                </PieChart>
-                            </ResponsiveContainer>
+                            <EChart option={gradePieOption} height={300} />
                         </Card>
                     </>
                 )}
@@ -275,18 +280,7 @@ export const ReportsView: React.FC = () => {
                 {selectedReport === 'temporal' && (
                     <Card className="p-6 lg:col-span-2">
                         <h3 className="text-lg font-semibold text-gray-900 mb-4">Tendencias Temporales de Postulaciones</h3>
-                        <ResponsiveContainer width="100%" height={400}>
-                            <LineChart data={temporalData}>
-                                <CartesianGrid strokeDasharray="3 3" />
-                                <XAxis dataKey="month" />
-                                <YAxis />
-                                <Tooltip />
-                                <Legend />
-                                <Line type="monotone" dataKey="applications" stroke="#3B82F6" strokeWidth={2} name="Postulaciones" />
-                                <Line type="monotone" dataKey="approved" stroke="#10B981" strokeWidth={2} name="Aprobadas" />
-                                <Line type="monotone" dataKey="rejected" stroke="#EF4444" strokeWidth={2} name="Rechazadas" />
-                            </LineChart>
-                        </ResponsiveContainer>
+                        <EChart option={temporalOption} height={400} />
                     </Card>
                 )}
             </div>

--- a/microfrontends/apps/mf-interviews/components/charts/EChart.tsx
+++ b/microfrontends/apps/mf-interviews/components/charts/EChart.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactECharts from 'echarts-for-react';
+import type { EChartsOption } from 'echarts';
+
+interface EChartProps {
+  option: EChartsOption;
+  height?: number;
+  onEvents?: Record<string, (params: any) => void>;
+}
+
+const EChart: React.FC<EChartProps> = ({ option, height = 300, onEvents }) => (
+  <ReactECharts
+    option={option}
+    notMerge
+    lazyUpdate
+    onEvents={onEvents}
+    style={{ width: '100%', height }}
+  />
+);
+
+export default EChart;

--- a/microfrontends/apps/mf-interviews/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-interviews/components/interviews/InterviewForm.tsx
@@ -1080,7 +1080,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : (
                   <div className="p-4 bg-gray-50 border border-gray-200 rounded-md">
                     <p className="text-sm text-gray-600 text-center">
-                      👆 Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
+                      Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
                     </p>
                   </div>
                 )}

--- a/microfrontends/apps/mf-interviews/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-interviews/components/interviews/InterviewForm.tsx
@@ -133,21 +133,18 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
 
         console.log('Array de entrevistadores:', dataArray);
 
-        // El backend ya devuelve el formato correcto con firstName, lastName, role, scheduleCount
+        // El backend puede devolver array directo o envuelto, y nombres separados o name.
         const mappedInterviewers: BackendInterviewer[] = dataArray.map((item: any) => ({
-          id: item.id,
-          name: `${item.firstName} ${item.lastName}`,
-          role: item.role,
-          subject: item.subject,
+          id: Number(item.id),
+          name: item.name || `${item.firstName || ''} ${item.lastName || ''}`.trim() || item.email,
+          role: item.role || '',
+          subject: item.subject || '',
           educationalLevel: item.educationalLevel,
-          scheduleCount: item.scheduleCount || 0
-        }));
+          scheduleCount: Number(item.scheduleCount || 0)
+        })).filter((item) => item.id && item.name);
 
-        // Filtrar solo entrevistadores con horarios configurados
-        const interviewersWithSchedules = mappedInterviewers.filter(i => i.scheduleCount > 0);
-
-        console.log(`Entrevistadores con horarios: ${interviewersWithSchedules.length}/${mappedInterviewers.length}`);
-        setInterviewers(interviewersWithSchedules);
+        console.log(`Entrevistadores cargados: ${mappedInterviewers.length}`);
+        setInterviewers(mappedInterviewers);
       } catch (error: any) {
         console.error('Error cargando entrevistadores:', error);
 
@@ -263,7 +260,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
     // Validación de parámetros requeridos
     if (!formData.interviewerId || !formData.scheduledDate) {
       console.log('[loadAvailableTimeSlots] Faltan parámetros requeridos - abortando');
-      setAvailableTimeSlots(INTERVIEW_CONFIG.DEFAULT_TIME_SLOTS);
+      setAvailableTimeSlots([]);
       return;
     }
 
@@ -350,7 +347,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
 
       // Solo actualizar estado si no fue cancelada
       if (!currentController.signal.aborted) {
-        setAvailableTimeSlots(INTERVIEW_CONFIG.DEFAULT_TIME_SLOTS);
+        setAvailableTimeSlots([]);
       }
     } finally {
       // Solo limpiar loading state si esta es la llamada más reciente
@@ -936,9 +933,8 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                     <option
                       key={interviewer.id}
                       value={interviewer.id}
-                      disabled={interviewer.scheduleCount === 0}
                     >
-                      {interviewer.name} - {interviewer.role} {interviewer.scheduleCount === 0 ? '(Sin horarios)' : `(${interviewer.scheduleCount} horarios)`}
+                      {interviewer.name} - {interviewer.role} {interviewer.scheduleCount > 0 ? `(${interviewer.scheduleCount} horarios)` : ''}
                     </option>
                   ))
                 )}
@@ -969,7 +965,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : interviewersError ? (
                   <option disabled>{interviewersError}</option>
                 ) : interviewers.length === 0 ? (
-                  <option disabled>No hay entrevistadores con horarios configurados</option>
+                  <option disabled>No hay entrevistadores disponibles</option>
                 ) : (
                   (() => {
                     const filteredInterviewers = interviewers.filter(interviewer => {
@@ -988,9 +984,8 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                       <option
                         key={interviewer.id}
                         value={interviewer.id}
-                        disabled={interviewer.scheduleCount === 0}
                       >
-                        {interviewer.name} - {interviewer.role} {interviewer.scheduleCount === 0 ? '(Sin horarios)' : `(${interviewer.scheduleCount} horarios)`}
+                        {interviewer.name} - {interviewer.role} {interviewer.scheduleCount > 0 ? `(${interviewer.scheduleCount} horarios)` : ''}
                       </option>
                     ));
                   })()

--- a/microfrontends/apps/mf-interviews/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-interviews/components/interviews/InterviewForm.tsx
@@ -1080,7 +1080,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : (
                   <div className="p-4 bg-gray-50 border border-gray-200 rounded-md">
                     <p className="text-sm text-gray-600 text-center">
-                      Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
+                      👆 Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
                     </p>
                   </div>
                 )}

--- a/microfrontends/apps/mf-interviews/components/layout/Footer.tsx
+++ b/microfrontends/apps/mf-interviews/components/layout/Footer.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Facebook, Instagram, Linkedin } from 'lucide-react';
+import { microfrontendUrls } from '../../utils/microfrontendUrls';
 
 const Footer: React.FC = () => {
     const [showModal, setShowModal] = useState(false);
@@ -63,8 +64,9 @@ const Footer: React.FC = () => {
                         </div>
                     </div>
                 </div>
-                <div className="border-t border-blue-800 mt-10 pt-6 text-center text-sm text-gray-400">
+                <div className="border-t border-blue-800 mt-10 pt-6 flex flex-col sm:flex-row items-center justify-between gap-2 text-sm text-gray-400">
                     <p>&copy; {new Date().getFullYear()} Colegio Monte Tabor y Nazaret. Todos los derechos reservados.</p>
+                    <a href={microfrontendUrls.adminLogin} className="text-gray-400 hover:text-dorado-nazaret transition-colors text-xs underline underline-offset-2">Acceso personal MTN</a>
                 </div>
             </div>
             {/* Modal de contacto */}

--- a/microfrontends/apps/mf-interviews/components/modals/CoordinatorDashboardModal.tsx
+++ b/microfrontends/apps/mf-interviews/components/modals/CoordinatorDashboardModal.tsx
@@ -7,7 +7,8 @@ import React, { useState, useEffect } from 'react';
 import { FiX, FiRefreshCw } from 'react-icons/fi';
 import { dashboardClient } from '../../src/api/dashboard.client';
 import type { DetailedAdminStats, Alert } from '../../src/api/dashboard.types';
-import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 
 interface CoordinatorDashboardModalProps {
   isOpen: boolean;
@@ -115,6 +116,32 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
   const acceptanceRate = stats && stats.totalApplications > 0
     ? ((stats.statusBreakdown.approved / stats.totalApplications) * 100).toFixed(1)
     : '0.0';
+
+  const statusChartOption: EChartsOption = {
+    color: statusData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [
+      {
+        type: 'pie',
+        radius: ['42%', '70%'],
+        center: ['50%', '50%'],
+        avoidLabelOverlap: true,
+        itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+        label: { formatter: '{b}: {d}%' },
+        data: statusData.map(item => ({ name: item.name, value: item.value }))
+      }
+    ]
+  };
+
+  const gradeChartOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: gradeData.map(item => item.grade), axisTick: { alignWithLabel: true } },
+    yAxis: { type: 'value' },
+    series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 42 }]
+  };
 
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
@@ -348,25 +375,7 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
                   {/* Status Distribution Pie Chart */}
                   <div className="bg-white border border-gray-200 shadow-sm rounded-lg p-6">
                     <h3 className="text-lg font-medium text-gray-900 mb-4">Distribución por Estado</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                      <PieChart>
-                        <Pie
-                          data={statusData}
-                          cx="50%"
-                          cy="50%"
-                          labelLine={false}
-                          label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
-                          outerRadius={80}
-                          fill="#8884d8"
-                          dataKey="value"
-                        >
-                          {statusData.map((entry, index) => (
-                            <Cell key={`cell-${index}`} fill={entry.color} />
-                          ))}
-                        </Pie>
-                        <Tooltip />
-                      </PieChart>
-                    </ResponsiveContainer>
+                    <EChart option={statusChartOption} height={300} />
                     <div className="mt-4 grid grid-cols-2 gap-2 text-sm">
                       {statusData.map((item, index) => (
                         <div key={index} className="flex items-center">
@@ -383,16 +392,7 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
                   {/* Grade Distribution Bar Chart */}
                   <div className="bg-white border border-gray-200 shadow-sm rounded-lg p-6">
                     <h3 className="text-lg font-medium text-gray-900 mb-4">Distribución por Nivel</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                      <BarChart data={gradeData}>
-                        <CartesianGrid strokeDasharray="3 3" />
-                        <XAxis dataKey="grade" />
-                        <YAxis />
-                        <Tooltip />
-                        <Legend />
-                        <Bar dataKey="count" fill="#3B82F6" name="Postulaciones" />
-                      </BarChart>
-                    </ResponsiveContainer>
+                    <EChart option={gradeChartOption} height={300} />
                   </div>
                 </div>
 

--- a/microfrontends/apps/mf-interviews/package.json
+++ b/microfrontends/apps/mf-interviews/package.json
@@ -14,6 +14,8 @@
     "axios": "^1.11.0",
     "axios-retry": "^4.5.0",
     "date-fns": "^4.1.0",
+    "echarts": "^6.0.0",
+    "echarts-for-react": "^3.0.6",
     "express": "^4.18.2",
     "firebase": "^12.12.1",
     "lucide-react": "^0.540.0",
@@ -23,7 +25,6 @@
     "react-dropzone": "^14.3.8",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.3",
-    "recharts": "^3.2.1",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {

--- a/microfrontends/apps/mf-interviews/services/interviewService.ts
+++ b/microfrontends/apps/mf-interviews/services/interviewService.ts
@@ -796,14 +796,14 @@ class InterviewService {
       const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
       if (!dateRegex.test(date)) {
         console.error(`getAvailableTimeSlots: Formato de fecha inválido "${date}". Se esperaba YYYY-MM-DD`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Verificar que el año sea razonable
       const year = parseInt(date.split('-')[0]);
       if (year < 2020 || year > 2100) {
         console.error(`getAvailableTimeSlots: Año inválido ${year}. Debe estar entre 2020 y 2100`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Validar y usar duración por defecto si es inválida
@@ -825,8 +825,8 @@ class InterviewService {
 
       // Verificar si la respuesta es del placeholder (microservicio no implementado)
       if (response.data && typeof response.data === 'object' && 'error' in response.data) {
-        console.log('Available slots service no implementado, usando horarios por defecto');
-        return this.getDefaultTimeSlots();
+        console.log('Available slots service no implementado, devolviendo horarios vacíos');
+        return [];
       }
 
       // CASO 1: Backend devuelve estructura { success: true, data: { availableSlots: [...] } }
@@ -878,13 +878,12 @@ class InterviewService {
         }
       }
 
-      console.log('Estructura de respuesta inesperada para available slots, usando horarios por defecto');
+      console.log('Estructura de respuesta inesperada para available slots, devolviendo horarios vacíos');
       console.log('Data recibida:', response.data);
-      return this.getDefaultTimeSlots();
+      return [];
     } catch (error) {
       console.error('Error fetching available slots:', error);
-      // Fallback: horarios estándar si el backend no los tiene configurados
-      return this.getDefaultTimeSlots();
+      return [];
     }
   }
 
@@ -979,14 +978,14 @@ class InterviewService {
       const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
       if (!dateRegex.test(date)) {
         console.error(`getCommonTimeSlots: Formato de fecha inválido "${date}". Se esperaba YYYY-MM-DD`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Verificar que el año sea razonable
       const year = parseInt(date.split('-')[0]);
       if (year < 2020 || year > 2100) {
         console.error(`getCommonTimeSlots: Año inválido ${year}. Debe estar entre 2020 y 2100`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Obtener los horarios disponibles de ambos entrevistadores
@@ -1006,8 +1005,7 @@ class InterviewService {
       return commonSlots;
     } catch (error) {
       console.error('Error obteniendo horarios comunes:', error);
-      // Fallback: horarios por defecto
-      return this.getDefaultTimeSlots();
+      return [];
     }
   }
 

--- a/microfrontends/apps/mf-interviews/src/components/charts/EChart.tsx
+++ b/microfrontends/apps/mf-interviews/src/components/charts/EChart.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactECharts from 'echarts-for-react';
+import type { EChartsOption } from 'echarts';
+
+interface EChartProps {
+  option: EChartsOption;
+  height?: number;
+  onEvents?: Record<string, (params: any) => void>;
+}
+
+const EChart: React.FC<EChartProps> = ({ option, height = 300, onEvents }) => (
+  <ReactECharts
+    option={option}
+    notMerge
+    lazyUpdate
+    onEvents={onEvents}
+    style={{ width: '100%', height }}
+  />
+);
+
+export default EChart;

--- a/microfrontends/apps/mf-interviews/src/components/coordinator/CoordinatorDashboard.tsx
+++ b/microfrontends/apps/mf-interviews/src/components/coordinator/CoordinatorDashboard.tsx
@@ -9,7 +9,8 @@
 import React, { useState, useEffect } from 'react';
 import { dashboardClient } from '../../api/dashboard.client';
 import type { DetailedAdminStats, Alert } from '../../api/dashboard.types';
-import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { ApplicantMetricsModal } from '../../../components/modals/ApplicantMetricsModal';
 
 export const CoordinatorDashboard: React.FC = () => {
@@ -143,6 +144,32 @@ export const CoordinatorDashboard: React.FC = () => {
   const acceptanceRate = stats.totalApplications > 0
     ? ((stats.statusBreakdown.approved / stats.totalApplications) * 100).toFixed(1)
     : '0.0';
+
+  const statusChartOption: EChartsOption = {
+    color: statusData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [
+      {
+        type: 'pie',
+        radius: ['42%', '70%'],
+        center: ['50%', '50%'],
+        avoidLabelOverlap: true,
+        itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+        label: { formatter: '{b}: {d}%' },
+        data: statusData.map(item => ({ name: item.name, value: item.value }))
+      }
+    ]
+  };
+
+  const gradeChartOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: gradeData.map(item => item.grade), axisTick: { alignWithLabel: true } },
+    yAxis: { type: 'value' },
+    series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 42 }]
+  };
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -336,25 +363,7 @@ export const CoordinatorDashboard: React.FC = () => {
         {/* Status Distribution Pie Chart */}
         <div className="bg-white shadow rounded-lg p-6">
           <h2 className="text-lg font-medium text-gray-900 mb-4">Distribución por Estado</h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie
-                data={statusData}
-                cx="50%"
-                cy="50%"
-                labelLine={false}
-                label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
-                outerRadius={80}
-                fill="#8884d8"
-                dataKey="value"
-              >
-                {statusData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
-                ))}
-              </Pie>
-              <Tooltip />
-            </PieChart>
-          </ResponsiveContainer>
+          <EChart option={statusChartOption} height={300} />
           <div className="mt-4 grid grid-cols-2 gap-2 text-sm">
             {statusData.map((item, index) => (
               <div key={index} className="flex items-center">
@@ -371,16 +380,7 @@ export const CoordinatorDashboard: React.FC = () => {
         {/* Grade Distribution Bar Chart */}
         <div className="bg-white shadow rounded-lg p-6">
           <h2 className="text-lg font-medium text-gray-900 mb-4">Distribución por Nivel</h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={gradeData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="grade" />
-              <YAxis />
-              <Tooltip />
-              <Legend />
-              <Bar dataKey="count" fill="#3B82F6" name="Postulaciones" />
-            </BarChart>
-          </ResponsiveContainer>
+          <EChart option={gradeChartOption} height={300} />
         </div>
       </div>
 

--- a/microfrontends/apps/mf-interviews/src/components/coordinator/TemporalTrendsView.tsx
+++ b/microfrontends/apps/mf-interviews/src/components/coordinator/TemporalTrendsView.tsx
@@ -8,7 +8,8 @@
 import React, { useState, useEffect } from 'react';
 import { dashboardClient } from '../../api/dashboard.client';
 import type { TemporalTrend, DetailedAdminStats } from '../../api/dashboard.types';
-import { LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { format } from 'date-fns';
 
 export const TemporalTrendsView: React.FC = () => {
@@ -114,6 +115,52 @@ export const TemporalTrendsView: React.FC = () => {
     };
   }).filter(Boolean);
 
+  const monthlyTrendsOption: EChartsOption = {
+    color: ['#3B82F6', '#10B981', '#EF4444', '#F59E0B'],
+    tooltip: { trigger: 'axis' },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 48, top: 24, bottom: 80, containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: monthlyTrendsData.map(item => item.month),
+      axisLabel: { rotate: 45 }
+    },
+    yAxis: [
+      { type: 'value', name: 'Postulaciones' },
+      { type: 'value', name: '%' }
+    ],
+    series: [
+      { name: 'Total Postulaciones', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.total) },
+      { name: 'Aprobadas', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.approved) },
+      { name: 'Rechazadas', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.rejected) },
+      { name: 'Tasa de Crecimiento (%)', type: 'line', smooth: true, yAxisIndex: 1, lineStyle: { type: 'dashed' }, data: monthlyTrendsData.map(item => item.growthRate) }
+    ]
+  };
+
+  const comparisonOption: EChartsOption = {
+    color: ['#3B82F6', '#10B981', '#EF4444'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: comparisonData.map((item: any) => item.year) },
+    yAxis: { type: 'value' },
+    series: [
+      { name: 'Total', type: 'bar', data: comparisonData.map((item: any) => item.total) },
+      { name: 'Aprobadas', type: 'bar', data: comparisonData.map((item: any) => item.approved) },
+      { name: 'Rechazadas', type: 'bar', data: comparisonData.map((item: any) => item.rejected) }
+    ]
+  };
+
+  const acceptanceRateOption: EChartsOption = {
+    color: ['#10B981'],
+    tooltip: { trigger: 'axis', valueFormatter: value => `${Number(value).toFixed(1)}%` },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: comparisonData.map((item: any) => item.year) },
+    yAxis: { type: 'value', min: 0, max: 100 },
+    series: [{ name: 'Tasa de Aceptación (%)', type: 'bar', data: comparisonData.map((item: any) => item.acceptanceRate), barMaxWidth: 48 }]
+  };
+
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       {/* Header */}
@@ -147,50 +194,7 @@ export const TemporalTrendsView: React.FC = () => {
       {/* Monthly Trends Chart */}
       <div className="bg-white shadow rounded-lg p-6 mb-6">
         <h2 className="text-lg font-medium text-gray-900 mb-4">Tendencia Mensual (Últimos 12 meses)</h2>
-        <ResponsiveContainer width="100%" height={400}>
-          <LineChart data={monthlyTrendsData}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="month" angle={-45} textAnchor="end" height={80} />
-            <YAxis yAxisId="left" />
-            <YAxis yAxisId="right" orientation="right" />
-            <Tooltip />
-            <Legend />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="total"
-              stroke="#3B82F6"
-              strokeWidth={2}
-              name="Total Postulaciones"
-              dot={{ r: 4 }}
-            />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="approved"
-              stroke="#10B981"
-              strokeWidth={2}
-              name="Aprobadas"
-            />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="rejected"
-              stroke="#EF4444"
-              strokeWidth={2}
-              name="Rechazadas"
-            />
-            <Line
-              yAxisId="right"
-              type="monotone"
-              dataKey="growthRate"
-              stroke="#F59E0B"
-              strokeWidth={2}
-              name="Tasa de Crecimiento (%)"
-              strokeDasharray="5 5"
-            />
-          </LineChart>
-        </ResponsiveContainer>
+        <EChart option={monthlyTrendsOption} height={400} />
       </div>
 
       {/* Year Comparison */}
@@ -199,33 +203,13 @@ export const TemporalTrendsView: React.FC = () => {
           {/* Total Applications Comparison */}
           <div className="bg-white shadow rounded-lg p-6">
             <h2 className="text-lg font-medium text-gray-900 mb-4">Comparativa de Postulaciones</h2>
-            <ResponsiveContainer width="100%" height={300}>
-              <BarChart data={comparisonData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="year" />
-                <YAxis />
-                <Tooltip />
-                <Legend />
-                <Bar dataKey="total" fill="#3B82F6" name="Total" />
-                <Bar dataKey="approved" fill="#10B981" name="Aprobadas" />
-                <Bar dataKey="rejected" fill="#EF4444" name="Rechazadas" />
-              </BarChart>
-            </ResponsiveContainer>
+            <EChart option={comparisonOption} height={300} />
           </div>
 
           {/* Acceptance Rate Comparison */}
           <div className="bg-white shadow rounded-lg p-6">
             <h2 className="text-lg font-medium text-gray-900 mb-4">Tasa de Aceptación por Año</h2>
-            <ResponsiveContainer width="100%" height={300}>
-              <BarChart data={comparisonData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="year" />
-                <YAxis domain={[0, 100]} />
-                <Tooltip formatter={(value) => `${Number(value).toFixed(1)}%`} />
-                <Legend />
-                <Bar dataKey="acceptanceRate" fill="#10B981" name="Tasa de Aceptación (%)" />
-              </BarChart>
-            </ResponsiveContainer>
+            <EChart option={acceptanceRateOption} height={300} />
           </div>
         </div>
       )}

--- a/microfrontends/apps/mf-reports/App.tsx
+++ b/microfrontends/apps/mf-reports/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Suspense } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import AdminLoginPage from './pages/AdminLoginPage';
 import ReportsDashboard from './pages/ReportsDashboard';
 import ProtectedAdminRoute from './components/auth/ProtectedAdminRoute';
@@ -20,13 +20,15 @@ const LoadingFallback = () => (
 
 function App() {
   const legacyRedirects = createLegacyRedirectRoutes();
+  const location = useLocation();
+  const isPortalPage = location.pathname !== '/login';
 
   return (
     <ErrorBoundary>
       <AuthProvider>
         <AppProvider>
           <div className="flex min-h-screen flex-col bg-blanco-pureza text-gray-800">
-            <Header />
+            {!isPortalPage && <Header />}
             <main className="flex-grow overflow-x-hidden">
               <Suspense fallback={<LoadingFallback />}>
                 <Routes>

--- a/microfrontends/apps/mf-reports/components/admin/AnalyticsView.tsx
+++ b/microfrontends/apps/mf-reports/components/admin/AnalyticsView.tsx
@@ -6,7 +6,8 @@
 import React, { useState, useEffect } from 'react';
 import { FiTrendingUp, FiUsers, FiAward, FiClock } from 'react-icons/fi';
 import Card from '../ui/Card';
-import { BarChart, Bar, LineChart, Line, RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { dashboardClient } from '../../src/api/dashboard.client';
 
 export const AnalyticsView: React.FC = () => {
@@ -54,7 +55,34 @@ export const AnalyticsView: React.FC = () => {
         );
     }
 
-    const COLORS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899'];
+    const evaluatorPerformanceOption: EChartsOption = {
+        color: ['#10B981', '#F59E0B'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: evaluatorData.map(item => item.name) },
+        yAxis: { type: 'value' },
+        series: [
+            { name: 'Completadas', type: 'bar', data: evaluatorData.map(item => item.completed) },
+            { name: 'Pendientes', type: 'bar', data: evaluatorData.map(item => item.pending) }
+        ]
+    };
+
+    const radarData = evaluatorData.slice(0, 6);
+    const evaluatorWorkloadOption: EChartsOption = {
+        color: ['#3B82F6'],
+        tooltip: {},
+        radar: {
+            indicator: radarData.map(item => ({ name: item.name, max: Math.max(...radarData.map(e => e.total || 0), 1) })),
+            splitArea: { areaStyle: { color: ['rgba(59, 130, 246, 0.04)', 'rgba(59, 130, 246, 0.1)'] } }
+        },
+        series: [{
+            name: 'Evaluaciones',
+            type: 'radar',
+            areaStyle: { opacity: 0.35 },
+            data: [{ name: 'Evaluaciones', value: radarData.map(item => item.total || 0) }]
+        }]
+    };
 
     return (
         <div className="space-y-6">
@@ -136,31 +164,13 @@ export const AnalyticsView: React.FC = () => {
                 {/* Evaluator Performance */}
                 <Card className="p-6">
                     <h3 className="text-lg font-semibold text-gray-900 mb-4">Rendimiento de Evaluadores</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <BarChart data={evaluatorData}>
-                            <CartesianGrid strokeDasharray="3 3" />
-                            <XAxis dataKey="name" />
-                            <YAxis />
-                            <Tooltip />
-                            <Legend />
-                            <Bar dataKey="completed" fill="#10B981" name="Completadas" />
-                            <Bar dataKey="pending" fill="#F59E0B" name="Pendientes" />
-                        </BarChart>
-                    </ResponsiveContainer>
+                    <EChart option={evaluatorPerformanceOption} height={300} />
                 </Card>
 
                 {/* Evaluator Workload Radar */}
                 <Card className="p-6">
                     <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución de Carga de Trabajo</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <RadarChart data={evaluatorData.slice(0, 6)}>
-                            <PolarGrid />
-                            <PolarAngleAxis dataKey="name" />
-                            <PolarRadiusAxis />
-                            <Radar name="Evaluaciones" dataKey="total" stroke="#3B82F6" fill="#3B82F6" fillOpacity={0.6} />
-                            <Tooltip />
-                        </RadarChart>
-                    </ResponsiveContainer>
+                    <EChart option={evaluatorWorkloadOption} height={300} />
                 </Card>
             </div>
 

--- a/microfrontends/apps/mf-reports/components/admin/ApplicantMetricsView.tsx
+++ b/microfrontends/apps/mf-reports/components/admin/ApplicantMetricsView.tsx
@@ -5,7 +5,8 @@ import Badge from '../ui/Badge';
 import Button from '../ui/Button';
 import { dashboardClient } from '../../src/api/dashboard.client';
 import type { ApplicantMetric, ApplicantMetricsFilters } from '../../src/api/dashboard.types';
-import { PieChart, Pie, BarChart, Bar, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, LabelList } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 
 // Version: 2025-11-11 - Added overallOpinionScore display
 export const ApplicantMetricsView: React.FC = () => {
@@ -178,6 +179,48 @@ export const ApplicantMetricsView: React.FC = () => {
   };
 
   const { performanceData, avgData } = getChartData();
+
+  const performanceDistributionOption: EChartsOption = {
+    color: performanceData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    legend: { bottom: 0 },
+    series: [{
+      type: 'pie',
+      radius: ['42%', '70%'],
+      center: ['50%', '44%'],
+      itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+      label: { formatter: '{d}%' },
+      data: performanceData.map(item => ({ name: item.name, value: item.value }))
+    }]
+  };
+
+  const examAverageOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', valueFormatter: value => `${value}%` },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 24, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: avgData.map(item => item.name) },
+    yAxis: { type: 'value', min: 0, max: 100 },
+    series: [{
+      name: 'Promedio (%)',
+      type: 'bar',
+      data: avgData.map(item => item.promedio),
+      barMaxWidth: 48,
+      label: { show: true, position: 'top', formatter: '{c}%' }
+    }]
+  };
+
+  const subjectDistributionOption: EChartsOption = {
+    color: subjectDistribution.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [{
+      type: 'pie',
+      radius: ['42%', '72%'],
+      itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+      label: { formatter: '{b}: {d}%' },
+      data: subjectDistribution.map(item => ({ name: item.name, value: item.value }))
+    }]
+  };
 
   const uniqueGrades = [...new Set(applicants.map(a => a.gradeApplied))].sort();
   const uniqueStatuses = [...new Set(applicants.map(a => a.applicationStatus))];
@@ -420,56 +463,17 @@ export const ApplicantMetricsView: React.FC = () => {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <Card className="p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución de Rendimiento</h3>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie
-                data={performanceData}
-                cx="50%"
-                cy="50%"
-                labelLine={false}
-                label={({ percent }: { percent?: number }) => `${Math.round((percent || 0) * 100)}%`}
-                outerRadius={80}
-                fill="#8884d8"
-                dataKey="value"
-              >
-                {performanceData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
-                ))}
-              </Pie>
-              <Tooltip />
-              <Legend
-                verticalAlign="bottom"
-                height={36}
-                formatter={(value, entry: any) => entry.payload.name}
-              />
-            </PieChart>
-          </ResponsiveContainer>
+          <EChart option={performanceDistributionOption} height={300} />
         </Card>
 
         <Card className="p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Promedio por Examen</h3>
           <p className="text-sm text-gray-500 mb-2">Haz clic en una barra para ver la distribución detallada</p>
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={avgData} onClick={(data) => {
-              if (data && data.activeLabel) {
-                handleSubjectClick(data.activeLabel);
-              }
-            }}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
-              <YAxis domain={[0, 100]} />
-              <Tooltip />
-              <Legend />
-              <Bar
-                dataKey="promedio"
-                fill="#3B82F6"
-                name="Promedio (%)"
-                cursor="pointer"
-              >
-                <LabelList dataKey="promedio" position="top" formatter={(value: number) => `${value}%`} />
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+          <EChart
+            option={examAverageOption}
+            height={300}
+            onEvents={{ click: params => params.name && handleSubjectClick(String(params.name)) }}
+          />
         </Card>
       </div>
 
@@ -680,27 +684,7 @@ export const ApplicantMetricsView: React.FC = () => {
               </div>
 
               <div className="mb-6">
-                <ResponsiveContainer width="100%" height={350}>
-                  <PieChart>
-                    <Pie
-                      data={subjectDistribution}
-                      cx="50%"
-                      cy="50%"
-                      labelLine={false}
-                      label={({ name, percent }: { name: string, percent?: number }) =>
-                        `${name}: ${Math.round((percent || 0) * 100)}%`
-                      }
-                      outerRadius={120}
-                      fill="#8884d8"
-                      dataKey="value"
-                    >
-                      {subjectDistribution.map((entry, index) => (
-                        <Cell key={`cell-${index}`} fill={entry.color} />
-                      ))}
-                    </Pie>
-                    <Tooltip />
-                  </PieChart>
-                </ResponsiveContainer>
+                <EChart option={subjectDistributionOption} height={350} />
               </div>
 
               <div className="border-t pt-4">

--- a/microfrontends/apps/mf-reports/components/admin/ReportsView.tsx
+++ b/microfrontends/apps/mf-reports/components/admin/ReportsView.tsx
@@ -7,7 +7,8 @@ import React, { useState, useEffect } from 'react';
 import { FiDownload, FiFilter, FiCalendar, FiBarChart2, FiPieChart, FiTrendingUp } from 'react-icons/fi';
 import Card from '../ui/Card';
 import Button from '../ui/Button';
-import { BarChart, Bar, PieChart, Pie, LineChart, Line, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { dashboardClient } from '../../src/api/dashboard.client';
 
 interface ReportFilters {
@@ -85,6 +86,64 @@ export const ReportsView: React.FC = () => {
     };
 
     const COLORS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899'];
+
+    const statusBarOption: EChartsOption = {
+        color: ['#3B82F6'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: statusData.map(item => item.name) },
+        yAxis: { type: 'value' },
+        series: [{ name: 'Cantidad', type: 'bar', data: statusData.map(item => item.value), barMaxWidth: 44 }]
+    };
+
+    const statusPieOption: EChartsOption = {
+        color: COLORS,
+        tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+        series: [{
+            type: 'pie',
+            radius: ['42%', '70%'],
+            itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+            label: { formatter: '{b}: {c}' },
+            data: statusData.map(item => ({ name: item.name, value: item.value }))
+        }]
+    };
+
+    const gradeBarOption: EChartsOption = {
+        color: ['#10B981'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: gradeData.map(item => item.grade) },
+        yAxis: { type: 'value' },
+        series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 44 }]
+    };
+
+    const gradePieOption: EChartsOption = {
+        color: COLORS,
+        tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+        series: [{
+            type: 'pie',
+            radius: ['42%', '70%'],
+            itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+            label: { formatter: '{b}: {c}' },
+            data: gradeData.map(item => ({ name: item.grade, value: item.count }))
+        }]
+    };
+
+    const temporalOption: EChartsOption = {
+        color: ['#3B82F6', '#10B981', '#EF4444'],
+        tooltip: { trigger: 'axis' },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 24, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: temporalData.map(item => item.month) },
+        yAxis: { type: 'value' },
+        series: [
+            { name: 'Postulaciones', type: 'line', smooth: true, data: temporalData.map(item => item.applications) },
+            { name: 'Aprobadas', type: 'line', smooth: true, data: temporalData.map(item => item.approved) },
+            { name: 'Rechazadas', type: 'line', smooth: true, data: temporalData.map(item => item.rejected) }
+        ]
+    };
 
     if (loading) {
         return (
@@ -196,38 +255,11 @@ export const ReportsView: React.FC = () => {
                     <>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución por Estado (Barras)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <BarChart data={statusData}>
-                                    <CartesianGrid strokeDasharray="3 3" />
-                                    <XAxis dataKey="name" />
-                                    <YAxis />
-                                    <Tooltip />
-                                    <Legend />
-                                    <Bar dataKey="value" fill="#3B82F6" />
-                                </BarChart>
-                            </ResponsiveContainer>
+                            <EChart option={statusBarOption} height={300} />
                         </Card>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución por Estado (Pastel)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <PieChart>
-                                    <Pie
-                                        data={statusData}
-                                        cx="50%"
-                                        cy="50%"
-                                        labelLine={false}
-                                        label={(entry) => `${entry.name}: ${entry.value}`}
-                                        outerRadius={80}
-                                        fill="#8884d8"
-                                        dataKey="value"
-                                    >
-                                        {statusData.map((entry, index) => (
-                                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                        ))}
-                                    </Pie>
-                                    <Tooltip />
-                                </PieChart>
-                            </ResponsiveContainer>
+                            <EChart option={statusPieOption} height={300} />
                         </Card>
                     </>
                 )}
@@ -236,38 +268,11 @@ export const ReportsView: React.FC = () => {
                     <>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Postulaciones por Grado (Barras)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <BarChart data={gradeData}>
-                                    <CartesianGrid strokeDasharray="3 3" />
-                                    <XAxis dataKey="grade" />
-                                    <YAxis />
-                                    <Tooltip />
-                                    <Legend />
-                                    <Bar dataKey="count" fill="#10B981" />
-                                </BarChart>
-                            </ResponsiveContainer>
+                            <EChart option={gradeBarOption} height={300} />
                         </Card>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Postulaciones por Grado (Pastel)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <PieChart>
-                                    <Pie
-                                        data={gradeData}
-                                        cx="50%"
-                                        cy="50%"
-                                        labelLine={false}
-                                        label={(entry) => `${entry.grade}: ${entry.count}`}
-                                        outerRadius={80}
-                                        fill="#8884d8"
-                                        dataKey="count"
-                                    >
-                                        {gradeData.map((entry, index) => (
-                                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                        ))}
-                                    </Pie>
-                                    <Tooltip />
-                                </PieChart>
-                            </ResponsiveContainer>
+                            <EChart option={gradePieOption} height={300} />
                         </Card>
                     </>
                 )}
@@ -275,18 +280,7 @@ export const ReportsView: React.FC = () => {
                 {selectedReport === 'temporal' && (
                     <Card className="p-6 lg:col-span-2">
                         <h3 className="text-lg font-semibold text-gray-900 mb-4">Tendencias Temporales de Postulaciones</h3>
-                        <ResponsiveContainer width="100%" height={400}>
-                            <LineChart data={temporalData}>
-                                <CartesianGrid strokeDasharray="3 3" />
-                                <XAxis dataKey="month" />
-                                <YAxis />
-                                <Tooltip />
-                                <Legend />
-                                <Line type="monotone" dataKey="applications" stroke="#3B82F6" strokeWidth={2} name="Postulaciones" />
-                                <Line type="monotone" dataKey="approved" stroke="#10B981" strokeWidth={2} name="Aprobadas" />
-                                <Line type="monotone" dataKey="rejected" stroke="#EF4444" strokeWidth={2} name="Rechazadas" />
-                            </LineChart>
-                        </ResponsiveContainer>
+                        <EChart option={temporalOption} height={400} />
                     </Card>
                 )}
             </div>

--- a/microfrontends/apps/mf-reports/components/charts/EChart.tsx
+++ b/microfrontends/apps/mf-reports/components/charts/EChart.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactECharts from 'echarts-for-react';
+import type { EChartsOption } from 'echarts';
+
+interface EChartProps {
+  option: EChartsOption;
+  height?: number;
+  onEvents?: Record<string, (params: any) => void>;
+}
+
+const EChart: React.FC<EChartProps> = ({ option, height = 300, onEvents }) => (
+  <ReactECharts
+    option={option}
+    notMerge
+    lazyUpdate
+    onEvents={onEvents}
+    style={{ width: '100%', height }}
+  />
+);
+
+export default EChart;

--- a/microfrontends/apps/mf-reports/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-reports/components/interviews/InterviewForm.tsx
@@ -1080,7 +1080,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : (
                   <div className="p-4 bg-gray-50 border border-gray-200 rounded-md">
                     <p className="text-sm text-gray-600 text-center">
-                      👆 Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
+                      Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
                     </p>
                   </div>
                 )}

--- a/microfrontends/apps/mf-reports/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-reports/components/interviews/InterviewForm.tsx
@@ -133,21 +133,18 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
 
         console.log('Array de entrevistadores:', dataArray);
 
-        // El backend ya devuelve el formato correcto con firstName, lastName, role, scheduleCount
+        // El backend puede devolver array directo o envuelto, y nombres separados o name.
         const mappedInterviewers: BackendInterviewer[] = dataArray.map((item: any) => ({
-          id: item.id,
-          name: `${item.firstName} ${item.lastName}`,
-          role: item.role,
-          subject: item.subject,
+          id: Number(item.id),
+          name: item.name || `${item.firstName || ''} ${item.lastName || ''}`.trim() || item.email,
+          role: item.role || '',
+          subject: item.subject || '',
           educationalLevel: item.educationalLevel,
-          scheduleCount: item.scheduleCount || 0
-        }));
+          scheduleCount: Number(item.scheduleCount || 0)
+        })).filter((item) => item.id && item.name);
 
-        // Filtrar solo entrevistadores con horarios configurados
-        const interviewersWithSchedules = mappedInterviewers.filter(i => i.scheduleCount > 0);
-
-        console.log(`Entrevistadores con horarios: ${interviewersWithSchedules.length}/${mappedInterviewers.length}`);
-        setInterviewers(interviewersWithSchedules);
+        console.log(`Entrevistadores cargados: ${mappedInterviewers.length}`);
+        setInterviewers(mappedInterviewers);
       } catch (error: any) {
         console.error('Error cargando entrevistadores:', error);
 
@@ -263,7 +260,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
     // Validación de parámetros requeridos
     if (!formData.interviewerId || !formData.scheduledDate) {
       console.log('[loadAvailableTimeSlots] Faltan parámetros requeridos - abortando');
-      setAvailableTimeSlots(INTERVIEW_CONFIG.DEFAULT_TIME_SLOTS);
+      setAvailableTimeSlots([]);
       return;
     }
 
@@ -350,7 +347,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
 
       // Solo actualizar estado si no fue cancelada
       if (!currentController.signal.aborted) {
-        setAvailableTimeSlots(INTERVIEW_CONFIG.DEFAULT_TIME_SLOTS);
+        setAvailableTimeSlots([]);
       }
     } finally {
       // Solo limpiar loading state si esta es la llamada más reciente
@@ -936,9 +933,8 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                     <option
                       key={interviewer.id}
                       value={interviewer.id}
-                      disabled={interviewer.scheduleCount === 0}
                     >
-                      {interviewer.name} - {interviewer.role} {interviewer.scheduleCount === 0 ? '(Sin horarios)' : `(${interviewer.scheduleCount} horarios)`}
+                      {interviewer.name} - {interviewer.role} {interviewer.scheduleCount > 0 ? `(${interviewer.scheduleCount} horarios)` : ''}
                     </option>
                   ))
                 )}
@@ -969,7 +965,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : interviewersError ? (
                   <option disabled>{interviewersError}</option>
                 ) : interviewers.length === 0 ? (
-                  <option disabled>No hay entrevistadores con horarios configurados</option>
+                  <option disabled>No hay entrevistadores disponibles</option>
                 ) : (
                   (() => {
                     const filteredInterviewers = interviewers.filter(interviewer => {
@@ -988,9 +984,8 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                       <option
                         key={interviewer.id}
                         value={interviewer.id}
-                        disabled={interviewer.scheduleCount === 0}
                       >
-                        {interviewer.name} - {interviewer.role} {interviewer.scheduleCount === 0 ? '(Sin horarios)' : `(${interviewer.scheduleCount} horarios)`}
+                        {interviewer.name} - {interviewer.role} {interviewer.scheduleCount > 0 ? `(${interviewer.scheduleCount} horarios)` : ''}
                       </option>
                     ));
                   })()

--- a/microfrontends/apps/mf-reports/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-reports/components/interviews/InterviewForm.tsx
@@ -1080,7 +1080,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : (
                   <div className="p-4 bg-gray-50 border border-gray-200 rounded-md">
                     <p className="text-sm text-gray-600 text-center">
-                      Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
+                      👆 Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
                     </p>
                   </div>
                 )}

--- a/microfrontends/apps/mf-reports/components/layout/Footer.tsx
+++ b/microfrontends/apps/mf-reports/components/layout/Footer.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Facebook, Instagram, Linkedin } from 'lucide-react';
+import { microfrontendUrls } from '../../utils/microfrontendUrls';
 
 const Footer: React.FC = () => {
     const [showModal, setShowModal] = useState(false);
@@ -63,8 +64,9 @@ const Footer: React.FC = () => {
                         </div>
                     </div>
                 </div>
-                <div className="border-t border-blue-800 mt-10 pt-6 text-center text-sm text-gray-400">
+                <div className="border-t border-blue-800 mt-10 pt-6 flex flex-col sm:flex-row items-center justify-between gap-2 text-sm text-gray-400">
                     <p>&copy; {new Date().getFullYear()} Colegio Monte Tabor y Nazaret. Todos los derechos reservados.</p>
+                    <a href={microfrontendUrls.adminLogin} className="text-gray-400 hover:text-dorado-nazaret transition-colors text-xs underline underline-offset-2">Acceso personal MTN</a>
                 </div>
             </div>
             {/* Modal de contacto */}

--- a/microfrontends/apps/mf-reports/components/modals/CoordinatorDashboardModal.tsx
+++ b/microfrontends/apps/mf-reports/components/modals/CoordinatorDashboardModal.tsx
@@ -7,7 +7,8 @@ import React, { useState, useEffect } from 'react';
 import { FiX, FiRefreshCw } from 'react-icons/fi';
 import { dashboardClient } from '../../src/api/dashboard.client';
 import type { DetailedAdminStats, Alert } from '../../src/api/dashboard.types';
-import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 
 interface CoordinatorDashboardModalProps {
   isOpen: boolean;
@@ -115,6 +116,32 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
   const acceptanceRate = stats && stats.totalApplications > 0
     ? ((stats.statusBreakdown.approved / stats.totalApplications) * 100).toFixed(1)
     : '0.0';
+
+  const statusChartOption: EChartsOption = {
+    color: statusData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [
+      {
+        type: 'pie',
+        radius: ['42%', '70%'],
+        center: ['50%', '50%'],
+        avoidLabelOverlap: true,
+        itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+        label: { formatter: '{b}: {d}%' },
+        data: statusData.map(item => ({ name: item.name, value: item.value }))
+      }
+    ]
+  };
+
+  const gradeChartOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: gradeData.map(item => item.grade), axisTick: { alignWithLabel: true } },
+    yAxis: { type: 'value' },
+    series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 42 }]
+  };
 
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
@@ -348,25 +375,7 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
                   {/* Status Distribution Pie Chart */}
                   <div className="bg-white border border-gray-200 shadow-sm rounded-lg p-6">
                     <h3 className="text-lg font-medium text-gray-900 mb-4">Distribución por Estado</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                      <PieChart>
-                        <Pie
-                          data={statusData}
-                          cx="50%"
-                          cy="50%"
-                          labelLine={false}
-                          label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
-                          outerRadius={80}
-                          fill="#8884d8"
-                          dataKey="value"
-                        >
-                          {statusData.map((entry, index) => (
-                            <Cell key={`cell-${index}`} fill={entry.color} />
-                          ))}
-                        </Pie>
-                        <Tooltip />
-                      </PieChart>
-                    </ResponsiveContainer>
+                    <EChart option={statusChartOption} height={300} />
                     <div className="mt-4 grid grid-cols-2 gap-2 text-sm">
                       {statusData.map((item, index) => (
                         <div key={index} className="flex items-center">
@@ -383,16 +392,7 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
                   {/* Grade Distribution Bar Chart */}
                   <div className="bg-white border border-gray-200 shadow-sm rounded-lg p-6">
                     <h3 className="text-lg font-medium text-gray-900 mb-4">Distribución por Nivel</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                      <BarChart data={gradeData}>
-                        <CartesianGrid strokeDasharray="3 3" />
-                        <XAxis dataKey="grade" />
-                        <YAxis />
-                        <Tooltip />
-                        <Legend />
-                        <Bar dataKey="count" fill="#3B82F6" name="Postulaciones" />
-                      </BarChart>
-                    </ResponsiveContainer>
+                    <EChart option={gradeChartOption} height={300} />
                   </div>
                 </div>
 

--- a/microfrontends/apps/mf-reports/components/schedule/WeeklyCalendar.tsx
+++ b/microfrontends/apps/mf-reports/components/schedule/WeeklyCalendar.tsx
@@ -100,8 +100,9 @@ const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({
   const loadSchedules = async () => {
     try {
       setLoading(true);
-      console.log(`[WeeklyCalendar] Cargando horarios para userId: ${userId}, año: 2025`);
-      const schedules = await interviewerScheduleService.getInterviewerSchedulesByYear(userId, 2025);
+      const currentYear = new Date().getFullYear();
+      console.log(`[WeeklyCalendar] Cargando horarios para userId: ${userId}, año: ${currentYear}`);
+      const schedules = await interviewerScheduleService.getInterviewerSchedulesByYear(userId, currentYear);
       console.log(`[WeeklyCalendar] Horarios recibidos del backend:`, schedules);
       console.log(`[WeeklyCalendar] Total de horarios: ${schedules.length}`);
 
@@ -222,7 +223,7 @@ const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({
       console.log('Iniciando guardado incremental de horarios...');
 
       // 1. Cargar horarios actuales de la BD
-      const existingSchedules = await interviewerScheduleService.getInterviewerSchedulesByYear(userId, 2025);
+      const existingSchedules = await interviewerScheduleService.getInterviewerSchedulesByYear(userId, new Date().getFullYear());
       console.log(`Horarios existentes en BD: ${existingSchedules.length}`);
 
       // 2. Construir conjunto de slots seleccionados en pantalla
@@ -316,7 +317,7 @@ const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({
             startTime: slot,
             endTime: endTime,  // Siempre +30 minutos
             scheduleType: 'RECURRING' as const,
-            year: 2025,
+            year: new Date().getFullYear(),
             isActive: true,
             notes: 'Bloque de 30 minutos - Sistema de horarios'
           };

--- a/microfrontends/apps/mf-reports/context/AuthContext.tsx
+++ b/microfrontends/apps/mf-reports/context/AuthContext.tsx
@@ -133,7 +133,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         return () => unsubscribe();
     }, []);
 
-    const login = async (email: string, password: string, _role: string) => {
+    const login = async (email: string, password: string, portalRole: string) => {
         setIsLoading(true);
         try {
             const response = await authService.login({ email, password });
@@ -141,6 +141,18 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             const u = response.user;
             if (response.success && u) {
                 const userData = buildUserFromBff(u);
+                const expectedRole = portalRole.toUpperCase();
+
+                if (expectedRole === 'ADMIN' && userData.role !== 'ADMIN') {
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                    throw new Error('Su cuenta no tiene acceso al panel de administración. Use el portal correspondiente a su rol.');
+                }
+
+                if (expectedRole === 'APODERADO' && userData.role !== 'APODERADO') {
+                    localStorage.removeItem(getStorageKey(BASE_STORAGE_KEYS.AUTH_TOKEN));
+                    throw new Error('Esta cuenta no corresponde a un apoderado. Use el portal de profesores o administración.');
+                }
+
                 setAdminCompat(userData, response.token ?? '', u?.subject);
                 localStorage.setItem(getStorageKey(BASE_STORAGE_KEYS.AUTHENTICATED_USER), JSON.stringify(userData));
                 setUser(userData);

--- a/microfrontends/apps/mf-reports/package.json
+++ b/microfrontends/apps/mf-reports/package.json
@@ -14,6 +14,8 @@
     "axios": "^1.11.0",
     "axios-retry": "^4.5.0",
     "date-fns": "^4.1.0",
+    "echarts": "^6.0.0",
+    "echarts-for-react": "^3.0.6",
     "express": "^4.18.2",
     "firebase": "^12.12.1",
     "lucide-react": "^0.540.0",
@@ -23,7 +25,6 @@
     "react-dropzone": "^14.3.8",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.3",
-    "recharts": "^3.2.1",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {

--- a/microfrontends/apps/mf-reports/pages/AdminDashboard.tsx
+++ b/microfrontends/apps/mf-reports/pages/AdminDashboard.tsx
@@ -61,6 +61,7 @@ import CoordinatorDashboardModal from '../components/modals/CoordinatorDashboard
 import { useAuth } from '../context/AuthContext';
 import ApplicationsTable from '../components/admin/ApplicationsTable';
 import SimpleToast from '../components/ui/SimpleToast';
+import { microfrontendUrls } from '../utils/microfrontendUrls';
 import AdminDataTables from '../components/admin/AdminDataTables';
 import StudentDetailModal from '../components/admin/StudentDetailModal';
 import ApplicationDecisionModal from '../components/admin/ApplicationDecisionModal';
@@ -80,7 +81,7 @@ const sections = [
 ];
 
 const AdminDashboard: React.FC = () => {
-  const navigate = useNavigate();
+  const navigate = useNavigate(); // eslint-disable-line @typescript-eslint/no-unused-vars
   const [activeSection, setActiveSection] = useState('dashboard');
   const [selectedApplication, setSelectedApplication] = useState<Application | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -892,8 +893,8 @@ Esta acción:
         <Button
           variant="primary"
           className="w-full bg-azul-monte-tabor hover:bg-blue-700 text-white font-medium py-3 transition-all duration-200 shadow-md hover:shadow-lg"
-          onClick={() => logout()}
-          ariaLabel="Cerrar sesión y salir del panel de administración"
+          onClick={() => { logout(); window.location.href = microfrontendUrls.home; }}
+          ariaLabel="Cerrar sesión y volver al portal principal"
         >
           Cerrar Sesión
         </Button>

--- a/microfrontends/apps/mf-reports/pages/AdminLoginPage.tsx
+++ b/microfrontends/apps/mf-reports/pages/AdminLoginPage.tsx
@@ -65,31 +65,9 @@ const LoginPage: React.FC = () => {
                         setLoginError(null);
                         
                         try {
-                            await login(email, password, userType);
+                            const portalRole = userType === 'admin' ? 'ADMIN' : 'APODERADO';
+                            await login(email, password, portalRole);
 
-                            // Verificar que el rol coincida con el tipo de portal seleccionado
-                            const storedUser = JSON.parse(localStorage.getItem('authenticated_user') || 'null');
-                            const role = storedUser?.role || '';
-
-                            if (userType === 'admin' && role === 'APODERADO') {
-                                const msg = 'Esta cuenta no tiene acceso al panel administrativo.';
-                                setLoginError(msg);
-                                addNotification({ type: 'error', title: 'Acceso denegado', message: msg });
-                                localStorage.removeItem('auth_token');
-                                localStorage.removeItem('authenticated_user');
-                                return;
-                            }
-
-                            if (userType === 'familia' && role !== 'APODERADO') {
-                                const msg = 'Esta cuenta es de personal del colegio. Use el portal de profesores.';
-                                setLoginError(msg);
-                                addNotification({ type: 'error', title: 'Acceso denegado', message: msg });
-                                localStorage.removeItem('auth_token');
-                                localStorage.removeItem('authenticated_user');
-                                return;
-                            }
-
-                            // Redirigir según el tipo de usuario
                             if (userType === 'familia') {
                                 navigate('/familia');
                             } else {

--- a/microfrontends/apps/mf-reports/pages/ApoderadoLogin.tsx
+++ b/microfrontends/apps/mf-reports/pages/ApoderadoLogin.tsx
@@ -50,19 +50,6 @@ const ApoderadoLogin: React.FC = () => {
 
         try {
             await login(email, password, 'apoderado');
-
-            // Verificar que el rol sea APODERADO
-            const storedUser = JSON.parse(localStorage.getItem('authenticated_user') || 'null');
-            if (storedUser && storedUser.role !== 'APODERADO') {
-                const msg = 'Esta cuenta no corresponde a un apoderado. Use el portal de profesores.';
-                setError(msg);
-                addNotification({ type: 'error', title: 'Acceso denegado', message: msg });
-                localStorage.removeItem('auth_token');
-                localStorage.removeItem('authenticated_user');
-                setIsLoading(false);
-                return;
-            }
-
             navigate(redirectTo);
         } catch (err: any) {
             const msg = err.message || 'Credenciales inválidas. Verifique su email y contraseña.';

--- a/microfrontends/apps/mf-reports/pages/FamilyDashboard.tsx
+++ b/microfrontends/apps/mf-reports/pages/FamilyDashboard.tsx
@@ -6,6 +6,7 @@ import Button from '../components/ui/Button';
 import { ApplicationStatus, Document } from '../types';
 import { DOCUMENT_TYPE_LABELS, DocumentType } from '../types/document';
 import { applicationService } from '../services/applicationService';
+import { microfrontendUrls } from '../utils/microfrontendUrls';
 import { applicationWorkflowService } from '../services/applicationWorkflowService';
 import { useUserProfile } from '../hooks/useUserProfile';
 import { CheckCircleIcon, ClockIcon, FileTextIcon, XCircleIcon, CalendarIcon, UsersIcon, LogoIcon } from '../components/icons/Icons';
@@ -255,6 +256,7 @@ const FamilyDashboard: React.FC = () => {
                     onClick={() => {
                       if (window.confirm('¿Está seguro que desea cerrar sesión?')) {
                         logout();
+                        window.location.href = microfrontendUrls.home;
                       }
                     }}
                   >

--- a/microfrontends/apps/mf-reports/pages/ProfessorDashboard.tsx
+++ b/microfrontends/apps/mf-reports/pages/ProfessorDashboard.tsx
@@ -37,6 +37,7 @@ import {
 import { interviewService } from '../services/interviewService';
 import { UserRole, USER_ROLE_LABELS } from '../types/user';
 import api from '../services/api';
+import { microfrontendUrls } from '../utils/microfrontendUrls';
 
 const baseSections = [
     { key: 'dashboard', label: 'Dashboard General', icon: DashboardIcon },
@@ -243,8 +244,8 @@ const ProfessorDashboard: React.FC = () => {
     }, [currentProfessor?.id]);
 
     const handleLogout = () => {
-        localStorage.removeItem('currentProfessor');
-        navigate('/profesor/login');
+        professorAuthService.logout();
+        window.location.href = microfrontendUrls.home;
     };
 
     // Determinar si mostrar sección de administrador
@@ -1591,23 +1592,13 @@ const ProfessorDashboard: React.FC = () => {
                     );
                 })}
             </nav>
-            <div className="mt-8 pt-8 border-t border-blue-700 space-y-2">
-                <Link to="/" onClick={() => onNavigate?.()}>
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        className="w-full text-blanco-pureza border-blanco-pureza hover:bg-blanco-pureza hover:text-azul-monte-tabor"
-                        ariaLabel="Volver al portal principal del sistema"
-                    >
-                        Volver al Portal Principal
-                    </Button>
-                </Link>
+            <div className="mt-8 pt-8 border-t border-blue-700">
                 <Button
                     variant="outline"
                     size="sm"
                     className="w-full text-blanco-pureza border-blanco-pureza hover:bg-red-500 hover:text-blanco-pureza"
                     onClick={handleLogout}
-                    ariaLabel="Cerrar sesión y salir del portal de profesores"
+                    ariaLabel="Cerrar sesión y volver al portal principal"
                 >
                     Cerrar Sesión
                 </Button>

--- a/microfrontends/apps/mf-reports/services/interviewService.ts
+++ b/microfrontends/apps/mf-reports/services/interviewService.ts
@@ -796,14 +796,14 @@ class InterviewService {
       const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
       if (!dateRegex.test(date)) {
         console.error(`getAvailableTimeSlots: Formato de fecha inválido "${date}". Se esperaba YYYY-MM-DD`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Verificar que el año sea razonable
       const year = parseInt(date.split('-')[0]);
       if (year < 2020 || year > 2100) {
         console.error(`getAvailableTimeSlots: Año inválido ${year}. Debe estar entre 2020 y 2100`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Validar y usar duración por defecto si es inválida
@@ -825,8 +825,8 @@ class InterviewService {
 
       // Verificar si la respuesta es del placeholder (microservicio no implementado)
       if (response.data && typeof response.data === 'object' && 'error' in response.data) {
-        console.log('Available slots service no implementado, usando horarios por defecto');
-        return this.getDefaultTimeSlots();
+        console.log('Available slots service no implementado, devolviendo horarios vacíos');
+        return [];
       }
 
       // CASO 1: Backend devuelve estructura { success: true, data: { availableSlots: [...] } }
@@ -878,13 +878,12 @@ class InterviewService {
         }
       }
 
-      console.log('Estructura de respuesta inesperada para available slots, usando horarios por defecto');
+      console.log('Estructura de respuesta inesperada para available slots, devolviendo horarios vacíos');
       console.log('Data recibida:', response.data);
-      return this.getDefaultTimeSlots();
+      return [];
     } catch (error) {
       console.error('Error fetching available slots:', error);
-      // Fallback: horarios estándar si el backend no los tiene configurados
-      return this.getDefaultTimeSlots();
+      return [];
     }
   }
 
@@ -979,14 +978,14 @@ class InterviewService {
       const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
       if (!dateRegex.test(date)) {
         console.error(`getCommonTimeSlots: Formato de fecha inválido "${date}". Se esperaba YYYY-MM-DD`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Verificar que el año sea razonable
       const year = parseInt(date.split('-')[0]);
       if (year < 2020 || year > 2100) {
         console.error(`getCommonTimeSlots: Año inválido ${year}. Debe estar entre 2020 y 2100`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Obtener los horarios disponibles de ambos entrevistadores
@@ -1006,8 +1005,7 @@ class InterviewService {
       return commonSlots;
     } catch (error) {
       console.error('Error obteniendo horarios comunes:', error);
-      // Fallback: horarios por defecto
-      return this.getDefaultTimeSlots();
+      return [];
     }
   }
 

--- a/microfrontends/apps/mf-reports/services/interviewService.ts
+++ b/microfrontends/apps/mf-reports/services/interviewService.ts
@@ -499,34 +499,24 @@ class InterviewService {
 
   async getInterviewsByInterviewer(interviewerId: number): Promise<Interview[]> {
     try {
-      // Add cache-busting headers and timestamp to force fresh data
       const timestamp = Date.now();
-      console.log(`[getInterviewsByInterviewer] Fetching with timestamp: ${timestamp} for interviewer ${interviewerId}`);
+      console.log(`[getInterviewsByInterviewer] Fetching for interviewer ${interviewerId}`);
 
-      const response = await api.get<InterviewResponse[]>(
-        `${this.baseUrl}/interviewer/${interviewerId}?_t=${timestamp}`,
-        {
-          headers: {
-            'Cache-Control': 'no-cache, no-store, must-revalidate',
-            'Pragma': 'no-cache',
-            'Expires': '0'
-          }
-        }
+      const response = await api.get<any>(
+        `${this.baseUrl}/interviewer/${interviewerId}?_t=${timestamp}`
       );
 
-      // Verificar si la respuesta es del placeholder (microservicio no implementado)
-      if (response.data && typeof response.data === 'object' && 'error' in response.data) {
-        console.log('Interviews by interviewer service no implementado, devolviendo array vacío');
-        return [];
+      // Backend returns { success: true, data: [...], count: n }
+      if (response.data?.success && Array.isArray(response.data.data)) {
+        console.log(`[getInterviewsByInterviewer] Received ${response.data.data.length} interviews`);
+        return response.data.data.map((item: any) => this.mapBackendResponse(item));
       }
 
-      // Verificar si es un array válido
+      // Fallback: bare array (legacy)
       if (Array.isArray(response.data)) {
-        console.log(`[getInterviewsByInterviewer] Received ${response.data.length} interviews for interviewer ${interviewerId}`);
-        return response.data.map(item => this.mapInterviewResponse(item));
+        return response.data.map((item: any) => this.mapBackendResponse(item));
       }
 
-      console.log('Estructura de respuesta inesperada para interviews by interviewer');
       return [];
     } catch (error) {
       console.error('Error fetching interviews by interviewer:', error);

--- a/microfrontends/apps/mf-reports/services/interviewerScheduleService.ts
+++ b/microfrontends/apps/mf-reports/services/interviewerScheduleService.ts
@@ -191,10 +191,7 @@ export class InterviewerScheduleService {
      */
     async getInterviewerSchedulesByYear(interviewerId: number, year: number): Promise<InterviewerSchedule[]> {
         try {
-            const response = await axios.get(`${this.baseURL}/interviewer/${interviewerId}/year/${year}`, {
-                headers: this.getAuthHeaders()
-            });
-            return response.data;
+            return await httpClient.get(`/v1/interviewer-schedules/interviewer/${interviewerId}/year/${year}`);
         } catch (error) {
             console.error('Error fetching schedules by year:', error);
             throw new Error(axios.isAxiosError(error) ? 

--- a/microfrontends/apps/mf-reports/services/professorAuthService.ts
+++ b/microfrontends/apps/mf-reports/services/professorAuthService.ts
@@ -39,7 +39,7 @@ class ProfessorAuthService {
 
             // Send credentials directly over HTTPS (no RSA encryption)
             console.log('[Professor Auth] Sending credentials over HTTPS');
-            const response = await api.post('/v1/auth/login', request);
+            const response = await api.post('/v1/auth/login', { ...request, portalType: 'STAFF' });
             const data = response.data;
 
             console.log('Login exitoso para profesor:', data);
@@ -64,8 +64,10 @@ class ProfessorAuthService {
             
             if (error.response?.status === 401) {
                 throw new Error('Credenciales inválidas');
+            } else if (error.response?.status === 403) {
+                throw new Error(error.response?.data?.error?.message || 'Su cuenta no tiene acceso al portal de profesores. Use el portal correspondiente a su rol.');
             } else if (error.response?.status === 400) {
-                throw new Error('Datos de login inválidos');
+                throw new Error(error.response?.data?.error?.message || 'Datos de login inválidos');
             } else if (error.response?.status === 500) {
                 throw new Error('Error del servidor');
             }
@@ -119,9 +121,6 @@ class ProfessorAuthService {
     // Método para verificar si el usuario es un profesor válido
     isProfessorRole(role: string): boolean {
         const professorRoles = [
-            // Administración
-            'ADMIN',
-
             // Roles del backend (actuales)
             'TEACHER',
             'COORDINATOR',

--- a/microfrontends/apps/mf-reports/src/components/charts/EChart.tsx
+++ b/microfrontends/apps/mf-reports/src/components/charts/EChart.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactECharts from 'echarts-for-react';
+import type { EChartsOption } from 'echarts';
+
+interface EChartProps {
+  option: EChartsOption;
+  height?: number;
+  onEvents?: Record<string, (params: any) => void>;
+}
+
+const EChart: React.FC<EChartProps> = ({ option, height = 300, onEvents }) => (
+  <ReactECharts
+    option={option}
+    notMerge
+    lazyUpdate
+    onEvents={onEvents}
+    style={{ width: '100%', height }}
+  />
+);
+
+export default EChart;

--- a/microfrontends/apps/mf-reports/src/components/coordinator/CoordinatorDashboard.tsx
+++ b/microfrontends/apps/mf-reports/src/components/coordinator/CoordinatorDashboard.tsx
@@ -9,7 +9,8 @@
 import React, { useState, useEffect } from 'react';
 import { dashboardClient } from '../../api/dashboard.client';
 import type { DetailedAdminStats, Alert } from '../../api/dashboard.types';
-import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { ApplicantMetricsModal } from '../../../components/modals/ApplicantMetricsModal';
 
 export const CoordinatorDashboard: React.FC = () => {
@@ -143,6 +144,32 @@ export const CoordinatorDashboard: React.FC = () => {
   const acceptanceRate = stats.totalApplications > 0
     ? ((stats.statusBreakdown.approved / stats.totalApplications) * 100).toFixed(1)
     : '0.0';
+
+  const statusChartOption: EChartsOption = {
+    color: statusData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [
+      {
+        type: 'pie',
+        radius: ['42%', '70%'],
+        center: ['50%', '50%'],
+        avoidLabelOverlap: true,
+        itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+        label: { formatter: '{b}: {d}%' },
+        data: statusData.map(item => ({ name: item.name, value: item.value }))
+      }
+    ]
+  };
+
+  const gradeChartOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: gradeData.map(item => item.grade), axisTick: { alignWithLabel: true } },
+    yAxis: { type: 'value' },
+    series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 42 }]
+  };
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -336,25 +363,7 @@ export const CoordinatorDashboard: React.FC = () => {
         {/* Status Distribution Pie Chart */}
         <div className="bg-white shadow rounded-lg p-6">
           <h2 className="text-lg font-medium text-gray-900 mb-4">Distribución por Estado</h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie
-                data={statusData}
-                cx="50%"
-                cy="50%"
-                labelLine={false}
-                label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
-                outerRadius={80}
-                fill="#8884d8"
-                dataKey="value"
-              >
-                {statusData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
-                ))}
-              </Pie>
-              <Tooltip />
-            </PieChart>
-          </ResponsiveContainer>
+          <EChart option={statusChartOption} height={300} />
           <div className="mt-4 grid grid-cols-2 gap-2 text-sm">
             {statusData.map((item, index) => (
               <div key={index} className="flex items-center">
@@ -371,16 +380,7 @@ export const CoordinatorDashboard: React.FC = () => {
         {/* Grade Distribution Bar Chart */}
         <div className="bg-white shadow rounded-lg p-6">
           <h2 className="text-lg font-medium text-gray-900 mb-4">Distribución por Nivel</h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={gradeData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="grade" />
-              <YAxis />
-              <Tooltip />
-              <Legend />
-              <Bar dataKey="count" fill="#3B82F6" name="Postulaciones" />
-            </BarChart>
-          </ResponsiveContainer>
+          <EChart option={gradeChartOption} height={300} />
         </div>
       </div>
 

--- a/microfrontends/apps/mf-reports/src/components/coordinator/TemporalTrendsView.tsx
+++ b/microfrontends/apps/mf-reports/src/components/coordinator/TemporalTrendsView.tsx
@@ -8,7 +8,8 @@
 import React, { useState, useEffect } from 'react';
 import { dashboardClient } from '../../api/dashboard.client';
 import type { TemporalTrend, DetailedAdminStats } from '../../api/dashboard.types';
-import { LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { format } from 'date-fns';
 
 export const TemporalTrendsView: React.FC = () => {
@@ -114,6 +115,52 @@ export const TemporalTrendsView: React.FC = () => {
     };
   }).filter(Boolean);
 
+  const monthlyTrendsOption: EChartsOption = {
+    color: ['#3B82F6', '#10B981', '#EF4444', '#F59E0B'],
+    tooltip: { trigger: 'axis' },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 48, top: 24, bottom: 80, containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: monthlyTrendsData.map(item => item.month),
+      axisLabel: { rotate: 45 }
+    },
+    yAxis: [
+      { type: 'value', name: 'Postulaciones' },
+      { type: 'value', name: '%' }
+    ],
+    series: [
+      { name: 'Total Postulaciones', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.total) },
+      { name: 'Aprobadas', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.approved) },
+      { name: 'Rechazadas', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.rejected) },
+      { name: 'Tasa de Crecimiento (%)', type: 'line', smooth: true, yAxisIndex: 1, lineStyle: { type: 'dashed' }, data: monthlyTrendsData.map(item => item.growthRate) }
+    ]
+  };
+
+  const comparisonOption: EChartsOption = {
+    color: ['#3B82F6', '#10B981', '#EF4444'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: comparisonData.map((item: any) => item.year) },
+    yAxis: { type: 'value' },
+    series: [
+      { name: 'Total', type: 'bar', data: comparisonData.map((item: any) => item.total) },
+      { name: 'Aprobadas', type: 'bar', data: comparisonData.map((item: any) => item.approved) },
+      { name: 'Rechazadas', type: 'bar', data: comparisonData.map((item: any) => item.rejected) }
+    ]
+  };
+
+  const acceptanceRateOption: EChartsOption = {
+    color: ['#10B981'],
+    tooltip: { trigger: 'axis', valueFormatter: value => `${Number(value).toFixed(1)}%` },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: comparisonData.map((item: any) => item.year) },
+    yAxis: { type: 'value', min: 0, max: 100 },
+    series: [{ name: 'Tasa de Aceptación (%)', type: 'bar', data: comparisonData.map((item: any) => item.acceptanceRate), barMaxWidth: 48 }]
+  };
+
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       {/* Header */}
@@ -147,50 +194,7 @@ export const TemporalTrendsView: React.FC = () => {
       {/* Monthly Trends Chart */}
       <div className="bg-white shadow rounded-lg p-6 mb-6">
         <h2 className="text-lg font-medium text-gray-900 mb-4">Tendencia Mensual (Últimos 12 meses)</h2>
-        <ResponsiveContainer width="100%" height={400}>
-          <LineChart data={monthlyTrendsData}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="month" angle={-45} textAnchor="end" height={80} />
-            <YAxis yAxisId="left" />
-            <YAxis yAxisId="right" orientation="right" />
-            <Tooltip />
-            <Legend />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="total"
-              stroke="#3B82F6"
-              strokeWidth={2}
-              name="Total Postulaciones"
-              dot={{ r: 4 }}
-            />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="approved"
-              stroke="#10B981"
-              strokeWidth={2}
-              name="Aprobadas"
-            />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="rejected"
-              stroke="#EF4444"
-              strokeWidth={2}
-              name="Rechazadas"
-            />
-            <Line
-              yAxisId="right"
-              type="monotone"
-              dataKey="growthRate"
-              stroke="#F59E0B"
-              strokeWidth={2}
-              name="Tasa de Crecimiento (%)"
-              strokeDasharray="5 5"
-            />
-          </LineChart>
-        </ResponsiveContainer>
+        <EChart option={monthlyTrendsOption} height={400} />
       </div>
 
       {/* Year Comparison */}
@@ -199,33 +203,13 @@ export const TemporalTrendsView: React.FC = () => {
           {/* Total Applications Comparison */}
           <div className="bg-white shadow rounded-lg p-6">
             <h2 className="text-lg font-medium text-gray-900 mb-4">Comparativa de Postulaciones</h2>
-            <ResponsiveContainer width="100%" height={300}>
-              <BarChart data={comparisonData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="year" />
-                <YAxis />
-                <Tooltip />
-                <Legend />
-                <Bar dataKey="total" fill="#3B82F6" name="Total" />
-                <Bar dataKey="approved" fill="#10B981" name="Aprobadas" />
-                <Bar dataKey="rejected" fill="#EF4444" name="Rechazadas" />
-              </BarChart>
-            </ResponsiveContainer>
+            <EChart option={comparisonOption} height={300} />
           </div>
 
           {/* Acceptance Rate Comparison */}
           <div className="bg-white shadow rounded-lg p-6">
             <h2 className="text-lg font-medium text-gray-900 mb-4">Tasa de Aceptación por Año</h2>
-            <ResponsiveContainer width="100%" height={300}>
-              <BarChart data={comparisonData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="year" />
-                <YAxis domain={[0, 100]} />
-                <Tooltip formatter={(value) => `${Number(value).toFixed(1)}%`} />
-                <Legend />
-                <Bar dataKey="acceptanceRate" fill="#10B981" name="Tasa de Aceptación (%)" />
-              </BarChart>
-            </ResponsiveContainer>
+            <EChart option={acceptanceRateOption} height={300} />
           </div>
         </div>
       )}

--- a/microfrontends/apps/mf-student/components/admin/AnalyticsView.tsx
+++ b/microfrontends/apps/mf-student/components/admin/AnalyticsView.tsx
@@ -6,7 +6,8 @@
 import React, { useState, useEffect } from 'react';
 import { FiTrendingUp, FiUsers, FiAward, FiClock } from 'react-icons/fi';
 import Card from '../ui/Card';
-import { BarChart, Bar, LineChart, Line, RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { dashboardClient } from '../../src/api/dashboard.client';
 
 export const AnalyticsView: React.FC = () => {
@@ -54,7 +55,34 @@ export const AnalyticsView: React.FC = () => {
         );
     }
 
-    const COLORS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899'];
+    const evaluatorPerformanceOption: EChartsOption = {
+        color: ['#10B981', '#F59E0B'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: evaluatorData.map(item => item.name) },
+        yAxis: { type: 'value' },
+        series: [
+            { name: 'Completadas', type: 'bar', data: evaluatorData.map(item => item.completed) },
+            { name: 'Pendientes', type: 'bar', data: evaluatorData.map(item => item.pending) }
+        ]
+    };
+
+    const radarData = evaluatorData.slice(0, 6);
+    const evaluatorWorkloadOption: EChartsOption = {
+        color: ['#3B82F6'],
+        tooltip: {},
+        radar: {
+            indicator: radarData.map(item => ({ name: item.name, max: Math.max(...radarData.map(e => e.total || 0), 1) })),
+            splitArea: { areaStyle: { color: ['rgba(59, 130, 246, 0.04)', 'rgba(59, 130, 246, 0.1)'] } }
+        },
+        series: [{
+            name: 'Evaluaciones',
+            type: 'radar',
+            areaStyle: { opacity: 0.35 },
+            data: [{ name: 'Evaluaciones', value: radarData.map(item => item.total || 0) }]
+        }]
+    };
 
     return (
         <div className="space-y-6">
@@ -136,31 +164,13 @@ export const AnalyticsView: React.FC = () => {
                 {/* Evaluator Performance */}
                 <Card className="p-6">
                     <h3 className="text-lg font-semibold text-gray-900 mb-4">Rendimiento de Evaluadores</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <BarChart data={evaluatorData}>
-                            <CartesianGrid strokeDasharray="3 3" />
-                            <XAxis dataKey="name" />
-                            <YAxis />
-                            <Tooltip />
-                            <Legend />
-                            <Bar dataKey="completed" fill="#10B981" name="Completadas" />
-                            <Bar dataKey="pending" fill="#F59E0B" name="Pendientes" />
-                        </BarChart>
-                    </ResponsiveContainer>
+                    <EChart option={evaluatorPerformanceOption} height={300} />
                 </Card>
 
                 {/* Evaluator Workload Radar */}
                 <Card className="p-6">
                     <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución de Carga de Trabajo</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <RadarChart data={evaluatorData.slice(0, 6)}>
-                            <PolarGrid />
-                            <PolarAngleAxis dataKey="name" />
-                            <PolarRadiusAxis />
-                            <Radar name="Evaluaciones" dataKey="total" stroke="#3B82F6" fill="#3B82F6" fillOpacity={0.6} />
-                            <Tooltip />
-                        </RadarChart>
-                    </ResponsiveContainer>
+                    <EChart option={evaluatorWorkloadOption} height={300} />
                 </Card>
             </div>
 

--- a/microfrontends/apps/mf-student/components/admin/ApplicantMetricsView.tsx
+++ b/microfrontends/apps/mf-student/components/admin/ApplicantMetricsView.tsx
@@ -5,7 +5,8 @@ import Badge from '../ui/Badge';
 import Button from '../ui/Button';
 import { dashboardClient } from '../../src/api/dashboard.client';
 import type { ApplicantMetric, ApplicantMetricsFilters } from '../../src/api/dashboard.types';
-import { PieChart, Pie, BarChart, Bar, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, LabelList } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 
 // Version: 2025-11-11 - Added overallOpinionScore display
 export const ApplicantMetricsView: React.FC = () => {
@@ -178,6 +179,48 @@ export const ApplicantMetricsView: React.FC = () => {
   };
 
   const { performanceData, avgData } = getChartData();
+
+  const performanceDistributionOption: EChartsOption = {
+    color: performanceData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    legend: { bottom: 0 },
+    series: [{
+      type: 'pie',
+      radius: ['42%', '70%'],
+      center: ['50%', '44%'],
+      itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+      label: { formatter: '{d}%' },
+      data: performanceData.map(item => ({ name: item.name, value: item.value }))
+    }]
+  };
+
+  const examAverageOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', valueFormatter: value => `${value}%` },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 24, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: avgData.map(item => item.name) },
+    yAxis: { type: 'value', min: 0, max: 100 },
+    series: [{
+      name: 'Promedio (%)',
+      type: 'bar',
+      data: avgData.map(item => item.promedio),
+      barMaxWidth: 48,
+      label: { show: true, position: 'top', formatter: '{c}%' }
+    }]
+  };
+
+  const subjectDistributionOption: EChartsOption = {
+    color: subjectDistribution.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [{
+      type: 'pie',
+      radius: ['42%', '72%'],
+      itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+      label: { formatter: '{b}: {d}%' },
+      data: subjectDistribution.map(item => ({ name: item.name, value: item.value }))
+    }]
+  };
 
   const uniqueGrades = [...new Set(applicants.map(a => a.gradeApplied))].sort();
   const uniqueStatuses = [...new Set(applicants.map(a => a.applicationStatus))];
@@ -420,56 +463,17 @@ export const ApplicantMetricsView: React.FC = () => {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <Card className="p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución de Rendimiento</h3>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie
-                data={performanceData}
-                cx="50%"
-                cy="50%"
-                labelLine={false}
-                label={({ percent }: { percent?: number }) => `${Math.round((percent || 0) * 100)}%`}
-                outerRadius={80}
-                fill="#8884d8"
-                dataKey="value"
-              >
-                {performanceData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
-                ))}
-              </Pie>
-              <Tooltip />
-              <Legend
-                verticalAlign="bottom"
-                height={36}
-                formatter={(value, entry: any) => entry.payload.name}
-              />
-            </PieChart>
-          </ResponsiveContainer>
+          <EChart option={performanceDistributionOption} height={300} />
         </Card>
 
         <Card className="p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Promedio por Examen</h3>
           <p className="text-sm text-gray-500 mb-2">Haz clic en una barra para ver la distribución detallada</p>
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={avgData} onClick={(data) => {
-              if (data && data.activeLabel) {
-                handleSubjectClick(data.activeLabel);
-              }
-            }}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
-              <YAxis domain={[0, 100]} />
-              <Tooltip />
-              <Legend />
-              <Bar
-                dataKey="promedio"
-                fill="#3B82F6"
-                name="Promedio (%)"
-                cursor="pointer"
-              >
-                <LabelList dataKey="promedio" position="top" formatter={(value: number) => `${value}%`} />
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+          <EChart
+            option={examAverageOption}
+            height={300}
+            onEvents={{ click: params => params.name && handleSubjectClick(String(params.name)) }}
+          />
         </Card>
       </div>
 
@@ -680,27 +684,7 @@ export const ApplicantMetricsView: React.FC = () => {
               </div>
 
               <div className="mb-6">
-                <ResponsiveContainer width="100%" height={350}>
-                  <PieChart>
-                    <Pie
-                      data={subjectDistribution}
-                      cx="50%"
-                      cy="50%"
-                      labelLine={false}
-                      label={({ name, percent }: { name: string, percent?: number }) =>
-                        `${name}: ${Math.round((percent || 0) * 100)}%`
-                      }
-                      outerRadius={120}
-                      fill="#8884d8"
-                      dataKey="value"
-                    >
-                      {subjectDistribution.map((entry, index) => (
-                        <Cell key={`cell-${index}`} fill={entry.color} />
-                      ))}
-                    </Pie>
-                    <Tooltip />
-                  </PieChart>
-                </ResponsiveContainer>
+                <EChart option={subjectDistributionOption} height={350} />
               </div>
 
               <div className="border-t pt-4">

--- a/microfrontends/apps/mf-student/components/admin/ReportsView.tsx
+++ b/microfrontends/apps/mf-student/components/admin/ReportsView.tsx
@@ -7,7 +7,8 @@ import React, { useState, useEffect } from 'react';
 import { FiDownload, FiFilter, FiCalendar, FiBarChart2, FiPieChart, FiTrendingUp } from 'react-icons/fi';
 import Card from '../ui/Card';
 import Button from '../ui/Button';
-import { BarChart, Bar, PieChart, Pie, LineChart, Line, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { dashboardClient } from '../../src/api/dashboard.client';
 
 interface ReportFilters {
@@ -85,6 +86,64 @@ export const ReportsView: React.FC = () => {
     };
 
     const COLORS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899'];
+
+    const statusBarOption: EChartsOption = {
+        color: ['#3B82F6'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: statusData.map(item => item.name) },
+        yAxis: { type: 'value' },
+        series: [{ name: 'Cantidad', type: 'bar', data: statusData.map(item => item.value), barMaxWidth: 44 }]
+    };
+
+    const statusPieOption: EChartsOption = {
+        color: COLORS,
+        tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+        series: [{
+            type: 'pie',
+            radius: ['42%', '70%'],
+            itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+            label: { formatter: '{b}: {c}' },
+            data: statusData.map(item => ({ name: item.name, value: item.value }))
+        }]
+    };
+
+    const gradeBarOption: EChartsOption = {
+        color: ['#10B981'],
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: gradeData.map(item => item.grade) },
+        yAxis: { type: 'value' },
+        series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 44 }]
+    };
+
+    const gradePieOption: EChartsOption = {
+        color: COLORS,
+        tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+        series: [{
+            type: 'pie',
+            radius: ['42%', '70%'],
+            itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+            label: { formatter: '{b}: {c}' },
+            data: gradeData.map(item => ({ name: item.grade, value: item.count }))
+        }]
+    };
+
+    const temporalOption: EChartsOption = {
+        color: ['#3B82F6', '#10B981', '#EF4444'],
+        tooltip: { trigger: 'axis' },
+        legend: { bottom: 0 },
+        grid: { left: 8, right: 8, top: 24, bottom: 48, containLabel: true },
+        xAxis: { type: 'category', data: temporalData.map(item => item.month) },
+        yAxis: { type: 'value' },
+        series: [
+            { name: 'Postulaciones', type: 'line', smooth: true, data: temporalData.map(item => item.applications) },
+            { name: 'Aprobadas', type: 'line', smooth: true, data: temporalData.map(item => item.approved) },
+            { name: 'Rechazadas', type: 'line', smooth: true, data: temporalData.map(item => item.rejected) }
+        ]
+    };
 
     if (loading) {
         return (
@@ -196,38 +255,11 @@ export const ReportsView: React.FC = () => {
                     <>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución por Estado (Barras)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <BarChart data={statusData}>
-                                    <CartesianGrid strokeDasharray="3 3" />
-                                    <XAxis dataKey="name" />
-                                    <YAxis />
-                                    <Tooltip />
-                                    <Legend />
-                                    <Bar dataKey="value" fill="#3B82F6" />
-                                </BarChart>
-                            </ResponsiveContainer>
+                            <EChart option={statusBarOption} height={300} />
                         </Card>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Distribución por Estado (Pastel)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <PieChart>
-                                    <Pie
-                                        data={statusData}
-                                        cx="50%"
-                                        cy="50%"
-                                        labelLine={false}
-                                        label={(entry) => `${entry.name}: ${entry.value}`}
-                                        outerRadius={80}
-                                        fill="#8884d8"
-                                        dataKey="value"
-                                    >
-                                        {statusData.map((entry, index) => (
-                                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                        ))}
-                                    </Pie>
-                                    <Tooltip />
-                                </PieChart>
-                            </ResponsiveContainer>
+                            <EChart option={statusPieOption} height={300} />
                         </Card>
                     </>
                 )}
@@ -236,38 +268,11 @@ export const ReportsView: React.FC = () => {
                     <>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Postulaciones por Grado (Barras)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <BarChart data={gradeData}>
-                                    <CartesianGrid strokeDasharray="3 3" />
-                                    <XAxis dataKey="grade" />
-                                    <YAxis />
-                                    <Tooltip />
-                                    <Legend />
-                                    <Bar dataKey="count" fill="#10B981" />
-                                </BarChart>
-                            </ResponsiveContainer>
+                            <EChart option={gradeBarOption} height={300} />
                         </Card>
                         <Card className="p-6">
                             <h3 className="text-lg font-semibold text-gray-900 mb-4">Postulaciones por Grado (Pastel)</h3>
-                            <ResponsiveContainer width="100%" height={300}>
-                                <PieChart>
-                                    <Pie
-                                        data={gradeData}
-                                        cx="50%"
-                                        cy="50%"
-                                        labelLine={false}
-                                        label={(entry) => `${entry.grade}: ${entry.count}`}
-                                        outerRadius={80}
-                                        fill="#8884d8"
-                                        dataKey="count"
-                                    >
-                                        {gradeData.map((entry, index) => (
-                                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                        ))}
-                                    </Pie>
-                                    <Tooltip />
-                                </PieChart>
-                            </ResponsiveContainer>
+                            <EChart option={gradePieOption} height={300} />
                         </Card>
                     </>
                 )}
@@ -275,18 +280,7 @@ export const ReportsView: React.FC = () => {
                 {selectedReport === 'temporal' && (
                     <Card className="p-6 lg:col-span-2">
                         <h3 className="text-lg font-semibold text-gray-900 mb-4">Tendencias Temporales de Postulaciones</h3>
-                        <ResponsiveContainer width="100%" height={400}>
-                            <LineChart data={temporalData}>
-                                <CartesianGrid strokeDasharray="3 3" />
-                                <XAxis dataKey="month" />
-                                <YAxis />
-                                <Tooltip />
-                                <Legend />
-                                <Line type="monotone" dataKey="applications" stroke="#3B82F6" strokeWidth={2} name="Postulaciones" />
-                                <Line type="monotone" dataKey="approved" stroke="#10B981" strokeWidth={2} name="Aprobadas" />
-                                <Line type="monotone" dataKey="rejected" stroke="#EF4444" strokeWidth={2} name="Rechazadas" />
-                            </LineChart>
-                        </ResponsiveContainer>
+                        <EChart option={temporalOption} height={400} />
                     </Card>
                 )}
             </div>

--- a/microfrontends/apps/mf-student/components/charts/EChart.tsx
+++ b/microfrontends/apps/mf-student/components/charts/EChart.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactECharts from 'echarts-for-react';
+import type { EChartsOption } from 'echarts';
+
+interface EChartProps {
+  option: EChartsOption;
+  height?: number;
+  onEvents?: Record<string, (params: any) => void>;
+}
+
+const EChart: React.FC<EChartProps> = ({ option, height = 300, onEvents }) => (
+  <ReactECharts
+    option={option}
+    notMerge
+    lazyUpdate
+    onEvents={onEvents}
+    style={{ width: '100%', height }}
+  />
+);
+
+export default EChart;

--- a/microfrontends/apps/mf-student/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-student/components/interviews/InterviewForm.tsx
@@ -1080,7 +1080,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : (
                   <div className="p-4 bg-gray-50 border border-gray-200 rounded-md">
                     <p className="text-sm text-gray-600 text-center">
-                      👆 Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
+                      Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
                     </p>
                   </div>
                 )}

--- a/microfrontends/apps/mf-student/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-student/components/interviews/InterviewForm.tsx
@@ -133,21 +133,18 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
 
         console.log('Array de entrevistadores:', dataArray);
 
-        // El backend ya devuelve el formato correcto con firstName, lastName, role, scheduleCount
+        // El backend puede devolver array directo o envuelto, y nombres separados o name.
         const mappedInterviewers: BackendInterviewer[] = dataArray.map((item: any) => ({
-          id: item.id,
-          name: `${item.firstName} ${item.lastName}`,
-          role: item.role,
-          subject: item.subject,
+          id: Number(item.id),
+          name: item.name || `${item.firstName || ''} ${item.lastName || ''}`.trim() || item.email,
+          role: item.role || '',
+          subject: item.subject || '',
           educationalLevel: item.educationalLevel,
-          scheduleCount: item.scheduleCount || 0
-        }));
+          scheduleCount: Number(item.scheduleCount || 0)
+        })).filter((item) => item.id && item.name);
 
-        // Filtrar solo entrevistadores con horarios configurados
-        const interviewersWithSchedules = mappedInterviewers.filter(i => i.scheduleCount > 0);
-
-        console.log(`Entrevistadores con horarios: ${interviewersWithSchedules.length}/${mappedInterviewers.length}`);
-        setInterviewers(interviewersWithSchedules);
+        console.log(`Entrevistadores cargados: ${mappedInterviewers.length}`);
+        setInterviewers(mappedInterviewers);
       } catch (error: any) {
         console.error('Error cargando entrevistadores:', error);
 
@@ -263,7 +260,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
     // Validación de parámetros requeridos
     if (!formData.interviewerId || !formData.scheduledDate) {
       console.log('[loadAvailableTimeSlots] Faltan parámetros requeridos - abortando');
-      setAvailableTimeSlots(INTERVIEW_CONFIG.DEFAULT_TIME_SLOTS);
+      setAvailableTimeSlots([]);
       return;
     }
 
@@ -350,7 +347,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
 
       // Solo actualizar estado si no fue cancelada
       if (!currentController.signal.aborted) {
-        setAvailableTimeSlots(INTERVIEW_CONFIG.DEFAULT_TIME_SLOTS);
+        setAvailableTimeSlots([]);
       }
     } finally {
       // Solo limpiar loading state si esta es la llamada más reciente
@@ -936,9 +933,8 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                     <option
                       key={interviewer.id}
                       value={interviewer.id}
-                      disabled={interviewer.scheduleCount === 0}
                     >
-                      {interviewer.name} - {interviewer.role} {interviewer.scheduleCount === 0 ? '(Sin horarios)' : `(${interviewer.scheduleCount} horarios)`}
+                      {interviewer.name} - {interviewer.role} {interviewer.scheduleCount > 0 ? `(${interviewer.scheduleCount} horarios)` : ''}
                     </option>
                   ))
                 )}
@@ -969,7 +965,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : interviewersError ? (
                   <option disabled>{interviewersError}</option>
                 ) : interviewers.length === 0 ? (
-                  <option disabled>No hay entrevistadores con horarios configurados</option>
+                  <option disabled>No hay entrevistadores disponibles</option>
                 ) : (
                   (() => {
                     const filteredInterviewers = interviewers.filter(interviewer => {
@@ -988,9 +984,8 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                       <option
                         key={interviewer.id}
                         value={interviewer.id}
-                        disabled={interviewer.scheduleCount === 0}
                       >
-                        {interviewer.name} - {interviewer.role} {interviewer.scheduleCount === 0 ? '(Sin horarios)' : `(${interviewer.scheduleCount} horarios)`}
+                        {interviewer.name} - {interviewer.role} {interviewer.scheduleCount > 0 ? `(${interviewer.scheduleCount} horarios)` : ''}
                       </option>
                     ));
                   })()

--- a/microfrontends/apps/mf-student/components/interviews/InterviewForm.tsx
+++ b/microfrontends/apps/mf-student/components/interviews/InterviewForm.tsx
@@ -1080,7 +1080,7 @@ const InterviewForm: React.FC<InterviewFormProps> = ({
                 ) : (
                   <div className="p-4 bg-gray-50 border border-gray-200 rounded-md">
                     <p className="text-sm text-gray-600 text-center">
-                      Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
+                      👆 Primero seleccione {(formData.type === InterviewType.FAMILY || formData.type === InterviewType.CYCLE_DIRECTOR) ? 'ambos entrevistadores' : 'un entrevistador'} para ver los horarios disponibles
                     </p>
                   </div>
                 )}

--- a/microfrontends/apps/mf-student/components/layout/Footer.tsx
+++ b/microfrontends/apps/mf-student/components/layout/Footer.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Facebook, Instagram, Linkedin } from 'lucide-react';
+import { microfrontendUrls } from '../../utils/microfrontendUrls';
 
 const Footer: React.FC = () => {
     const [showModal, setShowModal] = useState(false);
@@ -63,8 +64,9 @@ const Footer: React.FC = () => {
                         </div>
                     </div>
                 </div>
-                <div className="border-t border-blue-800 mt-10 pt-6 text-center text-sm text-gray-400">
+                <div className="border-t border-blue-800 mt-10 pt-6 flex flex-col sm:flex-row items-center justify-between gap-2 text-sm text-gray-400">
                     <p>&copy; {new Date().getFullYear()} Colegio Monte Tabor y Nazaret. Todos los derechos reservados.</p>
+                    <a href={microfrontendUrls.adminLogin} className="text-gray-400 hover:text-dorado-nazaret transition-colors text-xs underline underline-offset-2">Acceso personal MTN</a>
                 </div>
             </div>
             {/* Modal de contacto */}

--- a/microfrontends/apps/mf-student/components/layout/Header.tsx
+++ b/microfrontends/apps/mf-student/components/layout/Header.tsx
@@ -124,16 +124,11 @@ const Header: React.FC = () => {
 
                 <div className="flex items-center gap-2 sm:gap-4">
                     {!isAnyUserLoggedIn && (
-                        <div className="hidden sm:flex items-center gap-3">
-                            <a href={microfrontendUrls.guardianLogin} className="text-gris-piedra hover:text-azul-monte-tabor font-semibold transition-colors duration-200">
-                                Iniciar sesión
-                            </a>
-                            <a href={microfrontendUrls.admissions}>
-                                <Button variant="primary" size="sm" className="!text-blanco-pureza">
-                                    Postular
-                                </Button>
-                            </a>
-                        </div>
+                        <a href={microfrontendUrls.admissions} className="hidden sm:block">
+                            <Button variant="primary" size="sm">
+                                Iniciar Postulación
+                            </Button>
+                        </a>
                     )}
                     {/* Hamburger button */}
                     <button
@@ -199,15 +194,10 @@ const Header: React.FC = () => {
                             </a>
                         )}
                         {!isAnyUserLoggedIn && (
-                            <div className="pt-2 pb-1 flex flex-col gap-2">
-                                <a href={microfrontendUrls.guardianLogin} onClick={() => setIsMobileMenuOpen(false)}>
-                                    <Button variant="outline" className="w-full">
-                                        Iniciar sesión
-                                    </Button>
-                                </a>
+                            <div className="pt-2 pb-1">
                                 <a href={microfrontendUrls.admissions} onClick={() => setIsMobileMenuOpen(false)}>
-                                    <Button variant="primary" className="w-full !text-blanco-pureza">
-                                        Postular
+                                    <Button variant="primary" className="w-full">
+                                        Iniciar Postulación
                                     </Button>
                                 </a>
                             </div>

--- a/microfrontends/apps/mf-student/components/layout/Header.tsx
+++ b/microfrontends/apps/mf-student/components/layout/Header.tsx
@@ -124,11 +124,16 @@ const Header: React.FC = () => {
 
                 <div className="flex items-center gap-2 sm:gap-4">
                     {!isAnyUserLoggedIn && (
-                        <a href={microfrontendUrls.admissions} className="hidden sm:block">
-                            <Button variant="primary" size="sm">
-                                Iniciar Postulación
-                            </Button>
-                        </a>
+                        <div className="hidden sm:flex items-center gap-3">
+                            <a href={microfrontendUrls.guardianLogin} className="text-gris-piedra hover:text-azul-monte-tabor font-semibold transition-colors duration-200">
+                                Iniciar sesión
+                            </a>
+                            <a href={microfrontendUrls.admissions}>
+                                <Button variant="primary" size="sm" className="!text-blanco-pureza">
+                                    Postular
+                                </Button>
+                            </a>
+                        </div>
                     )}
                     {/* Hamburger button */}
                     <button
@@ -194,10 +199,15 @@ const Header: React.FC = () => {
                             </a>
                         )}
                         {!isAnyUserLoggedIn && (
-                            <div className="pt-2 pb-1">
+                            <div className="pt-2 pb-1 flex flex-col gap-2">
+                                <a href={microfrontendUrls.guardianLogin} onClick={() => setIsMobileMenuOpen(false)}>
+                                    <Button variant="outline" className="w-full">
+                                        Iniciar sesión
+                                    </Button>
+                                </a>
                                 <a href={microfrontendUrls.admissions} onClick={() => setIsMobileMenuOpen(false)}>
-                                    <Button variant="primary" className="w-full">
-                                        Iniciar Postulación
+                                    <Button variant="primary" className="w-full !text-blanco-pureza">
+                                        Postular
                                     </Button>
                                 </a>
                             </div>

--- a/microfrontends/apps/mf-student/components/modals/CoordinatorDashboardModal.tsx
+++ b/microfrontends/apps/mf-student/components/modals/CoordinatorDashboardModal.tsx
@@ -7,7 +7,8 @@ import React, { useState, useEffect } from 'react';
 import { FiX, FiRefreshCw } from 'react-icons/fi';
 import { dashboardClient } from '../../src/api/dashboard.client';
 import type { DetailedAdminStats, Alert } from '../../src/api/dashboard.types';
-import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 
 interface CoordinatorDashboardModalProps {
   isOpen: boolean;
@@ -115,6 +116,32 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
   const acceptanceRate = stats && stats.totalApplications > 0
     ? ((stats.statusBreakdown.approved / stats.totalApplications) * 100).toFixed(1)
     : '0.0';
+
+  const statusChartOption: EChartsOption = {
+    color: statusData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [
+      {
+        type: 'pie',
+        radius: ['42%', '70%'],
+        center: ['50%', '50%'],
+        avoidLabelOverlap: true,
+        itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+        label: { formatter: '{b}: {d}%' },
+        data: statusData.map(item => ({ name: item.name, value: item.value }))
+      }
+    ]
+  };
+
+  const gradeChartOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: gradeData.map(item => item.grade), axisTick: { alignWithLabel: true } },
+    yAxis: { type: 'value' },
+    series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 42 }]
+  };
 
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
@@ -348,25 +375,7 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
                   {/* Status Distribution Pie Chart */}
                   <div className="bg-white border border-gray-200 shadow-sm rounded-lg p-6">
                     <h3 className="text-lg font-medium text-gray-900 mb-4">Distribución por Estado</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                      <PieChart>
-                        <Pie
-                          data={statusData}
-                          cx="50%"
-                          cy="50%"
-                          labelLine={false}
-                          label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
-                          outerRadius={80}
-                          fill="#8884d8"
-                          dataKey="value"
-                        >
-                          {statusData.map((entry, index) => (
-                            <Cell key={`cell-${index}`} fill={entry.color} />
-                          ))}
-                        </Pie>
-                        <Tooltip />
-                      </PieChart>
-                    </ResponsiveContainer>
+                    <EChart option={statusChartOption} height={300} />
                     <div className="mt-4 grid grid-cols-2 gap-2 text-sm">
                       {statusData.map((item, index) => (
                         <div key={index} className="flex items-center">
@@ -383,16 +392,7 @@ export const CoordinatorDashboardModal: React.FC<CoordinatorDashboardModalProps>
                   {/* Grade Distribution Bar Chart */}
                   <div className="bg-white border border-gray-200 shadow-sm rounded-lg p-6">
                     <h3 className="text-lg font-medium text-gray-900 mb-4">Distribución por Nivel</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                      <BarChart data={gradeData}>
-                        <CartesianGrid strokeDasharray="3 3" />
-                        <XAxis dataKey="grade" />
-                        <YAxis />
-                        <Tooltip />
-                        <Legend />
-                        <Bar dataKey="count" fill="#3B82F6" name="Postulaciones" />
-                      </BarChart>
-                    </ResponsiveContainer>
+                    <EChart option={gradeChartOption} height={300} />
                   </div>
                 </div>
 

--- a/microfrontends/apps/mf-student/package.json
+++ b/microfrontends/apps/mf-student/package.json
@@ -14,6 +14,8 @@
     "axios": "^1.11.0",
     "axios-retry": "^4.5.0",
     "date-fns": "^4.1.0",
+    "echarts": "^6.0.0",
+    "echarts-for-react": "^3.0.6",
     "express": "^4.18.2",
     "firebase": "^12.12.1",
     "lucide-react": "^0.540.0",
@@ -23,7 +25,6 @@
     "react-dropzone": "^14.3.8",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.3",
-    "recharts": "^3.2.1",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {

--- a/microfrontends/apps/mf-student/pages/ExamPortal.tsx
+++ b/microfrontends/apps/mf-student/pages/ExamPortal.tsx
@@ -141,53 +141,68 @@ const ExamPortal: React.FC = () => {
                 </div>
 
                 {/* Process Timeline */}
-                <Card className="p-4 sm:p-8">
-                    <h2 className="text-xl sm:text-2xl font-bold text-azul-monte-tabor text-center mb-6 sm:mb-8">
-                        Proceso de Exámenes
-                    </h2>
+                <div className="py-8 sm:py-12">
+                    <div className="text-center mb-12">
+                        <h2 className="text-xl sm:text-2xl font-bold text-azul-monte-tabor mb-3 font-serif">
+                            Proceso de Exámenes
+                        </h2>
+                        <p className="text-dorado-nazaret font-medium">Sigue estos pasos para completar tu proceso de evaluación</p>
+                    </div>
                     {/* Desktop: alternating timeline */}
-                    <div className="hidden sm:block relative max-w-4xl mx-auto">
-                        <div className="absolute left-1/2 h-full w-1 bg-azul-monte-tabor rounded-full transform -translate-x-1/2"></div>
+                    <div className="hidden sm:block relative max-w-3xl mx-auto">
+                        <div className="absolute left-1/2 h-full w-0.5 bg-gray-300 transform -translate-x-1/2"></div>
                         {[
                             { step: 1, title: "Preparación", description: "Revisa los temas y requisitos para cada asignatura", date: "Previo al examen" },
                             { step: 2, title: "Confirmación de Horarios", description: "Confirma tu asistencia a los horarios asignados", date: "Fecha fija" },
                             { step: 3, title: "Rendir Exámenes", description: "Presenta los exámenes - 31 preguntas en 80 minutos", date: "Fecha programada" },
                             { step: 4, title: "Resultados", description: "Consulta tus resultados en el portal (puntaje mínimo 60%)", date: "Posterior al examen" }
                         ].map((item, index) => (
-                            <div key={item.step} className={`flex items-center w-full mb-8 ${index % 2 === 0 ? 'justify-start' : 'justify-end'}`}>
-                                <div className={`w-5/12 ${index % 2 === 0 ? 'text-right pr-8' : 'text-left pl-8'}`}>
-                                    <div className={`${index % 2 === 0 ? 'text-right' : 'text-left'}`}>
-                                        <h3 className="font-bold text-azul-monte-tabor mb-1">Paso {item.step}: {item.title}</h3>
-                                        <p className="text-gris-piedra text-sm mb-1">{item.description}</p>
-                                        <p className="text-dorado-nazaret font-semibold text-sm">{item.date}</p>
-                                    </div>
+                            <div key={item.step} className="flex items-center w-full mb-16">
+                                <div className="flex-1 pr-10 text-right">
+                                    {index % 2 === 0 ? (
+                                        <>
+                                            <p className="text-xs font-bold uppercase tracking-wider mb-1 text-dorado-nazaret">{item.date}</p>
+                                            <p className="font-bold text-base text-azul-monte-tabor">Paso {item.step}: {item.title}</p>
+                                        </>
+                                    ) : (
+                                        <p className="text-gris-piedra text-sm">{item.description}</p>
+                                    )}
                                 </div>
-                                <div className="relative">
-                                    <div className="w-8 h-8 rounded-full bg-dorado-nazaret flex items-center justify-center z-10 text-azul-monte-tabor font-bold text-sm">{item.step}</div>
+                                <div className="flex-shrink-0 z-10 w-6">
+                                    <div className="w-6 h-6 rounded-full bg-dorado-nazaret flex items-center justify-center text-azul-monte-tabor font-bold text-xs">{item.step}</div>
                                 </div>
-                                <div className="w-5/12"></div>
+                                <div className="flex-1 pl-10 text-left">
+                                    {index % 2 === 0 ? (
+                                        <p className="text-gris-piedra text-sm">{item.description}</p>
+                                    ) : (
+                                        <>
+                                            <p className="text-xs font-bold uppercase tracking-wider mb-1 text-dorado-nazaret">{item.date}</p>
+                                            <p className="font-bold text-base text-azul-monte-tabor">Paso {item.step}: {item.title}</p>
+                                        </>
+                                    )}
+                                </div>
                             </div>
                         ))}
                     </div>
                     {/* Mobile: vertical steps */}
-                    <div className="sm:hidden space-y-3">
+                    <div className="sm:hidden space-y-4 max-w-sm mx-auto">
                         {[
                             { step: 1, title: "Preparación", description: "Revisa los temas y requisitos para cada asignatura", date: "Previo al examen" },
                             { step: 2, title: "Confirmación de Horarios", description: "Confirma tu asistencia a los horarios asignados", date: "Fecha fija" },
                             { step: 3, title: "Rendir Exámenes", description: "Presenta los exámenes - 31 preguntas en 80 minutos", date: "Fecha programada" },
                             { step: 4, title: "Resultados", description: "Consulta tus resultados en el portal (puntaje mínimo 60%)", date: "Posterior al examen" }
                         ].map((item) => (
-                            <div key={item.step} className="flex items-start gap-4 p-4 bg-gray-50 rounded-lg">
-                                <div className="w-8 h-8 rounded-full bg-dorado-nazaret flex items-center justify-center flex-shrink-0 text-azul-monte-tabor font-bold text-sm">{item.step}</div>
+                            <div key={item.step} className="flex items-start gap-4 p-4 rounded-lg border-l-4 border-dorado-nazaret bg-amber-50">
+                                <div className="w-6 h-6 rounded-full bg-dorado-nazaret flex items-center justify-center flex-shrink-0 text-azul-monte-tabor font-bold text-xs mt-0.5">{item.step}</div>
                                 <div>
-                                    <h3 className="font-bold text-azul-monte-tabor text-sm">{item.title}</h3>
-                                    <p className="text-gris-piedra text-xs mt-1">{item.description}</p>
-                                    <p className="text-dorado-nazaret font-semibold text-xs mt-1">{item.date}</p>
+                                    <p className="text-xs font-bold uppercase tracking-wider mb-1 text-dorado-nazaret">{item.date}</p>
+                                    <p className="font-bold text-sm text-azul-monte-tabor mb-1">Paso {item.step}: {item.title}</p>
+                                    <p className="text-gris-piedra text-sm">{item.description}</p>
                                 </div>
                             </div>
                         ))}
                     </div>
-                </Card>
+                </div>
             </div>
         </div>
     );

--- a/microfrontends/apps/mf-student/pages/ExamPortal.tsx
+++ b/microfrontends/apps/mf-student/pages/ExamPortal.tsx
@@ -141,68 +141,53 @@ const ExamPortal: React.FC = () => {
                 </div>
 
                 {/* Process Timeline */}
-                <div className="py-8 sm:py-12">
-                    <div className="text-center mb-12">
-                        <h2 className="text-xl sm:text-2xl font-bold text-azul-monte-tabor mb-3 font-serif">
-                            Proceso de Exámenes
-                        </h2>
-                        <p className="text-dorado-nazaret font-medium">Sigue estos pasos para completar tu proceso de evaluación</p>
-                    </div>
+                <Card className="p-4 sm:p-8">
+                    <h2 className="text-xl sm:text-2xl font-bold text-azul-monte-tabor text-center mb-6 sm:mb-8">
+                        Proceso de Exámenes
+                    </h2>
                     {/* Desktop: alternating timeline */}
-                    <div className="hidden sm:block relative max-w-3xl mx-auto">
-                        <div className="absolute left-1/2 h-full w-0.5 bg-gray-300 transform -translate-x-1/2"></div>
+                    <div className="hidden sm:block relative max-w-4xl mx-auto">
+                        <div className="absolute left-1/2 h-full w-1 bg-azul-monte-tabor rounded-full transform -translate-x-1/2"></div>
                         {[
                             { step: 1, title: "Preparación", description: "Revisa los temas y requisitos para cada asignatura", date: "Previo al examen" },
                             { step: 2, title: "Confirmación de Horarios", description: "Confirma tu asistencia a los horarios asignados", date: "Fecha fija" },
                             { step: 3, title: "Rendir Exámenes", description: "Presenta los exámenes - 31 preguntas en 80 minutos", date: "Fecha programada" },
                             { step: 4, title: "Resultados", description: "Consulta tus resultados en el portal (puntaje mínimo 60%)", date: "Posterior al examen" }
                         ].map((item, index) => (
-                            <div key={item.step} className="flex items-center w-full mb-16">
-                                <div className="flex-1 pr-10 text-right">
-                                    {index % 2 === 0 ? (
-                                        <>
-                                            <p className="text-xs font-bold uppercase tracking-wider mb-1 text-dorado-nazaret">{item.date}</p>
-                                            <p className="font-bold text-base text-azul-monte-tabor">Paso {item.step}: {item.title}</p>
-                                        </>
-                                    ) : (
-                                        <p className="text-gris-piedra text-sm">{item.description}</p>
-                                    )}
+                            <div key={item.step} className={`flex items-center w-full mb-8 ${index % 2 === 0 ? 'justify-start' : 'justify-end'}`}>
+                                <div className={`w-5/12 ${index % 2 === 0 ? 'text-right pr-8' : 'text-left pl-8'}`}>
+                                    <div className={`${index % 2 === 0 ? 'text-right' : 'text-left'}`}>
+                                        <h3 className="font-bold text-azul-monte-tabor mb-1">Paso {item.step}: {item.title}</h3>
+                                        <p className="text-gris-piedra text-sm mb-1">{item.description}</p>
+                                        <p className="text-dorado-nazaret font-semibold text-sm">{item.date}</p>
+                                    </div>
                                 </div>
-                                <div className="flex-shrink-0 z-10 w-6">
-                                    <div className="w-6 h-6 rounded-full bg-dorado-nazaret flex items-center justify-center text-azul-monte-tabor font-bold text-xs">{item.step}</div>
+                                <div className="relative">
+                                    <div className="w-8 h-8 rounded-full bg-dorado-nazaret flex items-center justify-center z-10 text-azul-monte-tabor font-bold text-sm">{item.step}</div>
                                 </div>
-                                <div className="flex-1 pl-10 text-left">
-                                    {index % 2 === 0 ? (
-                                        <p className="text-gris-piedra text-sm">{item.description}</p>
-                                    ) : (
-                                        <>
-                                            <p className="text-xs font-bold uppercase tracking-wider mb-1 text-dorado-nazaret">{item.date}</p>
-                                            <p className="font-bold text-base text-azul-monte-tabor">Paso {item.step}: {item.title}</p>
-                                        </>
-                                    )}
-                                </div>
+                                <div className="w-5/12"></div>
                             </div>
                         ))}
                     </div>
                     {/* Mobile: vertical steps */}
-                    <div className="sm:hidden space-y-4 max-w-sm mx-auto">
+                    <div className="sm:hidden space-y-3">
                         {[
                             { step: 1, title: "Preparación", description: "Revisa los temas y requisitos para cada asignatura", date: "Previo al examen" },
                             { step: 2, title: "Confirmación de Horarios", description: "Confirma tu asistencia a los horarios asignados", date: "Fecha fija" },
                             { step: 3, title: "Rendir Exámenes", description: "Presenta los exámenes - 31 preguntas en 80 minutos", date: "Fecha programada" },
                             { step: 4, title: "Resultados", description: "Consulta tus resultados en el portal (puntaje mínimo 60%)", date: "Posterior al examen" }
                         ].map((item) => (
-                            <div key={item.step} className="flex items-start gap-4 p-4 rounded-lg border-l-4 border-dorado-nazaret bg-amber-50">
-                                <div className="w-6 h-6 rounded-full bg-dorado-nazaret flex items-center justify-center flex-shrink-0 text-azul-monte-tabor font-bold text-xs mt-0.5">{item.step}</div>
+                            <div key={item.step} className="flex items-start gap-4 p-4 bg-gray-50 rounded-lg">
+                                <div className="w-8 h-8 rounded-full bg-dorado-nazaret flex items-center justify-center flex-shrink-0 text-azul-monte-tabor font-bold text-sm">{item.step}</div>
                                 <div>
-                                    <p className="text-xs font-bold uppercase tracking-wider mb-1 text-dorado-nazaret">{item.date}</p>
-                                    <p className="font-bold text-sm text-azul-monte-tabor mb-1">Paso {item.step}: {item.title}</p>
-                                    <p className="text-gris-piedra text-sm">{item.description}</p>
+                                    <h3 className="font-bold text-azul-monte-tabor text-sm">{item.title}</h3>
+                                    <p className="text-gris-piedra text-xs mt-1">{item.description}</p>
+                                    <p className="text-dorado-nazaret font-semibold text-xs mt-1">{item.date}</p>
                                 </div>
                             </div>
                         ))}
                     </div>
-                </div>
+                </Card>
             </div>
         </div>
     );

--- a/microfrontends/apps/mf-student/services/interviewService.ts
+++ b/microfrontends/apps/mf-student/services/interviewService.ts
@@ -796,14 +796,14 @@ class InterviewService {
       const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
       if (!dateRegex.test(date)) {
         console.error(`getAvailableTimeSlots: Formato de fecha inválido "${date}". Se esperaba YYYY-MM-DD`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Verificar que el año sea razonable
       const year = parseInt(date.split('-')[0]);
       if (year < 2020 || year > 2100) {
         console.error(`getAvailableTimeSlots: Año inválido ${year}. Debe estar entre 2020 y 2100`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Validar y usar duración por defecto si es inválida
@@ -825,8 +825,8 @@ class InterviewService {
 
       // Verificar si la respuesta es del placeholder (microservicio no implementado)
       if (response.data && typeof response.data === 'object' && 'error' in response.data) {
-        console.log('Available slots service no implementado, usando horarios por defecto');
-        return this.getDefaultTimeSlots();
+        console.log('Available slots service no implementado, devolviendo horarios vacíos');
+        return [];
       }
 
       // CASO 1: Backend devuelve estructura { success: true, data: { availableSlots: [...] } }
@@ -878,13 +878,12 @@ class InterviewService {
         }
       }
 
-      console.log('Estructura de respuesta inesperada para available slots, usando horarios por defecto');
+      console.log('Estructura de respuesta inesperada para available slots, devolviendo horarios vacíos');
       console.log('Data recibida:', response.data);
-      return this.getDefaultTimeSlots();
+      return [];
     } catch (error) {
       console.error('Error fetching available slots:', error);
-      // Fallback: horarios estándar si el backend no los tiene configurados
-      return this.getDefaultTimeSlots();
+      return [];
     }
   }
 
@@ -979,14 +978,14 @@ class InterviewService {
       const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
       if (!dateRegex.test(date)) {
         console.error(`getCommonTimeSlots: Formato de fecha inválido "${date}". Se esperaba YYYY-MM-DD`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Verificar que el año sea razonable
       const year = parseInt(date.split('-')[0]);
       if (year < 2020 || year > 2100) {
         console.error(`getCommonTimeSlots: Año inválido ${year}. Debe estar entre 2020 y 2100`);
-        return this.getDefaultTimeSlots();
+        return [];
       }
 
       // Obtener los horarios disponibles de ambos entrevistadores
@@ -1006,8 +1005,7 @@ class InterviewService {
       return commonSlots;
     } catch (error) {
       console.error('Error obteniendo horarios comunes:', error);
-      // Fallback: horarios por defecto
-      return this.getDefaultTimeSlots();
+      return [];
     }
   }
 

--- a/microfrontends/apps/mf-student/src/components/charts/EChart.tsx
+++ b/microfrontends/apps/mf-student/src/components/charts/EChart.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactECharts from 'echarts-for-react';
+import type { EChartsOption } from 'echarts';
+
+interface EChartProps {
+  option: EChartsOption;
+  height?: number;
+  onEvents?: Record<string, (params: any) => void>;
+}
+
+const EChart: React.FC<EChartProps> = ({ option, height = 300, onEvents }) => (
+  <ReactECharts
+    option={option}
+    notMerge
+    lazyUpdate
+    onEvents={onEvents}
+    style={{ width: '100%', height }}
+  />
+);
+
+export default EChart;

--- a/microfrontends/apps/mf-student/src/components/coordinator/CoordinatorDashboard.tsx
+++ b/microfrontends/apps/mf-student/src/components/coordinator/CoordinatorDashboard.tsx
@@ -9,7 +9,8 @@
 import React, { useState, useEffect } from 'react';
 import { dashboardClient } from '../../api/dashboard.client';
 import type { DetailedAdminStats, Alert } from '../../api/dashboard.types';
-import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { ApplicantMetricsModal } from '../../../components/modals/ApplicantMetricsModal';
 
 export const CoordinatorDashboard: React.FC = () => {
@@ -143,6 +144,32 @@ export const CoordinatorDashboard: React.FC = () => {
   const acceptanceRate = stats.totalApplications > 0
     ? ((stats.statusBreakdown.approved / stats.totalApplications) * 100).toFixed(1)
     : '0.0';
+
+  const statusChartOption: EChartsOption = {
+    color: statusData.map(item => item.color),
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    series: [
+      {
+        type: 'pie',
+        radius: ['42%', '70%'],
+        center: ['50%', '50%'],
+        avoidLabelOverlap: true,
+        itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+        label: { formatter: '{b}: {d}%' },
+        data: statusData.map(item => ({ name: item.name, value: item.value }))
+      }
+    ]
+  };
+
+  const gradeChartOption: EChartsOption = {
+    color: ['#3B82F6'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: gradeData.map(item => item.grade), axisTick: { alignWithLabel: true } },
+    yAxis: { type: 'value' },
+    series: [{ name: 'Postulaciones', type: 'bar', data: gradeData.map(item => item.count), barMaxWidth: 42 }]
+  };
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -336,25 +363,7 @@ export const CoordinatorDashboard: React.FC = () => {
         {/* Status Distribution Pie Chart */}
         <div className="bg-white shadow rounded-lg p-6">
           <h2 className="text-lg font-medium text-gray-900 mb-4">Distribución por Estado</h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie
-                data={statusData}
-                cx="50%"
-                cy="50%"
-                labelLine={false}
-                label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
-                outerRadius={80}
-                fill="#8884d8"
-                dataKey="value"
-              >
-                {statusData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
-                ))}
-              </Pie>
-              <Tooltip />
-            </PieChart>
-          </ResponsiveContainer>
+          <EChart option={statusChartOption} height={300} />
           <div className="mt-4 grid grid-cols-2 gap-2 text-sm">
             {statusData.map((item, index) => (
               <div key={index} className="flex items-center">
@@ -371,16 +380,7 @@ export const CoordinatorDashboard: React.FC = () => {
         {/* Grade Distribution Bar Chart */}
         <div className="bg-white shadow rounded-lg p-6">
           <h2 className="text-lg font-medium text-gray-900 mb-4">Distribución por Nivel</h2>
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={gradeData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="grade" />
-              <YAxis />
-              <Tooltip />
-              <Legend />
-              <Bar dataKey="count" fill="#3B82F6" name="Postulaciones" />
-            </BarChart>
-          </ResponsiveContainer>
+          <EChart option={gradeChartOption} height={300} />
         </div>
       </div>
 

--- a/microfrontends/apps/mf-student/src/components/coordinator/TemporalTrendsView.tsx
+++ b/microfrontends/apps/mf-student/src/components/coordinator/TemporalTrendsView.tsx
@@ -8,7 +8,8 @@
 import React, { useState, useEffect } from 'react';
 import { dashboardClient } from '../../api/dashboard.client';
 import type { TemporalTrend, DetailedAdminStats } from '../../api/dashboard.types';
-import { LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { EChartsOption } from 'echarts';
+import EChart from '../charts/EChart';
 import { format } from 'date-fns';
 
 export const TemporalTrendsView: React.FC = () => {
@@ -114,6 +115,52 @@ export const TemporalTrendsView: React.FC = () => {
     };
   }).filter(Boolean);
 
+  const monthlyTrendsOption: EChartsOption = {
+    color: ['#3B82F6', '#10B981', '#EF4444', '#F59E0B'],
+    tooltip: { trigger: 'axis' },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 48, top: 24, bottom: 80, containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: monthlyTrendsData.map(item => item.month),
+      axisLabel: { rotate: 45 }
+    },
+    yAxis: [
+      { type: 'value', name: 'Postulaciones' },
+      { type: 'value', name: '%' }
+    ],
+    series: [
+      { name: 'Total Postulaciones', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.total) },
+      { name: 'Aprobadas', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.approved) },
+      { name: 'Rechazadas', type: 'line', smooth: true, yAxisIndex: 0, data: monthlyTrendsData.map(item => item.rejected) },
+      { name: 'Tasa de Crecimiento (%)', type: 'line', smooth: true, yAxisIndex: 1, lineStyle: { type: 'dashed' }, data: monthlyTrendsData.map(item => item.growthRate) }
+    ]
+  };
+
+  const comparisonOption: EChartsOption = {
+    color: ['#3B82F6', '#10B981', '#EF4444'],
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: comparisonData.map((item: any) => item.year) },
+    yAxis: { type: 'value' },
+    series: [
+      { name: 'Total', type: 'bar', data: comparisonData.map((item: any) => item.total) },
+      { name: 'Aprobadas', type: 'bar', data: comparisonData.map((item: any) => item.approved) },
+      { name: 'Rechazadas', type: 'bar', data: comparisonData.map((item: any) => item.rejected) }
+    ]
+  };
+
+  const acceptanceRateOption: EChartsOption = {
+    color: ['#10B981'],
+    tooltip: { trigger: 'axis', valueFormatter: value => `${Number(value).toFixed(1)}%` },
+    legend: { bottom: 0 },
+    grid: { left: 8, right: 8, top: 16, bottom: 48, containLabel: true },
+    xAxis: { type: 'category', data: comparisonData.map((item: any) => item.year) },
+    yAxis: { type: 'value', min: 0, max: 100 },
+    series: [{ name: 'Tasa de Aceptación (%)', type: 'bar', data: comparisonData.map((item: any) => item.acceptanceRate), barMaxWidth: 48 }]
+  };
+
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       {/* Header */}
@@ -147,50 +194,7 @@ export const TemporalTrendsView: React.FC = () => {
       {/* Monthly Trends Chart */}
       <div className="bg-white shadow rounded-lg p-6 mb-6">
         <h2 className="text-lg font-medium text-gray-900 mb-4">Tendencia Mensual (Últimos 12 meses)</h2>
-        <ResponsiveContainer width="100%" height={400}>
-          <LineChart data={monthlyTrendsData}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="month" angle={-45} textAnchor="end" height={80} />
-            <YAxis yAxisId="left" />
-            <YAxis yAxisId="right" orientation="right" />
-            <Tooltip />
-            <Legend />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="total"
-              stroke="#3B82F6"
-              strokeWidth={2}
-              name="Total Postulaciones"
-              dot={{ r: 4 }}
-            />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="approved"
-              stroke="#10B981"
-              strokeWidth={2}
-              name="Aprobadas"
-            />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="rejected"
-              stroke="#EF4444"
-              strokeWidth={2}
-              name="Rechazadas"
-            />
-            <Line
-              yAxisId="right"
-              type="monotone"
-              dataKey="growthRate"
-              stroke="#F59E0B"
-              strokeWidth={2}
-              name="Tasa de Crecimiento (%)"
-              strokeDasharray="5 5"
-            />
-          </LineChart>
-        </ResponsiveContainer>
+        <EChart option={monthlyTrendsOption} height={400} />
       </div>
 
       {/* Year Comparison */}
@@ -199,33 +203,13 @@ export const TemporalTrendsView: React.FC = () => {
           {/* Total Applications Comparison */}
           <div className="bg-white shadow rounded-lg p-6">
             <h2 className="text-lg font-medium text-gray-900 mb-4">Comparativa de Postulaciones</h2>
-            <ResponsiveContainer width="100%" height={300}>
-              <BarChart data={comparisonData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="year" />
-                <YAxis />
-                <Tooltip />
-                <Legend />
-                <Bar dataKey="total" fill="#3B82F6" name="Total" />
-                <Bar dataKey="approved" fill="#10B981" name="Aprobadas" />
-                <Bar dataKey="rejected" fill="#EF4444" name="Rechazadas" />
-              </BarChart>
-            </ResponsiveContainer>
+            <EChart option={comparisonOption} height={300} />
           </div>
 
           {/* Acceptance Rate Comparison */}
           <div className="bg-white shadow rounded-lg p-6">
             <h2 className="text-lg font-medium text-gray-900 mb-4">Tasa de Aceptación por Año</h2>
-            <ResponsiveContainer width="100%" height={300}>
-              <BarChart data={comparisonData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="year" />
-                <YAxis domain={[0, 100]} />
-                <Tooltip formatter={(value) => `${Number(value).toFixed(1)}%`} />
-                <Legend />
-                <Bar dataKey="acceptanceRate" fill="#10B981" name="Tasa de Aceptación (%)" />
-              </BarChart>
-            </ResponsiveContainer>
+            <EChart option={acceptanceRateOption} height={300} />
           </div>
         </div>
       )}

--- a/microfrontends/apps/shell/src/manifest.ts
+++ b/microfrontends/apps/shell/src/manifest.ts
@@ -33,7 +33,7 @@ const getMfUrl = (name: string, localPort: number, localPath: string, prodPath: 
 };
 
 const appUrls = {
-  admissions: getMfUrl('admissions', 5201, '/postulacion', '/postulacion'),
+  admissions: getMfUrl('admissions', 5201, '/', '/'),
   guardian: getMfUrl('guardian', 5202, '/apoderado/login', '/apoderado/login'),
   student: getMfUrl('student', 5203, '/examenes', '/examenes'),
   evaluations: getMfUrl('evaluations', 5204, '/profesor/login', '/profesor/login'),

--- a/microfrontends/packages/backend-sdk/src/index.ts
+++ b/microfrontends/packages/backend-sdk/src/index.ts
@@ -166,6 +166,34 @@ export function resolveSession(storage: Pick<Storage, 'getItem'> = window.localS
   }
 }
 
+/**
+ * Limpia TODAS las claves de sesión conocidas del localStorage.
+ * Llamar antes de cualquier login para evitar cruce de sesiones entre roles.
+ */
+export function clearAllSessions(storage: Pick<Storage, 'removeItem'> = window.localStorage): void {
+  const baseKeys = [
+    BASE_STORAGE_KEYS.AUTH_TOKEN,
+    BASE_STORAGE_KEYS.PROFESSOR_TOKEN,
+    BASE_STORAGE_KEYS.APODERADO_TOKEN,
+    BASE_STORAGE_KEYS.AUTHENTICATED_USER,
+    BASE_STORAGE_KEYS.PROFESSOR_USER,
+    BASE_STORAGE_KEYS.CURRENT_PROFESSOR,
+    BASE_STORAGE_KEYS.APODERADO_USER,
+  ];
+  const envs = ['development', 'staging', 'sta', 'production', 'dev', 'qa', 'uat', 'test'];
+  for (const key of baseKeys) {
+    storage.removeItem(key);
+    for (const env of envs) {
+      storage.removeItem(`${key}__${env}`);
+    }
+  }
+  // Legacy plain keys
+  storage.removeItem('currentProfessor');
+  storage.removeItem('currentUser');
+  storage.removeItem('currentApoderado');
+  storage.removeItem('mtn_auth_state');
+}
+
 export function buildAuthHeaders(storage: Pick<Storage, 'getItem'> = window.localStorage): HeadersInit {
   const token = resolveAccessToken(storage);
   if (!token) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
         "axios": "^1.11.0",
         "axios-retry": "^4.5.0",
         "date-fns": "^4.1.0",
+        "echarts": "^6.0.0",
+        "echarts-for-react": "^3.0.6",
         "express": "^4.18.2",
         "firebase": "^12.12.1",
         "lucide-react": "^0.540.0",
@@ -26,7 +28,6 @@
         "react-dropzone": "^14.3.8",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.3",
-        "recharts": "^3.2.1",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -52,6 +53,8 @@
         "axios": "^1.11.0",
         "axios-retry": "^4.5.0",
         "date-fns": "^4.1.0",
+        "echarts": "^6.0.0",
+        "echarts-for-react": "^3.0.6",
         "express": "^4.18.2",
         "firebase": "^12.12.1",
         "lucide-react": "^0.540.0",
@@ -61,7 +64,6 @@
         "react-dropzone": "^14.3.8",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.3",
-        "recharts": "^3.2.1",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -87,6 +89,8 @@
         "axios": "^1.11.0",
         "axios-retry": "^4.5.0",
         "date-fns": "^4.1.0",
+        "echarts": "^6.0.0",
+        "echarts-for-react": "^3.0.6",
         "express": "^4.18.2",
         "firebase": "^12.12.1",
         "lucide-react": "^0.540.0",
@@ -96,7 +100,6 @@
         "react-dropzone": "^14.3.8",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.3",
-        "recharts": "^3.2.1",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -122,6 +125,8 @@
         "axios": "^1.11.0",
         "axios-retry": "^4.5.0",
         "date-fns": "^4.1.0",
+        "echarts": "^6.0.0",
+        "echarts-for-react": "^3.0.6",
         "express": "^4.18.2",
         "firebase": "^12.12.1",
         "lucide-react": "^0.540.0",
@@ -131,7 +136,6 @@
         "react-dropzone": "^14.3.8",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.3",
-        "recharts": "^3.2.1",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -157,6 +161,8 @@
         "axios": "^1.11.0",
         "axios-retry": "^4.5.0",
         "date-fns": "^4.1.0",
+        "echarts": "^6.0.0",
+        "echarts-for-react": "^3.0.6",
         "express": "^4.18.2",
         "firebase": "^12.12.1",
         "lucide-react": "^0.540.0",
@@ -166,7 +172,6 @@
         "react-dropzone": "^14.3.8",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.3",
-        "recharts": "^3.2.1",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -192,6 +197,8 @@
         "axios": "^1.11.0",
         "axios-retry": "^4.5.0",
         "date-fns": "^4.1.0",
+        "echarts": "^6.0.0",
+        "echarts-for-react": "^3.0.6",
         "express": "^4.18.2",
         "firebase": "^12.12.1",
         "lucide-react": "^0.540.0",
@@ -201,7 +208,6 @@
         "react-dropzone": "^14.3.8",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.3",
-        "recharts": "^3.2.1",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -227,6 +233,8 @@
         "axios": "^1.11.0",
         "axios-retry": "^4.5.0",
         "date-fns": "^4.1.0",
+        "echarts": "^6.0.0",
+        "echarts-for-react": "^3.0.6",
         "express": "^4.18.2",
         "firebase": "^12.12.1",
         "lucide-react": "^0.540.0",
@@ -236,7 +244,6 @@
         "react-dropzone": "^14.3.8",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.3",
-        "recharts": "^3.2.1",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -262,6 +269,8 @@
         "axios": "^1.11.0",
         "axios-retry": "^4.5.0",
         "date-fns": "^4.1.0",
+        "echarts": "^6.0.0",
+        "echarts-for-react": "^3.0.6",
         "express": "^4.18.2",
         "firebase": "^12.12.1",
         "lucide-react": "^0.540.0",
@@ -271,7 +280,6 @@
         "react-dropzone": "^14.3.8",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.3",
-        "recharts": "^3.2.1",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -297,6 +305,8 @@
         "axios": "^1.11.0",
         "axios-retry": "^4.5.0",
         "date-fns": "^4.1.0",
+        "echarts": "^6.0.0",
+        "echarts-for-react": "^3.0.6",
         "express": "^4.18.2",
         "firebase": "^12.12.1",
         "lucide-react": "^0.540.0",
@@ -306,7 +316,6 @@
         "react-dropzone": "^14.3.8",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.3",
-        "recharts": "^3.2.1",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -2020,32 +2029,6 @@
         "npm": ">=9.5.0"
       }
     },
-    "node_modules/@reduxjs/toolkit": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.9.0.tgz",
-      "integrity": "sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==",
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "@standard-schema/utils": "^0.3.0",
-        "immer": "^10.0.3",
-        "redux": "^5.0.1",
-        "redux-thunk": "^3.1.0",
-        "reselect": "^5.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
-        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-redux": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.43",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.43.tgz",
@@ -2340,18 +2323,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
-      "license": "MIT"
-    },
-    "node_modules/@standard-schema/utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
-      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
-      "license": "MIT"
-    },
     "node_modules/@tanstack/query-core": {
       "version": "5.90.2",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.2.tgz",
@@ -2452,69 +2423,6 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/d3-array": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-interpolate": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-color": "*"
-      }
-    },
-    "node_modules/@types/d3-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
-      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2573,7 +2481,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2594,12 +2502,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
-      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -3016,15 +2918,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/codepage": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
@@ -3137,129 +3030,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/date-fns": {
       "version": "4.1.0",
@@ -3288,12 +3060,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/decimal.js-light": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
-      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
-      "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -3336,6 +3102,36 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/echarts": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
+      "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.0.0"
+      }
+    },
+    "node_modules/echarts-for-react": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-3.0.6.tgz",
+      "integrity": "sha512-4zqLgTGWS3JvkQDXjzkR1k1CHRdpd6by0988TWMJgnvDytegWLbeP/VNZmMa+0VJx2eD7Y632bi2JquXDgiGJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "size-sensor": "^1.0.1"
+      },
+      "peerDependencies": {
+        "echarts": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "react": "^15.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -3409,16 +3205,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/es-toolkit": {
-      "version": "1.39.10",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.10.tgz",
-      "integrity": "sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==",
-      "license": "MIT",
-      "workspaces": [
-        "docs",
-        "benchmarks"
-      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.6",
@@ -3495,12 +3281,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
     },
     "node_modules/expect": {
       "version": "30.3.0",
@@ -3594,7 +3374,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/faye-websocket": {
@@ -3970,16 +3749,6 @@
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "license": "ISC"
     },
-    "node_modules/immer": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
-      "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/index-to-position": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.1.0.tgz",
@@ -3998,15 +3767,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
-    },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -4757,29 +4517,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
-    "node_modules/react-redux": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
-      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/use-sync-external-store": "^0.0.6",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.2.25 || ^19",
-        "react": "^18.0 || ^19",
-        "redux": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "redux": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -4828,48 +4565,6 @@
         "react-dom": ">=18"
       }
     },
-    "node_modules/recharts": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.2.1.tgz",
-      "integrity": "sha512-0JKwHRiFZdmLq/6nmilxEZl3pqb4T+aKkOkOi/ZISRZwfBhVMgInxzlYU9D4KnCH3KINScLy68m/OvMXoYGZUw==",
-      "license": "MIT",
-      "dependencies": {
-        "@reduxjs/toolkit": "1.x.x || 2.x.x",
-        "clsx": "^2.1.1",
-        "decimal.js-light": "^2.5.1",
-        "es-toolkit": "^1.39.3",
-        "eventemitter3": "^5.0.1",
-        "immer": "^10.1.1",
-        "react-redux": "8.x.x || 9.x.x",
-        "reselect": "5.1.1",
-        "tiny-invariant": "^1.3.3",
-        "use-sync-external-store": "^1.2.2",
-        "victory-vendor": "^37.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
-    },
-    "node_modules/redux-thunk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
-      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "redux": "^5.0.0"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4888,12 +4583,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/reselect": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
-      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.45.1",
@@ -5124,6 +4813,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/size-sensor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.3.tgz",
+      "integrity": "sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A==",
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -5257,12 +4952,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT"
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -5388,15 +5077,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -5413,28 +5093,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/victory-vendor": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
-      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
-      "license": "MIT AND ISC",
-      "dependencies": {
-        "@types/d3-array": "^3.0.3",
-        "@types/d3-ease": "^3.0.0",
-        "@types/d3-interpolate": "^3.0.1",
-        "@types/d3-scale": "^4.0.2",
-        "@types/d3-shape": "^3.1.0",
-        "@types/d3-time": "^3.0.0",
-        "@types/d3-timer": "^3.0.0",
-        "d3-array": "^3.1.6",
-        "d3-ease": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.1.0",
-        "d3-time": "^3.0.0",
-        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {
@@ -5646,6 +5304,21 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/zrender": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
+      "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "axios": "^1.11.0",
     "axios-retry": "^4.5.0",
     "date-fns": "^4.1.0",
+    "echarts": "^6.0.0",
+    "echarts-for-react": "^3.0.6",
     "express": "^4.18.2",
     "firebase": "^12.12.1",
     "lucide-react": "^0.540.0",
@@ -38,7 +40,6 @@
     "react-dropzone": "^14.3.8",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.3",
-    "recharts": "^3.2.1",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
Reorganized the application form from 6 to 9 steps with proper separation of concerns:
1. Student Information
2. Residence/Location
3. Application Details
4. Father's Data
5. Mother's Data
6. Supporter
7. Guardian
8. Documentation
9. Confirmation

## Changes
- Added circular numbered progress indicators (1-9) with color progression (gray→gold→green)
- Added percentage progress bar below indicators
- Fixed authentication flow: HomePage → ApoderadoLogin → ApplicationForm (9 steps) → GuardianDashboard
- Improved ApoderadoLogin visual structure with larger logo and better spacing
- Fixed role case consistency (APODERADO) across login and registration
- Fixed cross-microfrontend redirects using microfrontendUrls
- Merged latest changes from develop branch

## Test Plan
- [ ] Login flow works correctly (ApoderadoLogin)
- [ ] New user registration redirects to application form
- [ ] All 9 steps display and validate correctly
- [ ] Progress indicators update as user navigates
- [ ] Form submission redirects to guardian dashboard
- [ ] Admin login flow works independently

🤖 Generated with Claude Code