### PR TITLE
feat: remove Iniciar sesión and Iniciar Postulación from navbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,9 @@ docker-compose.override.yml
 .stylelintcache
 .parcel-cache/
 
+# Claude Code
+CLAUDE.md
+
 # Security scanning results
 .snyk
 security-report.*

--- a/microfrontends/apps/mf-admissions/components/layout/Header.tsx
+++ b/microfrontends/apps/mf-admissions/components/layout/Header.tsx
@@ -127,22 +127,12 @@ const Header: React.FC = () => {
                 <div className="flex items-center gap-2 sm:gap-4">
                     {!isAnyUserLoggedIn && isHomePage && (
                         <div className="hidden sm:flex items-center gap-3">
-                            <a href={microfrontendUrls.guardianLogin} className="text-gris-piedra hover:text-azul-monte-tabor font-semibold transition-colors duration-200">
-                                Iniciar sesión
-                            </a>
                             <a href={microfrontendUrls.admissions}>
                                 <Button variant="primary" size="sm" className="!text-blanco-pureza">
                                     Postular
                                 </Button>
                             </a>
                         </div>
-                    )}
-                    {!isAnyUserLoggedIn && !isHomePage && (
-                        <a href={microfrontendUrls.admissions} className="hidden sm:block">
-                            <Button variant="primary" size="sm">
-                                Iniciar Postulación
-                            </Button>
-                        </a>
                     )}
                     {/* Hamburger button */}
                     <button
@@ -209,23 +199,9 @@ const Header: React.FC = () => {
                         )}
                         {!isAnyUserLoggedIn && isHomePage && (
                             <div className="pt-2 pb-1 flex flex-col gap-2">
-                                <a href={microfrontendUrls.guardianLogin} onClick={() => setIsMobileMenuOpen(false)}>
-                                    <Button variant="outline" className="w-full">
-                                        Iniciar sesión
-                                    </Button>
-                                </a>
                                 <a href={microfrontendUrls.admissions} onClick={() => setIsMobileMenuOpen(false)}>
                                     <Button variant="primary" className="w-full !text-blanco-pureza">
                                         Postular
-                                    </Button>
-                                </a>
-                            </div>
-                        )}
-                        {!isAnyUserLoggedIn && !isHomePage && (
-                            <div className="pt-2 pb-1">
-                                <a href={microfrontendUrls.admissions} onClick={() => setIsMobileMenuOpen(false)}>
-                                    <Button variant="primary" className="w-full">
-                                        Iniciar Postulación
                                     </Button>
                                 </a>
                             </div>

--- a/microfrontends/apps/mf-student/components/layout/Header.tsx
+++ b/microfrontends/apps/mf-student/components/layout/Header.tsx
@@ -125,9 +125,6 @@ const Header: React.FC = () => {
                 <div className="flex items-center gap-2 sm:gap-4">
                     {!isAnyUserLoggedIn && (
                         <div className="hidden sm:flex items-center gap-3">
-                            <a href={microfrontendUrls.guardianLogin} className="text-gris-piedra hover:text-azul-monte-tabor font-semibold transition-colors duration-200">
-                                Iniciar sesión
-                            </a>
                             <a href={microfrontendUrls.admissions}>
                                 <Button variant="primary" size="sm" className="!text-blanco-pureza">
                                     Postular
@@ -200,11 +197,6 @@ const Header: React.FC = () => {
                         )}
                         {!isAnyUserLoggedIn && (
                             <div className="pt-2 pb-1 flex flex-col gap-2">
-                                <a href={microfrontendUrls.guardianLogin} onClick={() => setIsMobileMenuOpen(false)}>
-                                    <Button variant="outline" className="w-full">
-                                        Iniciar sesión
-                                    </Button>
-                                </a>
                                 <a href={microfrontendUrls.admissions} onClick={() => setIsMobileMenuOpen(false)}>
                                     <Button variant="primary" className="w-full !text-blanco-pureza">
                                         Postular


### PR DESCRIPTION
  Se eliminaron los botones "Iniciar sesión" y "Iniciar Postulación" del navbar
  en los portales públicos (mf-admissions y mf-student).

  - mf-admissions: se quitó "Iniciar sesión" (home, desktop y mobile) y
    "Iniciar Postulación" (páginas internas, desktop y mobile), ya que el usuario
    se encuentra dentro del portal de postulación.
  - mf-student: se quitó "Iniciar sesión" (desktop y mobile), dejando únicamente
    el botón "Postular".
  - .gitignore: se agregó CLAUDE.md para excluirlo del control de versiones.