### PR TITLE
Shell: add styled navigation, role-aware nav items, and remote launcher

### DIFF
--- a/microfrontends/apps/shell/src/ShellApp.tsx
+++ b/microfrontends/apps/shell/src/ShellApp.tsx
@@ -1,98 +1,113 @@
-import React, { useEffect } from 'react';
-import { Link, Navigate, Route, Routes } from 'react-router-dom';
+import React, { useMemo } from 'react';
+import { Link, Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { resolveSession } from '../../../packages/backend-sdk/src/index';
 import { shellManifest } from './manifest';
+
+const shellStyles = {
+  page: { minHeight: '100vh', background: '#fcfbf7', color: '#1f2937', display: 'flex', flexDirection: 'column' as const },
+  banner: { padding: '12px 16px', background: '#f7f4ec', borderBottom: '1px solid #d9d2c3' },
+  nav: { display: 'flex', gap: 8, padding: 12, borderBottom: '1px solid #e5e7eb', flexWrap: 'wrap' as const, background: '#ffffff' },
+  navLink: { padding: '8px 12px', borderRadius: 8, textDecoration: 'none', color: '#1f2937', fontWeight: 500 },
+  navLinkActive: { background: '#eef2ff', color: '#3730a3' },
+  content: { flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 },
+  card: { maxWidth: 680, width: '100%', borderRadius: 12, border: '1px solid #e5e7eb', background: '#fff', padding: 20 },
+  button: { display: 'inline-block', padding: '10px 14px', borderRadius: 10, background: '#111827', color: '#fff', textDecoration: 'none', fontWeight: 600 },
+};
+
+type NavItem = { label: string; to: string; entry: string; roles?: string[] };
 
 function AccessBanner() {
   const session = resolveSession();
 
   return (
-    <div style={{ padding: '12px 16px', background: '#f7f4ec', borderBottom: '1px solid #d9d2c3' }}>
-      <strong>Sesion actual:</strong>{' '}
-      {session ? `${session.firstName} ${session.lastName} (${session.role})` : 'sin sesion detectada'}
+    <div style={shellStyles.banner}>
+      <strong>Sesión actual:</strong>{' '}
+      {session ? `${session.firstName} ${session.lastName} (${session.role})` : 'sin sesión detectada'}
     </div>
   );
 }
 
-function ExternalRedirect({ remoteName }: { remoteName: string }) {
+function RemoteLauncher({ remoteName }: { remoteName: string }) {
   const remote = shellManifest.remotes.find((item) => item.name === remoteName);
 
-  useEffect(() => {
-    if (remote?.entry) {
-      window.location.replace(remote.entry);
-    }
-  }, [remote]);
-
   if (!remote) {
-    return (
-      <section style={{ padding: 24 }}>
-        <h2>Microfrontend no encontrado</h2>
-      </section>
-    );
+    return <section style={shellStyles.card}>Microfrontend no encontrado.</section>;
   }
 
   return (
-    <section style={{ padding: 20 }}>
-      <h2 style={{ marginBottom: 12, textTransform: 'capitalize' }}>{remote.name}</h2>
-      <p style={{ marginBottom: 16, color: '#475569' }}>
-        Redirigiendo al microfrontend real en <code>{remote.entry}</code>
+    <section style={shellStyles.card}>
+      <h2 style={{ marginTop: 0, textTransform: 'capitalize' }}>{remote.name}</h2>
+      <p style={{ color: '#475569' }}>
+        La navegación entre dominios se hace fuera del shell para evitar conflictos de estilos/componentes y mantener la
+        sesión de autenticación definida por cada frontend.
       </p>
-      <a
-        href={remote.entry}
-        style={{
-          display: 'inline-block',
-          padding: '10px 14px',
-          borderRadius: 10,
-          background: '#111827',
-          color: '#fff',
-          textDecoration: 'none',
-          fontWeight: 600,
-        }}
-      >
-        Abrir ahora
+      <a href={remote.entry} style={shellStyles.button}>
+        Abrir {remote.name}
       </a>
     </section>
   );
 }
 
-function ShellNav() {
-  const navItems = shellManifest.remotes.map((remote) => ({
-    label: remote.nav?.[0]?.label ?? remote.name,
-    to: remote.routes[0]?.path ?? '/',
-  }));
+function ShellNav({ items }: { items: NavItem[] }) {
+  const location = useLocation();
 
   return (
-    <header style={{ display: 'flex', gap: 12, padding: 16, borderBottom: '1px solid #e5e7eb', flexWrap: 'wrap' }}>
-      <Link to="/">Inicio</Link>
-      {navItems.map((item) => (
-        <Link key={item.to} to={item.to}>
-          {item.label}
-        </Link>
-      ))}
+    <header style={shellStyles.nav}>
+      {items.map((item) => {
+        const active = location.pathname === item.to;
+        return (
+          <Link
+            key={item.to}
+            to={item.to}
+            style={active ? { ...shellStyles.navLink, ...shellStyles.navLinkActive } : shellStyles.navLink}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
     </header>
   );
 }
 
 export function ShellApp() {
-  const defaultRoute = shellManifest.remotes[0]?.routes[0]?.path ?? '/postulacion';
+  const session = resolveSession();
+
+  const navItems = useMemo<NavItem[]>(() => {
+    const role = session?.role;
+
+    return shellManifest.remotes
+      .flatMap((remote) => {
+        const sourceNav = remote.nav?.length
+          ? remote.nav
+          : [{ label: remote.name.charAt(0).toUpperCase() + remote.name.slice(1), to: remote.routes[0]?.path ?? '/', roles: remote.routes[0]?.roles }];
+
+        return sourceNav.map((nav) => ({
+          label: nav.label,
+          to: nav.to,
+          entry: remote.entry,
+          roles: nav.roles,
+        }));
+      })
+      .filter((item) => !item.roles?.length || (!!role && item.roles.includes(role)));
+  }, [session?.role]);
+
+  const defaultRoute = navItems[0]?.to ?? shellManifest.remotes[0]?.routes[0]?.path ?? '/postulacion';
 
   return (
-    <div style={{ minHeight: '100vh', background: '#fcfbf7', color: '#1f2937' }}>
+    <div style={shellStyles.page}>
       <AccessBanner />
-      <ShellNav />
-      <Routes>
-        <Route path="/" element={<Navigate to={defaultRoute} replace />} />
-        {shellManifest.remotes.flatMap((remote) =>
-          remote.routes.map((route) => (
-            <Route
-              key={route.path}
-              path={route.path}
-              element={<ExternalRedirect remoteName={remote.name} />}
-            />
-          ))
-        )}
-        <Route path="*" element={<Navigate to={defaultRoute} replace />} />
-      </Routes>
+      <ShellNav items={navItems} />
+      <main style={shellStyles.content}>
+        <Routes>
+          <Route path="/" element={<Navigate to={defaultRoute} replace />} />
+          {shellManifest.remotes.flatMap((remote) =>
+            remote.routes.map((route) => (
+              <Route key={route.path} path={route.path} element={<RemoteLauncher remoteName={remote.name} />} />
+            ))
+          )}
+          <Route path="*" element={<Navigate to={defaultRoute} replace />} />
+        </Routes>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Improve the shell user experience with clearer navigation, visual styling, and active state indicators. 
- Avoid immediate cross-domain redirects that can break styles and per-frontend authentication by providing an explicit launcher view. 
- Expose only routes appropriate to the current session role in the shell navigation.

### Description
- Replaced `ExternalRedirect` with `RemoteLauncher` that renders information and a link to the remote instead of calling `window.location.replace`.
- Added a `shellStyles` object and refactored layout to include a banner, navigation bar, content area, card and button styles for consistent look-and-feel.
- Introduced a `NavItem` type and compute `navItems` via `useMemo`, including role-based filtering using `resolveSession()` and incorporating `entry` URLs.
- Updated `ShellNav` to accept `items` and use `useLocation` to apply active link styling, and updated `Routes` to render `RemoteLauncher` for each remote route.

### Testing
- Ran TypeScript type-check with `tsc --noEmit`, which completed successfully.
- Ran unit tests via `yarn test`, which passed.
- Built the application with `yarn build` to verify bundling, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd5322b8d483278d4b8033d6b88024)