### PR TITLE
feat: professor evaluation dashboard improvements

### DIFF
--- a/.gstack/browse-audit.jsonl
+++ b/.gstack/browse-audit.jsonl
@@ -19,3 +19,9 @@
 {"ts":"2026-04-29T19:10:33.855Z","cmd":"screenshot","args":"/tmp/login-logo-mejorado.png","origin":"http://localhost:5206/#/login","durationMs":38,"status":"ok","hasCookies":false,"mode":"launched"}
 {"ts":"2026-04-29T19:29:29.609Z","cmd":"goto","args":"http://localhost:5206/#/login","origin":"http://localhost:5206/#/login","durationMs":2,"status":"ok","hasCookies":false,"mode":"launched"}
 {"ts":"2026-04-29T19:29:31.711Z","cmd":"screenshot","args":"/tmp/login-spacing.png","origin":"http://localhost:5206/#/login","durationMs":40,"status":"ok","hasCookies":false,"mode":"launched"}
+{"ts":"2026-05-10T04:22:15.820Z","cmd":"goto","args":"http://localhost:5206","origin":"http://localhost:5206/","durationMs":568,"status":"ok","hasCookies":false,"mode":"launched"}
+{"ts":"2026-05-10T04:22:17.886Z","cmd":"snapshot","args":"-i","origin":"http://localhost:5201/#/","durationMs":20,"status":"ok","hasCookies":false,"mode":"launched"}
+{"ts":"2026-05-10T04:22:31.357Z","cmd":"goto","args":"http://localhost:5206","origin":"http://localhost:5206/","durationMs":145,"status":"ok","hasCookies":false,"mode":"launched"}
+{"ts":"2026-05-10T04:22:33.409Z","cmd":"snapshot","args":"-i","origin":"http://localhost:5201/#/","durationMs":9,"status":"ok","hasCookies":false,"mode":"launched"}
+{"ts":"2026-05-10T04:22:43.373Z","cmd":"goto","args":"http://localhost:5206/#/login","origin":"http://localhost:5206/#/login","durationMs":141,"status":"ok","hasCookies":false,"mode":"launched"}
+{"ts":"2026-05-10T04:22:45.494Z","cmd":"snapshot","args":"-i -a -o /tmp/admin-login.png","origin":"http://localhost:5206/#/login","durationMs":73,"status":"ok","hasCookies":false,"mode":"launched"}

--- a/microfrontends/apps/mf-evaluations/components/evaluations/AdmissionReportForm.tsx
+++ b/microfrontends/apps/mf-evaluations/components/evaluations/AdmissionReportForm.tsx
@@ -103,8 +103,8 @@ const AdmissionReportForm: React.FC = () => {
                         age: age,
                         currentSchool: evaluationData.currentSchool || '',
 
-                        // Datos del evaluador
-                        evaluatorName: evaluationData.evaluatorName || (currentProfessor ? `${currentProfessor.firstName} ${currentProfessor.lastName}` : ''),
+                        // Datos del evaluador - usar profesor actual (quien completa el informe)
+                        evaluatorName: currentProfessor ? `${currentProfessor.firstName} ${currentProfessor.lastName}` : (evaluationData.evaluatorName || ''),
 
                         // Datos académicos - usar subject del profesor si está disponible
                         subject: evaluationData.evaluatorSubject ?

--- a/microfrontends/apps/mf-evaluations/components/evaluations/AdmissionReportForm.tsx
+++ b/microfrontends/apps/mf-evaluations/components/evaluations/AdmissionReportForm.tsx
@@ -7,6 +7,7 @@ import { ArrowLeftIcon, SaveIcon, FileTextIcon, PrinterIcon } from '../icons/Ico
 import { useNotifications } from '../../context/AppContext';
 import { professorEvaluationService, ProfessorEvaluation } from '../../services/professorEvaluationService';
 import { EvaluationType } from '../../types/evaluation';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
 
 interface AdmissionReportData {
     studentName: string;
@@ -67,9 +68,10 @@ const AdmissionReportForm: React.FC = () => {
         entranceGrade: ''
     });
 
-    // Obtener profesor actual del localStorage
+    // Obtener profesor actual del localStorage (con namespace correcto)
     const [currentProfessor] = useState(() => {
-        const storedProfessor = localStorage.getItem('currentProfessor');
+        const key = getStorageKey(BASE_STORAGE_KEYS.CURRENT_PROFESSOR);
+        const storedProfessor = localStorage.getItem(key) || localStorage.getItem('currentProfessor');
         return storedProfessor ? JSON.parse(storedProfessor) : null;
     });
 

--- a/microfrontends/apps/mf-evaluations/components/evaluations/AdmissionReportForm.tsx
+++ b/microfrontends/apps/mf-evaluations/components/evaluations/AdmissionReportForm.tsx
@@ -7,7 +7,7 @@ import { ArrowLeftIcon, SaveIcon, FileTextIcon, PrinterIcon } from '../icons/Ico
 import { useNotifications } from '../../context/AppContext';
 import { professorEvaluationService, ProfessorEvaluation } from '../../services/professorEvaluationService';
 import { EvaluationType } from '../../types/evaluation';
-import { getStorageKey, BASE_STORAGE_KEYS } from '../../../packages/backend-sdk/src/index';
+import { getStorageKey, BASE_STORAGE_KEYS } from '../../../../packages/backend-sdk/src/index';
 
 interface AdmissionReportData {
     studentName: string;

--- a/microfrontends/packages/shared-ui/src/services/professorEvaluationService.ts
+++ b/microfrontends/packages/shared-ui/src/services/professorEvaluationService.ts
@@ -67,8 +67,33 @@ class ProfessorEvaluationService {
             // Handle response wrapper: {success, data}
             const evaluations = response.data?.data || response.data;
 
+            // Mapear evaluaciones
+            let mappedEvaluations = this.mapToProfessorEvaluations(evaluations);
 
-            const mappedEvaluations = this.mapToProfessorEvaluations(evaluations);
+            // Enriquecer evaluaciones con datos faltantes en paralelo
+            mappedEvaluations = await Promise.all(
+                mappedEvaluations.map(async (evaluation) => {
+                    if (evaluation.applicationId && (!evaluation.studentName || !evaluation.studentBirthDate)) {
+                        try {
+                            const appResponse = await api.get(`/v1/applications/${evaluation.applicationId}`);
+                            const application = appResponse.data?.data || appResponse.data;
+
+                            if (application?.student) {
+                                const originalEval = evaluations.find((e: any) =>
+                                    (e.id || e.evaluationId) === evaluation.id
+                                );
+                                return this.mapToProfessorEvaluation({
+                                    ...originalEval,
+                                    application: application
+                                });
+                            }
+                        } catch (appError: any) {
+                            // Log silenciosamente y continuar con datos parciales
+                        }
+                    }
+                    return evaluation;
+                })
+            );
 
             return mappedEvaluations;
 
@@ -96,7 +121,35 @@ class ProfessorEvaluationService {
             // Handle response wrapper: {success, data}
             const evaluations = response.data?.data || response.data;
 
-            return this.mapToProfessorEvaluations(evaluations);
+            // Mapear evaluaciones
+            let mappedEvaluations = this.mapToProfessorEvaluations(evaluations);
+
+            // Enriquecer evaluaciones con datos faltantes en paralelo
+            mappedEvaluations = await Promise.all(
+                mappedEvaluations.map(async (evaluation) => {
+                    if (evaluation.applicationId && (!evaluation.studentName || !evaluation.studentBirthDate)) {
+                        try {
+                            const appResponse = await api.get(`/v1/applications/${evaluation.applicationId}`);
+                            const application = appResponse.data?.data || appResponse.data;
+
+                            if (application?.student) {
+                                const originalEval = evaluations.find((e: any) =>
+                                    (e.id || e.evaluationId) === evaluation.id
+                                );
+                                return this.mapToProfessorEvaluation({
+                                    ...originalEval,
+                                    application: application
+                                });
+                            }
+                        } catch (appError: any) {
+                            // Log silenciosamente y continuar con datos parciales
+                        }
+                    }
+                    return evaluation;
+                })
+            );
+
+            return mappedEvaluations;
 
         } catch (error: any) {
 
@@ -181,7 +234,28 @@ class ProfessorEvaluationService {
             // Handle response wrapper: {success, data}
             const evaluation = response.data?.data || response.data;
 
-            return this.mapToProfessorEvaluation(evaluation);
+            let enrichedEvaluation = this.mapToProfessorEvaluation(evaluation);
+
+            // Enriquecer con datos de la aplicación si faltan datos del estudiante
+            if (enrichedEvaluation.applicationId && (!enrichedEvaluation.studentName || !enrichedEvaluation.studentBirthDate)) {
+                try {
+                    const applicationResponse = await api.get(`/v1/applications/${enrichedEvaluation.applicationId}`);
+                    const application = applicationResponse.data?.data || applicationResponse.data;
+
+                    if (application?.student) {
+                        // Re-mapear con datos enriquecidos
+                        enrichedEvaluation = this.mapToProfessorEvaluation({
+                            ...evaluation,
+                            application: application
+                        });
+                    }
+                } catch (appError: any) {
+                    console.warn(`Could not enrich evaluation with application data:`, appError);
+                    // Continuar con los datos que tenemos
+                }
+            }
+
+            return enrichedEvaluation;
 
         } catch (error: any) {
 


### PR DESCRIPTION
## Summary

Professor Evaluation Dashboard enhancements:
- Data enrichment for missing student information
- Correct evaluator name display  
- Storage key fixes

## Changes

### professorEvaluationService.ts
- `getEvaluationById()`: Auto-enrich with application data
- `getMyEvaluations()`: Parallel enrichment
- `getMyPendingEvaluations()`: Parallel enrichment

### AdmissionReportForm.tsx
- Use current professor as evaluator
- Fix storage key retrieval with namespace
- Correct import paths

## Impact

- Eliminates "No disponible" placeholders
- Shows correct professor name as evaluator
- Graceful error handling

## Test

- Login as professor
- View pending evaluations
- Open admission report form
- Verify student data is populated
- Check evaluator name displays correctly

🤖 Generated with Claude Code