### PR TITLE
feat: hide sidebar sections from teacher role

### DIFF
--- a/microfrontends/apps/mf-evaluations/pages/ProfessorDashboard.tsx
+++ b/microfrontends/apps/mf-evaluations/pages/ProfessorDashboard.tsx
@@ -62,6 +62,7 @@ const ProfessorDashboard: React.FC = () => {
         return parsed;
     });
 
+
     // Determinar sección inicial según el rol
     const getInitialSection = () => {
         if (currentProfessor?.role === 'CYCLE_DIRECTOR' || currentProfessor?.role === 'PSYCHOLOGIST') {
@@ -254,10 +255,20 @@ const ProfessorDashboard: React.FC = () => {
         window.location.href = microfrontendUrls.home;
     };
 
+    // Filtrar secciones según el rol - TEACHER no ve "Mis Entrevistas" ni "Mis Horarios"
+    const filteredSections = baseSections.filter(section => {
+        if (currentProfessor?.role === 'TEACHER') {
+            if (section.key === 'entrevistas' || section.key === 'horarios') {
+                return false;
+            }
+        }
+        return true;
+    });
+
     // Determinar si mostrar sección de administrador
-    const sections = currentProfessor?.isAdmin 
-        ? [...baseSections, { key: 'admin', label: 'Panel Administrador', icon: UsersIcon }]
-        : baseSections;
+    const sections = currentProfessor?.isAdmin
+        ? [...filteredSections, { key: 'admin', label: 'Panel Administrador', icon: UsersIcon }]
+        : filteredSections;
 
     const getSubjectName = (subjectId: string) => {
         const names: { [key: string]: string } = {


### PR DESCRIPTION
## Summary

Hide 'Mis Entrevistas' and 'Mis Horarios' sections from TEACHER role in the professor dashboard sidebar.

## Changes

- Filter sidebar sections based on professor role
- TEACHER role no longer sees 'Mis Entrevistas' and 'Mis Horarios'
- Other roles (CYCLE_DIRECTOR, PSYCHOLOGIST, etc.) retain access to these sections
- Admin panel section functionality maintained

## Test Plan

- [ ] Login as TEACHER role
- [ ] Verify 'Mis Entrevistas' is NOT visible in sidebar
- [ ] Verify 'Mis Horarios' is NOT visible in sidebar
- [ ] Verify other sections are visible (Dashboard, Estudiantes, Reportes, etc.)
- [ ] Login as CYCLE_DIRECTOR and verify both sections ARE visible
- [ ] Test that admin section still appears for admin users

🤖 Generated with Claude Code