### PR TITLE
fix: usar endpoint correcto en getAllApplications para Tablas de datos

### DIFF
--- a/microfrontends/packages/shared-ui/src/services/applicationService.ts
+++ b/microfrontends/packages/shared-ui/src/services/applicationService.ts
@@ -171,43 +171,28 @@ class ApplicationService {
     // Método mejorado para administradores: obtener todas las postulaciones desde microservicio
     async getAllApplications(): Promise<Application[]> {
         try {
+            // Usar el endpoint principal con parámetros page y size (el que funciona correctamente)
+            // Este es el mismo endpoint que usa "Gestión de evaluaciones"
+            const response = await api.get('/v1/applications?page=0&size=2000');
 
-            // Primero intentar el endpoint principal que devuelve la estructura completa
-            try {
-                // BFF espera parámetro 'size' (no 'limit') para el tamaño de página
-                const response = await api.get('/v1/applications?size=1000');
+            // El backend devuelve {success: true, data: [...], count: X}
+            const applications = response.data?.data || response.data || [];
 
-                // El backend devuelve {success: true, data: [...]}
-                const applications = response.data?.data || response.data || [];
+            // El endpoint /v1/applications ya devuelve la estructura correcta
+            // Filtrar las aplicaciones válidas
+            const validApplications = applications.filter((app: any) =>
+                app &&
+                app.id &&
+                app.student &&
+                app.student.firstName &&
+                app.student.lastName &&
+                app.student.firstName !== null &&
+                app.student.lastName !== null
+            );
 
-                // El endpoint /v1/applications ya devuelve la estructura correcta
-                // No necesitamos adaptador, solo filtrar las aplicaciones válidas
-                const validApplications = applications.filter((app: any) =>
-                    app &&
-                    app.id &&
-                    app.student &&
-                    app.student.firstName &&
-                    app.student.lastName &&
-                    app.student.firstName !== null &&
-                    app.student.lastName !== null
-                );
-
-                if (validApplications.length > 0) {
-                }
-                return validApplications;
-
-            } catch (mainError) {
-
-                // Como fallback, usar el endpoint público con adaptador si es necesario
-                const response = await api.get('/v1/applications/public/all');
-
-                // Este endpoint devuelve formato diferente, usar adaptador
-                const adaptedApplications = DataAdapter.adaptApplicationApiResponse(response);
-                return adaptedApplications;
-            }
+            return validApplications;
 
         } catch (error: any) {
-
             // Como fallback, devolver un array vacío
             return [];
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -344,6 +344,14 @@
       "name": "@mtn-mf/contracts",
       "version": "0.0.1"
     },
+    "microfrontends/packages/shared-ui": {
+      "name": "@mtn-mf/shared-ui",
+      "version": "0.0.1"
+    },
+    "microfrontends/packages/shared-utils": {
+      "name": "@mtn-mf/shared-utils",
+      "version": "0.0.1"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
@@ -1897,6 +1905,14 @@
     },
     "node_modules/@mtn-mf/mf-student": {
       "resolved": "microfrontends/apps/mf-student",
+      "link": true
+    },
+    "node_modules/@mtn-mf/shared-ui": {
+      "resolved": "microfrontends/packages/shared-ui",
+      "link": true
+    },
+    "node_modules/@mtn-mf/shared-utils": {
+      "resolved": "microfrontends/packages/shared-utils",
       "link": true
     },
     "node_modules/@mtn-mf/shell": {


### PR DESCRIPTION
## Resumen

Corrige el problema donde 'Tablas de datos' no mostraba información porque estaba usando el endpoint incorrecto.

## Cambios

- Cambiar endpoint en `applicationService.getAllApplications()` de `/v1/applications?size=1000` a `/v1/applications?page=0&size=2000`
- Este es el mismo endpoint que funciona correctamente en 'Gestión de evaluaciones'
- Eliminar fallbacks innecesarios a `/v1/applications/public/all` que devolvía un array vacío

## Validación

✅ Endpoint `/api/applications?page=0&size=2000` devuelve 9 aplicaciones con datos completos
✅ Estructura de datos incluye: student, father, mother, guardian, documents
✅ Cambio será traducido por NGINX en staging/develop: `/v1/` → `/api/`

## Antes
- Endpoint: `/v1/applications?size=1000` → devolvía vacío
- Fallback: `/v1/applications/public/all` → devolvía vacío  

## Después
- Endpoint: `/v1/applications?page=0&size=2000` → devuelve datos correctamente
- Sin fallbacks innecesarios

---
🤖 Generado con Claude Code