### PR TITLE
fix: change school selector to gender and remove parent profession fields

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,15 @@
+# ============================================
+# Admitia Frontend - Development Environment
+# ============================================
 
+# NGINX Gateway (staging on Railway)
+VITE_API_BASE_URL=https://admitia-nginx-staging.up.railway.app
+
+# Firebase Authentication
+VITE_FIREBASE_API_KEY=AIzaSyDA51UgWgiQcVQaYix3talbmuO1cHjFkK0
+VITE_FIREBASE_AUTH_DOMAIN=admitia-55514.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=admitia-55514
+VITE_FIREBASE_STORAGE_BUCKET=admitia-55514.firebasestorage.app
+VITE_FIREBASE_MESSAGING_SENDER_ID=812821234932
+VITE_FIREBASE_APP_ID=1:812821234932:web:d764d0507bffa6692c4aa1
+VITE_FIREBASE_MEASUREMENT_ID=G-NQ2JG2DTSM

--- a/.gstack/browse-audit.jsonl
+++ b/.gstack/browse-audit.jsonl
@@ -25,3 +25,11 @@
 {"ts":"2026-05-10T04:22:33.409Z","cmd":"snapshot","args":"-i","origin":"http://localhost:5201/#/","durationMs":9,"status":"ok","hasCookies":false,"mode":"launched"}
 {"ts":"2026-05-10T04:22:43.373Z","cmd":"goto","args":"http://localhost:5206/#/login","origin":"http://localhost:5206/#/login","durationMs":141,"status":"ok","hasCookies":false,"mode":"launched"}
 {"ts":"2026-05-10T04:22:45.494Z","cmd":"snapshot","args":"-i -a -o /tmp/admin-login.png","origin":"http://localhost:5206/#/login","durationMs":73,"status":"ok","hasCookies":false,"mode":"launched"}
+{"ts":"2026-05-22T13:41:45.866Z","cmd":"goto","args":"http://localhost:5204","origin":"http://localhost:5204/","durationMs":28,"status":"ok","hasCookies":false,"mode":"launched"}
+{"ts":"2026-05-22T13:41:45.931Z","cmd":"snapshot","args":"-i -a -o /tmp/mf-eval-home.png","origin":"http://localhost:5204/","durationMs":25,"status":"ok","hasCookies":false,"mode":"launched"}
+{"ts":"2026-05-22T13:44:30.273Z","cmd":"goto","args":"http://localhost:5204/#/profesor/login","origin":"http://localhost:5204/#/profesor/login","durationMs":4,"status":"ok","hasCookies":false,"mode":"launched"}
+{"ts":"2026-05-22T13:44:30.309Z","cmd":"snapshot","args":"-i","origin":"http://localhost:5204/#/profesor/login","durationMs":3,"status":"ok","hasCookies":false,"mode":"launched"}
+{"ts":"2026-05-22T13:44:37.982Z","cmd":"console","args":"","origin":"http://localhost:5204/#/profesor/login","durationMs":1,"status":"ok","hasCookies":false,"mode":"launched"}
+{"ts":"2026-05-22T13:44:45.013Z","cmd":"network","args":"","origin":"http://localhost:5204/#/profesor/login","durationMs":0,"status":"ok","hasCookies":false,"mode":"launched"}
+{"ts":"2026-05-22T13:45:21.749Z","cmd":"goto","args":"http://127.0.0.1:5204/#/profesor/login","origin":"http://127.0.0.1:5204/#/profesor/login","durationMs":580,"status":"ok","hasCookies":false,"mode":"launched"}
+{"ts":"2026-05-22T13:45:21.924Z","cmd":"snapshot","args":"-i -a -o /tmp/profesor-login.png","origin":"http://127.0.0.1:5204/#/profesor/login","durationMs":98,"status":"ok","hasCookies":false,"mode":"launched"}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
 
 ## Quick Navigation
 
@@ -294,7 +294,7 @@ When refactoring or cleaning up pages:
    - Open DevTools, inspect the URL hash-based routing
    - Check `localStorage` to see auth tokens and user data
    - Look at one service file (e.g., `services/api.ts`) to understand API patterns
-   - Read this CLAUDE.md section: "Architecture Overview" and "API Communication"
+   - Read this AGENTS.md section: "Architecture Overview" and "API Communication"
 
 3. **Make a Change:**
    - Find where to edit (e.g., component in `pages/` or `components/`)

--- a/microfrontends/apps/mf-admin/components/admin/StudentDetailModal.tsx
+++ b/microfrontends/apps/mf-admin/components/admin/StudentDetailModal.tsx
@@ -39,7 +39,7 @@ interface Postulante {
     direccion: string;
     cursoPostulado: string;
     colegioActual?: string;
-    colegioDestino: 'MONTE_TABOR' | 'NAZARET' | null;
+    colegioDestino: 'MALE' | 'FEMALE' | null;
     añoAcademico: string;
     estadoPostulacion: string;
     fechaPostulacion: string;
@@ -82,6 +82,7 @@ interface StudentDetailModalProps {
     onUpdateStatus?: (postulante: Postulante, newStatus: string) => void;
     onScheduleInterview?: (postulante: Postulante, interviewType?: string) => void;
     onAssignEvaluator?: (applicationId: number, evaluationType: string, evaluatorId: number) => Promise<void>;
+    onRefresh?: () => void;
 }
 
 const StudentDetailModal: React.FC<StudentDetailModalProps> = ({
@@ -91,7 +92,8 @@ const StudentDetailModal: React.FC<StudentDetailModalProps> = ({
     onEdit,
     onUpdateStatus,
     onScheduleInterview,
-    onAssignEvaluator
+    onAssignEvaluator,
+    onRefresh
 }) => {
     const [activeTab, setActiveTab] = useState<'info' | 'familia' | 'academico' | 'entrevistas' | 'evaluaciones' | 'documentos' | 'historial'>('info');
     const [documentSubTab, setDocumentSubTab] = useState<'academic' | 'other'>('academic');
@@ -137,6 +139,11 @@ const StudentDetailModal: React.FC<StudentDetailModalProps> = ({
         try {
             const app = await applicationService.getApplicationById(postulante.id);
             setFullApplication(app);
+
+            // Actualizar selectedSchool con valor fresco del backend
+            if (app?.student?.gender) {
+                setSelectedSchool(app.student.gender);
+            }
 
             // Initialize document approval status from database
             if (app?.documents) {
@@ -422,20 +429,23 @@ const StudentDetailModal: React.FC<StudentDetailModalProps> = ({
         setSavingSchool(true);
         try {
             await applicationService.updateApplication(postulante.id, {
-                student: { targetSchool: school }
+                student: { gender: school }
             });
             setSelectedSchool(school);
             setIsEditingSchool(false);
             addNotification({
                 type: 'success',
-                title: 'Colegio asignado',
-                message: `Colegio destino actualizado correctamente`
+                title: 'Género asignado',
+                message: `Género destino actualizado correctamente`
             });
+            // Refrescar datos del modal y lista de postulantes
+            loadFullApplication();
+            if (onRefresh) onRefresh();
         } catch (error) {
             addNotification({
                 type: 'error',
                 title: 'Error',
-                message: 'No se pudo guardar el colegio destino'
+                message: 'No se pudo guardar el género destino'
             });
         } finally {
             setSavingSchool(false);
@@ -894,10 +904,10 @@ const StudentDetailModal: React.FC<StudentDetailModalProps> = ({
                             <Badge variant="blue" size="sm">{postulante.cursoPostulado}</Badge>
                         </div>
                         <div className="flex justify-between">
-                            <span className="text-gray-600">Colegio Destino:</span>
+                            <span className="text-gray-600">Género:</span>
                             {selectedSchool ? (
                                 <Badge variant="green" size="sm">
-                                    {selectedSchool === 'MONTE_TABOR' ? 'Monte Tabor' : 'Nazaret'}
+                                    {selectedSchool === 'MALE' ? 'Masculino' : selectedSchool === 'FEMALE' ? 'Femenino' : 'Pendiente'}
                                 </Badge>
                             ) : (
                                 <Badge variant="warning" size="sm">Pendiente</Badge>
@@ -1066,10 +1076,6 @@ const StudentDetailModal: React.FC<StudentDetailModalProps> = ({
                         </h4>
                         <div className="space-y-2 text-sm">
                             <div className="flex items-center gap-2">
-                                <FiBriefcase className="w-4 h-4 text-gray-400" />
-                                <span>Profesión: {fatherData.profession || postulante.profesionPadre || 'No especificada'}</span>
-                            </div>
-                            <div className="flex items-center gap-2">
                                 <FiPhone className="w-4 h-4 text-gray-400" />
                                 <span>Teléfono: {fatherData.phone || postulante.telefonoPadre || 'No especificado'}</span>
                             </div>
@@ -1098,10 +1104,6 @@ const StudentDetailModal: React.FC<StudentDetailModalProps> = ({
                             {motherData.fullName || postulante.nombreMadre || 'No especificado'}
                         </h4>
                         <div className="space-y-2 text-sm">
-                            <div className="flex items-center gap-2">
-                                <FiBriefcase className="w-4 h-4 text-gray-400" />
-                                <span>Profesión: {motherData.profession || postulante.profesionMadre || 'No especificada'}</span>
-                            </div>
                             <div className="flex items-center gap-2">
                                 <FiPhone className="w-4 h-4 text-gray-400" />
                                 <span>Teléfono: {motherData.phone || postulante.telefonoMadre || 'No especificado'}</span>
@@ -1461,12 +1463,12 @@ const StudentDetailModal: React.FC<StudentDetailModalProps> = ({
                 {/* Selector de colegio destino */}
                 <div className="border border-gray-200 rounded-lg p-4">
                     <div className="flex items-center justify-between mb-3">
-                        <span className="font-medium text-gray-900">Colegio destino del estudiante</span>
+                        <span className="font-medium text-gray-900">Género del estudiante</span>
                         {selectedSchool && !isEditingSchool && (
                             <button
                                 onClick={() => setIsEditingSchool(true)}
                                 className="text-gray-400 hover:text-gray-600 transition-colors"
-                                title="Editar colegio destino"
+                                title="Editar género del estudiante"
                             >
                                 <FiEdit className="w-4 h-4" />
                             </button>
@@ -1474,7 +1476,7 @@ const StudentDetailModal: React.FC<StudentDetailModalProps> = ({
                     </div>
                     {selectedSchool && !isEditingSchool ? (
                         <div className="bg-gray-100 text-gray-500 px-3 py-2 rounded-md text-sm font-medium">
-                            {selectedSchool === 'MONTE_TABOR' ? 'Monte Tabor' : 'Nazaret'}
+                            {selectedSchool === 'MALE' ? 'Masculino' : selectedSchool === 'FEMALE' ? 'Femenino' : 'Pendiente'}
                         </div>
                     ) : (
                         <select
@@ -1483,9 +1485,9 @@ const StudentDetailModal: React.FC<StudentDetailModalProps> = ({
                             onChange={(e) => { if (e.target.value) handleSaveSchool(e.target.value); }}
                             disabled={savingSchool}
                         >
-                            <option value="">Seleccione el colegio al que postula...</option>
-                            <option value="MONTE_TABOR">Monte Tabor</option>
-                            <option value="NAZARET">Nazaret</option>
+                            <option value="">Seleccione el género...</option>
+                            <option value="MALE">Masculino</option>
+                            <option value="FEMALE">Femenino</option>
                         </select>
                     )}
                 </div>

--- a/microfrontends/apps/mf-admin/pages/AdminDashboard.tsx
+++ b/microfrontends/apps/mf-admin/pages/AdminDashboard.tsx
@@ -294,7 +294,7 @@ const AdminDashboard: React.FC = () => {
       // Datos académicos
       cursoPostulado: app.student.gradeApplied,
       colegioActual: app.student.currentSchool,
-      colegioDestino: app.student.targetSchool || null,
+      colegioDestino: app.student.gender || null,
       añoAcademico: '2025',
       
       // Estado de postulación
@@ -312,13 +312,11 @@ const AdminDashboard: React.FC = () => {
       nombrePadre: app.father?.fullName,
       emailPadre: app.father?.email,
       telefonoPadre: app.father?.phone,
-      profesionPadre: app.father?.profession,
-      
+
       nombreMadre: app.mother?.fullName,
       emailMadre: app.mother?.email,
       telefonoMadre: app.mother?.phone,
-      profesionMadre: app.mother?.profession,
-      
+
       // Información académica y evaluaciones
       documentosCompletos: app.documents ? app.documents.length > 0 : false,
       cantidadDocumentos: app.documents ? app.documents.length : 0,
@@ -871,6 +869,7 @@ Esta acción:
         isOpen={isDetailModalOpen}
         onClose={handleCloseDetailModal}
         postulante={selectedPostulante}
+        onRefresh={loadApplications}
         onEdit={(postulante) => {
           handleCloseDetailModal();
           // TODO: Implementar edición si se necesita

--- a/microfrontends/apps/mf-admin/services/applicationService.ts
+++ b/microfrontends/apps/mf-admin/services/applicationService.ts
@@ -12,7 +12,7 @@ export interface ApplicationRequest {
     studentEmail?: string;
     studentAddress: string;
     grade: string;
-    schoolApplied: string; // "MONTE_TABOR" para niños, "NAZARET" para niñas
+    schoolApplied: string; // "MALE" para niños, "FEMALE" para niñas
     currentSchool?: string;
     additionalNotes?: string;
 
@@ -78,7 +78,7 @@ export interface Application {
         currentSchool?: string;
         additionalNotes?: string;
         // Campos de categorías especiales
-        targetSchool?: string;
+        gender?: string;
         isEmployeeChild?: boolean;
         employeeParentName?: string;
         isAlumniChild?: boolean;
@@ -484,6 +484,7 @@ class ApplicationService {
                 studentEmail: data.studentEmail || '',
                 studentAddress: data.studentAddress || '',
                 studentCurrentSchool: data.currentSchool || '',
+                studentGender: data.schoolApplied === 'MALE' ? 'MALE' : data.schoolApplied === 'FEMALE' ? 'FEMALE' : '',
                 studentAdmissionPreference: data.admissionPreference || 'NINGUNA',
                 studentPais: 'Chile',
                 studentRegion: '',
@@ -582,6 +583,12 @@ class ApplicationService {
             // Convertir gradeApplied al formato esperado por el backend
             if (applicationData.student?.gradeApplied) {
                 applicationData.student.gradeApplied = this.transformGradeToBackend(applicationData.student.gradeApplied);
+            }
+
+            // Convertir gender a studentGender para el backend
+            if (applicationData.student?.gender !== undefined) {
+                applicationData.studentGender = applicationData.student.gender === 'MALE' ? 'MALE' : applicationData.student.gender === 'FEMALE' ? 'FEMALE' : '';
+                delete applicationData.student.gender;
             }
 
             const response = await api.put(`/v1/applications/${applicationId}`, applicationData);

--- a/microfrontends/apps/mf-admin/services/dataService.ts
+++ b/microfrontends/apps/mf-admin/services/dataService.ts
@@ -47,7 +47,7 @@ export interface EmailNotificationData {
     subject: string;
     studentName: string;
     studentGender: 'MALE' | 'FEMALE';
-    targetSchool: 'MONTE_TABOR' | 'NAZARET';
+    gender: 'MALE' | 'FEMALE';
     sentAt: string;
     opened: boolean;
     openedAt?: string;
@@ -84,7 +84,7 @@ export interface PostulanteData {
     direccion: string;
     cursoPostulado: string;
     colegioActual?: string;
-    colegioDestino: 'MONTE_TABOR' | 'NAZARET';
+    colegioDestino: 'MALE' | 'FEMALE' | null;
     añoAcademico: string;
     estadoPostulacion: string;
     fechaPostulacion: string;
@@ -215,7 +215,7 @@ class DataService {
                 subject: 'Entrevista programada para Ana María',
                 studentName: 'Ana María Pérez',
                 studentGender: 'FEMALE',
-                targetSchool: 'MONTE_TABOR',
+                gender: 'MALE',
                 sentAt: '2025-08-20T10:00:00',
                 opened: true,
                 openedAt: '2025-08-20T10:05:00',
@@ -280,7 +280,7 @@ class DataService {
             direccion: student.address || 'Sin dirección',
             cursoPostulado: student.gradeApplied || 'No especificado',
             colegioActual: student.currentSchool || undefined,
-            colegioDestino: student.targetSchool || 'MONTE_TABOR',
+            colegioDestino: student.gender || null,
             añoAcademico: '2025',
             estadoPostulacion: app.status || 'PENDING',
             fechaPostulacion: app.submissionDate || app.createdAt || '',

--- a/microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx
+++ b/microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx
@@ -37,10 +37,29 @@ const gradeOptions = educationalLevels.map(level => ({
 }));
 
 const schoolOptions = [
-    { value: '', label: 'Seleccione un colegio...' },
-    { value: 'MONTE_TABOR', label: 'Monte Tabor' },
-    { value: 'NAZARET', label: 'Nazaret' }
+    { value: '', label: 'Seleccione un género...' },
+    { value: 'MALE', label: 'Masculino' },
+    { value: 'FEMALE', label: 'Femenino' }
 ];
+
+const documentTypes = [
+    { key: 'BIRTH_CERTIFICATE', label: 'Certificado de Nacimiento', required: true },
+    { key: 'GRADES_2023', label: 'Certificado de Estudios 2023 (si aplica)', required: true },
+    { key: 'GRADES_2024', label: 'Certificado de Estudios 2024', required: true },
+    { key: 'GRADES_2025_SEMESTER_1', label: 'Certificado de Estudios primer semestre 2025', required: true },
+    { key: 'PERSONALITY_REPORT_2024', label: 'Informe de Personalidad 2024', required: false },
+    { key: 'PERSONALITY_REPORT_2025_SEMESTER_1', label: 'Informe de Personalidad primer semestre 2025', required: false },
+    { key: 'STUDENT_PHOTO', label: 'Fotografía del Postulante', required: false },
+    { key: 'BAPTISM_CERTIFICATE', label: 'Certificado de Bautismo', required: false },
+    { key: 'PREVIOUS_SCHOOL_REPORT', label: 'Informe de Jardín/Colegio Anterior', required: false },
+    { key: 'MEDICAL_CERTIFICATE', label: 'Certificado Médico', required: false },
+    { key: 'PSYCHOLOGICAL_REPORT', label: 'Informe Psicológico (si aplica)', required: false }
+];
+
+const getDocumentLabel = (documentType: string): string => {
+    const doc = documentTypes.find(d => d.key === documentType);
+    return doc ? doc.label : documentType;
+};
 
 
 const validationConfig = {
@@ -2124,26 +2143,6 @@ const ApplicationForm: React.FC = () => {
 
             // Step 7: Documentación
             case 7:
-                const documentTypes = [
-                    { key: 'BIRTH_CERTIFICATE', label: 'Certificado de Nacimiento', required: true },
-                    { key: 'GRADES_2023', label: 'Certificado de Estudios 2023 (si aplica)', required: true },
-                    { key: 'GRADES_2024', label: 'Certificado de Estudios 2024', required: true },
-                    { key: 'GRADES_2025_SEMESTER_1', label: 'Certificado de Estudios primer semestre 2025', required: true },
-                    { key: 'PERSONALITY_REPORT_2024', label: 'Informe de Personalidad 2024', required: false },
-                    { key: 'PERSONALITY_REPORT_2025_SEMESTER_1', label: 'Informe de Personalidad primer semestre 2025', required: false },
-                    { key: 'STUDENT_PHOTO', label: 'Fotografía del Postulante', required: false },
-                    { key: 'BAPTISM_CERTIFICATE', label: 'Certificado de Bautismo', required: false },
-                    { key: 'PREVIOUS_SCHOOL_REPORT', label: 'Informe de Jardín/Colegio Anterior', required: false },
-                    { key: 'MEDICAL_CERTIFICATE', label: 'Certificado Médico', required: false },
-                    { key: 'PSYCHOLOGICAL_REPORT', label: 'Informe Psicológico (si aplica)', required: false }
-                ];
-
-                // Función para traducir tipos de documentos a español
-                const getDocumentLabel = (documentType: string): string => {
-                    const doc = documentTypes.find(d => d.key === documentType);
-                    return doc ? doc.label : documentType;
-                };
-
                 return (
                     <div>
                         <h3 className="text-xl font-bold text-azul-monte-tabor mb-4">Carga de Documentos</h3>

--- a/microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx
+++ b/microfrontends/apps/mf-admissions/pages/ApplicationForm.tsx
@@ -1111,7 +1111,6 @@ const ApplicationForm: React.FC = () => {
                 if (!data.parent1Email?.trim()) missing.push('Email');
                 if (!data.parent1Phone?.trim()) missing.push('Teléfono');
                 if (!data.parent1Address?.trim()) missing.push('Dirección');
-                if (!data.parent1Profession?.trim()) missing.push('Profesión');
                 break;
 
             // Step 4: Datos de la Madre
@@ -1121,7 +1120,6 @@ const ApplicationForm: React.FC = () => {
                 if (!data.parent2Email?.trim()) missing.push('Email');
                 if (!data.parent2Phone?.trim()) missing.push('Teléfono');
                 if (!data.parent2Address?.trim()) missing.push('Dirección');
-                if (!data.parent2Profession?.trim()) missing.push('Profesión');
                 break;
 
             // Step 5: Sostenedor
@@ -1878,18 +1876,6 @@ const ApplicationForm: React.FC = () => {
                                 error={errors.parent1Address}
                             />
                         </div>
-                        <div className="mt-4">
-                            <Input
-                                id="parent1-profession"
-                                label="Profesión"
-                                placeholder="Ingeniero Comercial"
-                                isRequired
-                                value={data.parent1Profession || ''}
-                                onChange={(e) => updateField('parent1Profession', e.target.value)}
-                                onBlur={() => touchField('parent1Profession')}
-                                error={errors.parent1Profession}
-                            />
-                        </div>
                     </div>
                 );
 
@@ -1952,18 +1938,6 @@ const ApplicationForm: React.FC = () => {
                                 onChange={(e) => updateField('parent2Address', e.target.value)}
                                 onBlur={() => touchField('parent2Address')}
                                 error={errors.parent2Address}
-                            />
-                        </div>
-                        <div className="mt-4">
-                            <Input
-                                id="parent2-profession"
-                                label="Profesión"
-                                placeholder="Profesora de Educación Básica"
-                                isRequired
-                                value={data.parent2Profession || ''}
-                                onChange={(e) => updateField('parent2Profession', e.target.value)}
-                                onBlur={() => touchField('parent2Profession')}
-                                error={errors.parent2Profession}
                             />
                         </div>
                     </div>

--- a/microfrontends/apps/mf-guardian/pages/FamilyDashboard.tsx
+++ b/microfrontends/apps/mf-guardian/pages/FamilyDashboard.tsx
@@ -518,7 +518,6 @@ const FamilyDashboard: React.FC = () => {
                     </div>
                     <div>
                       <p><strong>Teléfono:</strong> {myApplication.father.phone}</p>
-                      <p><strong>Profesión:</strong> {myApplication.father.profession}</p>
                       <p><strong>Dirección:</strong> {myApplication.father.address}</p>
                     </div>
                   </div>
@@ -537,7 +536,6 @@ const FamilyDashboard: React.FC = () => {
                     </div>
                     <div>
                       <p><strong>Teléfono:</strong> {myApplication.mother.phone}</p>
-                      <p><strong>Profesión:</strong> {myApplication.mother.profession}</p>
                       <p><strong>Dirección:</strong> {myApplication.mother.address}</p>
                     </div>
                   </div>

--- a/microfrontends/apps/mf-reports/pages/AdminDashboard.tsx
+++ b/microfrontends/apps/mf-reports/pages/AdminDashboard.tsx
@@ -296,7 +296,7 @@ const AdminDashboard: React.FC = () => {
       // Datos académicos
       cursoPostulado: app.student.gradeApplied,
       colegioActual: app.student.currentSchool,
-      colegioDestino: (app.student.targetSchool || 'MONTE_TABOR'),
+      colegioDestino: (app.student.gender || 'MALE'),
       añoAcademico: '2025',
       
       // Estado de postulación
@@ -314,13 +314,11 @@ const AdminDashboard: React.FC = () => {
       nombrePadre: app.father?.fullName,
       emailPadre: app.father?.email,
       telefonoPadre: app.father?.phone,
-      profesionPadre: app.father?.profession,
-      
+
       nombreMadre: app.mother?.fullName,
       emailMadre: app.mother?.email,
       telefonoMadre: app.mother?.phone,
-      profesionMadre: app.mother?.profession,
-      
+
       // Información académica y evaluaciones
       documentosCompletos: app.documents ? app.documents.length > 0 : false,
       cantidadDocumentos: app.documents ? app.documents.length : 0,

--- a/microfrontends/apps/mf-reports/pages/FamilyDashboard.tsx
+++ b/microfrontends/apps/mf-reports/pages/FamilyDashboard.tsx
@@ -548,7 +548,6 @@ const FamilyDashboard: React.FC = () => {
                     </div>
                     <div>
                       <p><strong>Teléfono:</strong> {myApplication.father.phone}</p>
-                      <p><strong>Profesión:</strong> {myApplication.father.profession}</p>
                       <p><strong>Dirección:</strong> {myApplication.father.address}</p>
                     </div>
                   </div>
@@ -567,7 +566,6 @@ const FamilyDashboard: React.FC = () => {
                     </div>
                     <div>
                       <p><strong>Teléfono:</strong> {myApplication.mother.phone}</p>
-                      <p><strong>Profesión:</strong> {myApplication.mother.profession}</p>
                       <p><strong>Dirección:</strong> {myApplication.mother.address}</p>
                     </div>
                   </div>

--- a/microfrontends/packages/shared-ui/src/components/admin/PostulantesDataTable.tsx
+++ b/microfrontends/packages/shared-ui/src/components/admin/PostulantesDataTable.tsx
@@ -34,7 +34,7 @@ interface Postulante {
     // Datos académicos
     cursoPostulado: string;
     colegioActual?: string;
-    colegioDestino: 'MONTE_TABOR' | 'NAZARET';
+    colegioDestino: 'MALE' | 'FEMALE';
     añoAcademico: string;
     
     // Estado de postulación
@@ -200,7 +200,7 @@ const PostulantesDataTable: React.FC<PostulantesDataTableProps> = ({
                         </Badge>
                         <div className="flex items-center gap-1 text-xs text-gray-500">
                             <FiHome className="w-3 h-3" />
-                            <span>{record.colegioDestino === 'MONTE_TABOR' ? 'Monte Tabor' : 'Nazaret'}</span>
+                            <span>{record.colegioDestino === 'MALE' ? 'Masculino' : record.colegioDestino === 'FEMALE' ? 'Femenino' : 'No especificado'}</span>
                         </div>
                     </div>
                 );
@@ -429,7 +429,7 @@ const PostulantesDataTable: React.FC<PostulantesDataTableProps> = ({
             // Datos académicos
             cursoPostulado: app.student.gradeApplied,
             colegioActual: app.student.currentSchool,
-            colegioDestino: (app.student.targetSchool || 'MONTE_TABOR') as 'MONTE_TABOR' | 'NAZARET',
+            colegioDestino: (app.student.gender || 'MALE') as 'MALE' | 'FEMALE',
             añoAcademico: '2025',
             
             // Estado de postulación
@@ -447,13 +447,11 @@ const PostulantesDataTable: React.FC<PostulantesDataTableProps> = ({
             nombrePadre: app.father?.fullName,
             emailPadre: app.father?.email,
             telefonoPadre: app.father?.phone,
-            profesionPadre: app.father?.profession,
-            
+
             nombreMadre: app.mother?.fullName,
             emailMadre: app.mother?.email,
             telefonoMadre: app.mother?.phone,
-            profesionMadre: app.mother?.profession,
-            
+
             // Información académica y evaluaciones
             documentosCompletos: app.documents ? app.documents.length > 0 : false,
             cantidadDocumentos: app.documents ? app.documents.length : 0,
@@ -563,7 +561,7 @@ const PostulantesDataTable: React.FC<PostulantesDataTableProps> = ({
             'Dirección': p.direccion,
             'Curso Postulado': p.cursoPostulado,
             'Colegio Actual': p.colegioActual || '',
-            'Colegio Destino': p.colegioDestino === 'MONTE_TABOR' ? 'Monte Tabor' : 'Nazaret',
+            'Género': p.colegioDestino === 'MALE' ? 'Masculino' : p.colegioDestino === 'FEMALE' ? 'Femenino' : 'No especificado',
             'Estado Postulación': p.estadoPostulacion,
             'Fecha Postulación': p.fechaPostulacion,
             'Contacto Principal': p.nombreContactoPrincipal,
@@ -573,11 +571,9 @@ const PostulantesDataTable: React.FC<PostulantesDataTableProps> = ({
             'Nombre Padre': p.nombrePadre || '',
             'Email Padre': p.emailPadre || '',
             'Teléfono Padre': p.telefonoPadre || '',
-            'Profesión Padre': p.profesionPadre || '',
             'Nombre Madre': p.nombreMadre || '',
             'Email Madre': p.emailMadre || '',
             'Teléfono Madre': p.telefonoMadre || '',
-            'Profesión Madre': p.profesionMadre || '',
             'Documentos Completos': p.documentosCompletos ? 'Sí' : 'No',
             'Cantidad Documentos': p.cantidadDocumentos,
             'Evaluación Pendiente': p.evaluacionPendiente ? 'Sí' : 'No',

--- a/microfrontends/packages/shared-ui/src/components/admin/StudentDetailModal.tsx
+++ b/microfrontends/packages/shared-ui/src/components/admin/StudentDetailModal.tsx
@@ -39,7 +39,7 @@ interface Postulante {
     direccion: string;
     cursoPostulado: string;
     colegioActual?: string;
-    colegioDestino: 'MONTE_TABOR' | 'NAZARET';
+    colegioDestino: 'MALE' | 'FEMALE';
     añoAcademico: string;
     estadoPostulacion: string;
     fechaPostulacion: string;
@@ -793,9 +793,9 @@ const StudentDetailModal: React.FC<StudentDetailModalProps> = ({
                             <Badge variant="blue" size="sm">{postulante.cursoPostulado}</Badge>
                         </div>
                         <div className="flex justify-between">
-                            <span className="text-gray-600">Colegio Destino:</span>
+                            <span className="text-gray-600">Género:</span>
                             <Badge variant="green" size="sm">
-                                {postulante.colegioDestino === 'MONTE_TABOR' ? 'Monte Tabor' : 'Nazaret'}
+                                {postulante.colegioDestino === 'MALE' ? 'Masculino' : postulante.colegioDestino === 'FEMALE' ? 'Femenino' : 'No especificado'}
                             </Badge>
                         </div>
                         <div className="flex justify-between">
@@ -930,10 +930,6 @@ const StudentDetailModal: React.FC<StudentDetailModalProps> = ({
                         </h4>
                         <div className="space-y-2 text-sm">
                             <div className="flex items-center gap-2">
-                                <FiBriefcase className="w-4 h-4 text-gray-400" />
-                                <span>Profesión: {fatherData.profession || postulante.profesionPadre || 'No especificada'}</span>
-                            </div>
-                            <div className="flex items-center gap-2">
                                 <FiPhone className="w-4 h-4 text-gray-400" />
                                 <span>Teléfono: {fatherData.phone || postulante.telefonoPadre || 'No especificado'}</span>
                             </div>
@@ -962,10 +958,6 @@ const StudentDetailModal: React.FC<StudentDetailModalProps> = ({
                             {motherData.fullName || postulante.nombreMadre || 'No especificado'}
                         </h4>
                         <div className="space-y-2 text-sm">
-                            <div className="flex items-center gap-2">
-                                <FiBriefcase className="w-4 h-4 text-gray-400" />
-                                <span>Profesión: {motherData.profession || postulante.profesionMadre || 'No especificada'}</span>
-                            </div>
                             <div className="flex items-center gap-2">
                                 <FiPhone className="w-4 h-4 text-gray-400" />
                                 <span>Teléfono: {motherData.phone || postulante.telefonoMadre || 'No especificado'}</span>

--- a/microfrontends/packages/shared-ui/src/components/ui/SavedFilters.tsx
+++ b/microfrontends/packages/shared-ui/src/components/ui/SavedFilters.tsx
@@ -124,7 +124,7 @@ const SavedFilters: React.FC<SavedFiltersProps> = ({
           id: '1',
           field: 'schoolApplied',
           operator: 'equals',
-          value: 'MONTE_TABOR',
+          value: 'MALE',
           logic: 'AND'
         },
         {

--- a/microfrontends/packages/shared-ui/src/services/applicationService.ts
+++ b/microfrontends/packages/shared-ui/src/services/applicationService.ts
@@ -11,7 +11,7 @@ export interface ApplicationRequest {
     studentEmail?: string;
     studentAddress: string;
     grade: string;
-    schoolApplied: string; // "MONTE_TABOR" para niños, "NAZARET" para niñas
+    schoolApplied: string; // "MALE" para niños, "FEMALE" para niñas
     currentSchool?: string;
     additionalNotes?: string;
 
@@ -74,7 +74,7 @@ export interface Application {
         currentSchool?: string;
         additionalNotes?: string;
         // Campos de categorías especiales
-        targetSchool?: string;
+        gender?: string;
         isEmployeeChild?: boolean;
         employeeParentName?: string;
         isAlumniChild?: boolean;
@@ -480,6 +480,7 @@ class ApplicationService {
                 studentEmail: data.studentEmail || '',
                 studentAddress: data.studentAddress || '',
                 studentCurrentSchool: data.currentSchool || '',
+                studentGender: data.schoolApplied === 'MALE' ? 'MALE' : data.schoolApplied === 'FEMALE' ? 'FEMALE' : '',
                 studentAdmissionPreference: data.admissionPreference || 'NINGUNA',
                 studentPais: 'Chile',
                 studentRegion: '',

--- a/microfrontends/packages/shared-ui/src/services/dataAdapter.ts
+++ b/microfrontends/packages/shared-ui/src/services/dataAdapter.ts
@@ -52,7 +52,7 @@ export interface Application {
     email?: string;
     address?: string;
     gradeApplied?: string;
-    targetSchool?: string;
+    gender?: string;
     currentSchool?: string;
     additionalNotes?: string;
     isEmployeeChild?: boolean;
@@ -162,7 +162,7 @@ export class DataAdapter {
         email: `${firstName.toLowerCase()}.${lastName.toLowerCase()}@example.com`,
         address: 'Dirección no especificada',
         gradeApplied: this.inferGradeFromName(studentName),
-        targetSchool: 'MONTE_TABOR',
+        gender: 'MALE',
         currentSchool: 'Colegio anterior',
         additionalNotes: 'Datos migrados desde microservicio',
         isEmployeeChild: false,
@@ -214,7 +214,7 @@ export class DataAdapter {
               email: 'error@ejemplo.com',
               address: 'N/A',
               gradeApplied: 'KINDER',
-              targetSchool: 'MONTE_TABOR',
+              gender: 'MALE',
               currentSchool: 'N/A',
               additionalNotes: 'Error al procesar datos',
               isEmployeeChild: false,

--- a/microfrontends/packages/shared-ui/src/services/dataService.ts
+++ b/microfrontends/packages/shared-ui/src/services/dataService.ts
@@ -46,7 +46,7 @@ export interface EmailNotificationData {
     subject: string;
     studentName: string;
     studentGender: 'MALE' | 'FEMALE';
-    targetSchool: 'MONTE_TABOR' | 'NAZARET';
+    gender: 'MALE' | 'FEMALE';
     sentAt: string;
     opened: boolean;
     openedAt?: string;
@@ -83,7 +83,7 @@ export interface PostulanteData {
     direccion: string;
     cursoPostulado: string;
     colegioActual?: string;
-    colegioDestino: 'MONTE_TABOR' | 'NAZARET';
+    colegioDestino: 'MALE' | 'FEMALE';
     añoAcademico: string;
     estadoPostulacion: string;
     fechaPostulacion: string;
@@ -209,7 +209,7 @@ class DataService {
                 subject: 'Entrevista programada para Ana María',
                 studentName: 'Ana María Pérez',
                 studentGender: 'FEMALE',
-                targetSchool: 'MONTE_TABOR',
+                gender: 'MALE',
                 sentAt: '2025-08-20T10:00:00',
                 opened: true,
                 openedAt: '2025-08-20T10:05:00',
@@ -274,7 +274,7 @@ class DataService {
             direccion: student.address || 'Sin dirección',
             cursoPostulado: student.gradeApplied || 'No especificado',
             colegioActual: student.currentSchool || undefined,
-            colegioDestino: student.targetSchool || 'MONTE_TABOR',
+            colegioDestino: student.gender || 'MALE',
             añoAcademico: '2025',
             estadoPostulacion: app.status || 'PENDING',
             fechaPostulacion: app.submissionDate || app.createdAt || '',

--- a/microfrontends/packages/shared-ui/src/src/api/applications.types.ts
+++ b/microfrontends/packages/shared-ui/src/src/api/applications.types.ts
@@ -43,7 +43,7 @@ export interface Student {
   specialNeeds: boolean;
   specialNeedsDescription?: string;
   age?: number;
-  targetSchool?: 'MONTE_TABOR' | 'NAZARET';
+  gender?: 'MALE' | 'FEMALE';
   isEmployeeChild?: boolean;
   employeeParentName?: string;
   isAlumniChild?: boolean;
@@ -101,7 +101,7 @@ export interface UpdateApplicationRequest {
 export interface ApplicationSearchParams {
   status?: Application['status'];
   gradeApplying?: string;
-  targetSchool?: 'MONTE_TABOR' | 'NAZARET';
+  gender?: 'MALE' | 'FEMALE';
   submissionDateFrom?: string;
   submissionDateTo?: string;
   studentName?: string;

--- a/microfrontends/packages/shared-ui/src/src/api/search.client.ts
+++ b/microfrontends/packages/shared-ui/src/src/api/search.client.ts
@@ -219,8 +219,8 @@ class SearchClient {
         { value: 2026, label: '2026' }
       ],
       schools: [
-        { value: 'MONTE_TABOR', label: 'Monte Tabor' },
-        { value: 'NAZARET', label: 'Nazaret' }
+        { value: 'MALE', label: 'Masculino' },
+        { value: 'FEMALE', label: 'Femenino' }
       ],
       evaluationStatuses: [
         { value: 'PENDING', label: 'Pendiente' },

--- a/microfrontends/packages/shared-ui/src/src/api/search.types.ts
+++ b/microfrontends/packages/shared-ui/src/src/api/search.types.ts
@@ -15,7 +15,7 @@ export interface AdvancedSearchParams {
   // Grade and school
   gradeApplied?: string;
   academicYear?: number;
-  schoolApplied?: 'MONTE_TABOR' | 'NAZARET';
+  schoolApplied?: 'MALE' | 'FEMALE';
 
   // Document filters
   documentsComplete?: boolean;


### PR DESCRIPTION
## Summary
- Change school selector from MONTE_TABOR/NAZARET to gender (MALE/FEMALE) with labels Masculino/Femenino in ApplicationForm
- Remove parent profession fields from all admission-related forms and displays

## Changes
### School selector → Gender
- ApplicationForm.tsx: Update schoolOptions to use gender values
- StudentDetailModal.tsx (shared-ui & mf-admin): Update dropdown and display labels
- PostulantesDataTable.tsx: Update CSV export column and display
- search.client.ts, search.types.ts: Update type definitions

### Remove parent profession
- PostulantesDataTable.tsx: Remove profesionPadre/profesionMadre from data mapping and CSV
- StudentDetailModal.tsx (shared-ui & mf-admin): Remove profession display for father/mother
- AdminDashboard.tsx (mf-admin & mf-reports): Remove profession from data mapping
- FamilyDashboard.tsx (mf-guardian & mf-reports): Remove profession display
- ApplicationForm.tsx: Remove profession inputs and validation

## Test plan
- [ ] Verify school selector shows Masculino/Femenino instead of Monte Tabor/Nazaret
- [ ] Verify parent profession fields are no longer displayed in forms
- [ ] Verify CSV export does not include profession columns
- [ ] Verify all microfrontends build without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)