### PR TITLE
feat(panels): standardize sidebar across apoderado and profesor/psico…

### DIFF
--- a/src/features/evaluations/pages/ProfessorDashboard.tsx
+++ b/src/features/evaluations/pages/ProfessorDashboard.tsx
@@ -44,13 +44,80 @@ import { appUrls } from '../../admin/utils/appUrls';
 import { getStorageKey, BASE_STORAGE_KEYS, useAuthStore } from '../../../packages/backend-sdk/src/index';
 
 const baseSections = [
-    { key: 'dashboard', label: 'Dashboard General', icon: DashboardIcon },
-    { key: 'entrevistas', label: 'Mis Entrevistas', icon: UsersIcon },
-    { key: 'estudiantes', label: 'Mis Estudiantes', icon: UsersIcon },
-    { key: 'horarios', label: 'Mis Horarios', icon: ClockIcon },
-    { key: 'reportes', label: 'Reportes y Estadísticas', icon: FileTextIcon },
-    { key: 'configuracion', label: 'Configuración', icon: BookOpenIcon }
+    { key: 'dashboard',    label: 'Dashboard General',        icon: DashboardIcon },
+    { key: 'entrevistas',  label: 'Mis Entrevistas',          icon: UsersIcon },
+    { key: 'estudiantes',  label: 'Mis Estudiantes',          icon: UsersIcon },
+    { key: 'horarios',     label: 'Mis Horarios',             icon: ClockIcon },
+    { key: 'reportes',     label: 'Reportes y Estadísticas',  icon: FileTextIcon },
+    { key: 'configuracion',label: 'Información',               icon: BookOpenIcon },
 ];
+
+interface SidebarNavProps {
+    sections: Array<{ key: string; label: string; icon: React.ComponentType<{ className?: string }> }>;
+    activeSection: string;
+    onSectionChange: (key: string) => void;
+    onShowLogout: () => void;
+    interviews: Interview[];
+    onNavigate?: () => void;
+}
+
+const SidebarNav = React.memo(function SidebarNav({
+    sections,
+    activeSection,
+    onSectionChange,
+    onShowLogout,
+    interviews,
+    onNavigate,
+}: SidebarNavProps) {
+    return (
+        <>
+            <div className="mb-8 text-center">
+                <LogoIcon className="mx-auto w-16 h-16 sm:w-24 sm:h-24 flex-shrink-0" />
+                <h2 className="text-xl font-bold text-azul-monte-tabor">Portal Profesores</h2>
+                <p className="text-gris-piedra text-sm">Sistema de Evaluaciones</p>
+            </div>
+            <nav className="space-y-2 flex-1" aria-label="Menú de navegación del profesor">
+                {sections.map((section) => {
+                    const IconComponent = section.icon;
+                    const showBadge = section.key === 'entrevistas' && interviews.length > 0;
+                    return (
+                        <button
+                            key={section.key}
+                            onClick={() => { onSectionChange(section.key); onNavigate?.(); }}
+                            className={`w-full text-left px-4 py-3 rounded-lg font-medium transition-colors duration-200 flex items-center gap-3 ${
+                                activeSection === section.key
+                                    ? 'bg-azul-monte-tabor text-white'
+                                    : 'text-gris-piedra hover:bg-gray-100'
+                            }`}
+                            aria-label={`Navegar a ${section.label}`}
+                            aria-current={activeSection === section.key ? 'page' : undefined}
+                        >
+                            <IconComponent className="w-5 h-5 flex-shrink-0" aria-hidden="true" />
+                            <span className="flex-1">{section.label}</span>
+                            {showBadge && (
+                                <span className="bg-red-500 text-white text-xs font-bold px-2 py-1 rounded-full">
+                                    {interviews.length}
+                                </span>
+                            )}
+                        </button>
+                    );
+                })}
+            </nav>
+            <div className="mt-8 pt-8 border-t border-gray-200 flex flex-col gap-3">
+                <ChangePasswordButton className="w-full" variant="outline" />
+                <Button
+                    variant="outline"
+                    size="sm"
+                    className="w-full"
+                    onClick={onShowLogout}
+                    ariaLabel="Cerrar sesión y volver al portal principal"
+                >
+                    Cerrar Sesión
+                </Button>
+            </div>
+        </>
+    );
+});
 
 const ProfessorDashboard: React.FC = () => {
     const navigate = useNavigate();
@@ -1638,7 +1705,7 @@ const ProfessorDashboard: React.FC = () => {
             case 'configuracion':
                 return (
                     <Card className="p-6">
-                        <h2 className="text-xl font-bold text-azul-monte-tabor mb-4">Configuración</h2>
+                        <h2 className="text-xl font-bold text-azul-monte-tabor mb-4">Información</h2>
                         <div className="space-y-4">
                             <div>
                                 <h3 className="font-semibold text-azul-monte-tabor mb-2">Información Personal</h3>
@@ -1649,9 +1716,6 @@ const ProfessorDashboard: React.FC = () => {
                                 {isAdminUser && (
                                     <p className="text-dorado-nazaret"><strong>Permisos:</strong> Administrador</p>
                                 )}
-                            </div>
-                            <div className="pt-4 border-t">
-                                <ChangePasswordButton variant="outline" />
                             </div>
                         </div>
                     </Card>
@@ -1702,66 +1766,20 @@ const ProfessorDashboard: React.FC = () => {
         }
     };
 
-    const SidebarNav = ({ onNavigate }: { onNavigate?: () => void }) => (
-        <>
-            <div className="text-blanco-pureza mb-8 text-center">
-                <LogoIcon className="mx-auto w-16 h-16 sm:w-24 sm:h-24 flex-shrink-0" />
-                <h2 className="text-xl font-bold">Portal Profesores</h2>
-                <p className="text-blue-200 text-sm">Sistema de Evaluaciones</p>
-            </div>
-            <nav className="space-y-2 flex-1" aria-label="Menú de navegación del profesor">
-                {sections.map((section) => {
-                    const IconComponent = section.icon;
-                    const showBadge = section.key === 'entrevistas' && interviews.length > 0;
-                    return (
-                        <button
-                            key={section.key}
-                            onClick={() => { setActiveSection(section.key); onNavigate?.(); }}
-                            className={`w-full text-left px-4 py-3 rounded-lg font-semibold transition-colors duration-200 flex items-center gap-3 ${
-                                activeSection === section.key
-                                    ? 'bg-dorado-nazaret text-azul-monte-tabor'
-                                    : 'text-blanco-pureza hover:bg-blue-800'
-                            }`}
-                            aria-label={`Navegar a sección ${section.label}`}
-                            aria-current={activeSection === section.key ? 'page' : undefined}
-                        >
-                            <IconComponent className="w-5 h-5" aria-hidden="true" />
-                            <span className="flex-1">{section.label}</span>
-                            {showBadge && (
-                                <span className="bg-red-500 text-white text-xs font-bold px-2 py-1 rounded-full">
-                                    {interviews.length}
-                                </span>
-                            )}
-                        </button>
-                    );
-                })}
-            </nav>
-            <div className="mt-8 pt-8 border-t border-blue-700">
-                <Button
-                    variant="outline"
-                    size="sm"
-                    className="w-full text-blanco-pureza border-blanco-pureza hover:bg-red-500 hover:text-blanco-pureza"
-                    onClick={() => setShowLogoutConfirm(true)}
-                    ariaLabel="Cerrar sesión y volver al portal principal"
-                >
-                    Cerrar Sesión
-                </Button>
-            </div>
-        </>
-    );
-
     return (
         <div className="bg-gray-50 min-h-screen">
             {/* Mobile top bar */}
-            <div className="md:hidden bg-azul-monte-tabor text-white px-4 py-3 flex items-center justify-between sticky top-0 z-30">
+            <div className="md:hidden bg-white shadow-sm px-4 py-3 flex items-center justify-between sticky top-0 z-30">
                 <div>
-                    <span className="font-bold">Portal Profesores</span>
-                    <p className="text-blue-200 text-xs">Sistema de Evaluaciones</p>
+                    <span className="font-bold text-azul-monte-tabor">Portal Profesores</span>
+                    <p className="text-gris-piedra text-xs">Sistema de Evaluaciones</p>
                 </div>
                 <button
                     onClick={() => setIsSidebarOpen(prev => !prev)}
-                    className="p-2 rounded-lg hover:bg-blue-800 transition-colors"
-                    aria-label="Abrir menú de navegación"
+                    className="p-2.5 min-w-[44px] min-h-[44px] rounded-lg text-gris-piedra hover:bg-gray-100 transition-colors"
+                    aria-expanded={isSidebarOpen}
+                    aria-controls="mobile-sidebar-profesor"
+                    aria-label={isSidebarOpen ? 'Cerrar menú de navegación' : 'Abrir menú de navegación'}
                 >
                     {isSidebarOpen ? (
                         <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1781,14 +1799,32 @@ const ProfessorDashboard: React.FC = () => {
             )}
 
             {/* Mobile sidebar drawer */}
-            <div className={`md:hidden fixed top-0 left-0 h-full w-64 bg-azul-monte-tabor z-50 p-6 flex flex-col overflow-y-auto transform transition-transform duration-300 ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full'}`}>
-                <SidebarNav onNavigate={() => setIsSidebarOpen(false)} />
+            <div
+                id="mobile-sidebar-profesor"
+                aria-hidden={!isSidebarOpen}
+                {...(!isSidebarOpen ? { inert: '' } : {})}
+                className={`md:hidden fixed top-0 left-0 h-full w-64 bg-white shadow-xl z-50 p-6 flex flex-col overflow-y-auto transform transition-transform duration-300 ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full'}`}
+            >
+                <SidebarNav
+                    sections={sections}
+                    activeSection={activeSection}
+                    onSectionChange={setActiveSection}
+                    onShowLogout={() => setShowLogoutConfirm(true)}
+                    interviews={interviews}
+                    onNavigate={() => setIsSidebarOpen(false)}
+                />
             </div>
 
             <div className="flex">
                 {/* Desktop Sidebar */}
-                <aside className="w-64 bg-azul-monte-tabor min-h-screen p-6 hidden md:flex flex-col sticky top-0 self-start h-screen overflow-y-auto">
-                    <SidebarNav />
+                <aside className="w-64 bg-white shadow-md min-h-screen p-6 hidden md:flex flex-col sticky top-0 self-start h-screen overflow-y-auto">
+                    <SidebarNav
+                        sections={sections}
+                        activeSection={activeSection}
+                        onSectionChange={setActiveSection}
+                        onShowLogout={() => setShowLogoutConfirm(true)}
+                        interviews={interviews}
+                    />
                 </aside>
 
                 {/* Main Content */}

--- a/src/features/guardian/pages/FamilyDashboard.tsx
+++ b/src/features/guardian/pages/FamilyDashboard.tsx
@@ -47,10 +47,10 @@ import FamilyCalendar from '../../admin/components/family/FamilyCalendar';
 import ComplementaryApplicationForm from '../../admin/pages/ComplementaryApplicationForm';
 
 const sections = [
-  { key: 'resumen', label: 'Resumen de Postulación' },
-  { key: 'datos', label: 'Datos del Postulante y Apoderados' },
-  { key: 'documentos', label: 'Documentos' },
-  { key: 'ayuda', label: 'Ayuda y Soporte' },
+  { key: 'resumen',    label: 'Resumen de Postulación',            icon: CheckCircleIcon },
+  { key: 'datos',      label: 'Datos del Postulante y Apoderados', icon: UsersIcon },
+  { key: 'documentos', label: 'Documentos',                        icon: FileTextIcon },
+  { key: 'ayuda',      label: 'Ayuda y Soporte',                   icon: FiInfo },
 ];
 
 const getStatusColor = (status: ApplicationStatus) => {
@@ -74,6 +74,64 @@ const getDocumentStatusIcon = (status: Document['status']) => {
     }
 };
 
+interface SidebarContentProps {
+  user: { firstName?: string; lastName?: string } | null;
+  activeSection: string;
+  sections: Array<{ key: string; label: string; icon: React.ComponentType<{ className?: string }> }>;
+  onSectionChange: (key: string) => void;
+  onShowLogout: () => void;
+  onNavigate?: () => void;
+}
+
+const SidebarContent = React.memo(function SidebarContent({
+  user,
+  activeSection,
+  sections,
+  onSectionChange,
+  onShowLogout,
+  onNavigate,
+}: SidebarContentProps) {
+  return (
+    <>
+      <div className="p-6 text-center">
+        <LogoIcon className="mx-auto w-16 h-16 sm:w-24 sm:h-24 flex-shrink-0" />
+        <h1 className="text-xl font-bold text-azul-monte-tabor">Portal Apoderados</h1>
+        <p className="text-sm text-gris-piedra mt-1">{user?.firstName} {user?.lastName}</p>
+      </div>
+      <nav className="px-4" aria-label="Secciones del portal de apoderados">
+        {sections.map(section => {
+          const Icon = section.icon;
+          return (
+            <button
+              key={section.key}
+              onClick={() => { onSectionChange(section.key); onNavigate?.(); }}
+              className={`w-full flex items-center gap-3 px-4 py-3 mb-2 rounded-lg text-left transition-colors ${
+                activeSection === section.key
+                  ? 'bg-azul-monte-tabor text-white'
+                  : 'text-gris-piedra hover:bg-gray-100'
+              }`}
+              aria-label={`Navegar a ${section.label}`}
+              aria-current={activeSection === section.key ? 'page' : undefined}
+            >
+              <Icon className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+              <span className="text-sm">{section.label}</span>
+            </button>
+          );
+        })}
+      </nav>
+      <div className="px-4 mt-auto pb-6 flex flex-col gap-3">
+        <Button
+          variant="outline"
+          className="w-full"
+          onClick={onShowLogout}
+          ariaLabel="Cerrar sesión y salir del portal"
+        >
+          Cerrar Sesión
+        </Button>
+      </div>
+    </>
+  );
+});
 
 const FamilyDashboard: React.FC = () => {
   const navigate = useNavigate();
@@ -719,42 +777,6 @@ const FamilyDashboard: React.FC = () => {
     }
   };
 
-  const SidebarContent = ({ onNavigate }: { onNavigate?: () => void }) => (
-    <>
-      <div className="p-6">
-        <LogoIcon className="mx-auto w-1/2 w-16 h-16 sm:w-24 sm:h-24 flex-shrink-0" />
-        <h1 className="text-xl font-bold text-azul-monte-tabor">Portal Apoderados</h1>
-        <p className="text-sm text-gris-piedra mt-1">{user?.firstName} {user?.lastName}</p>
-      </div>
-      <nav className="px-4" aria-label="Secciones del portal de apoderados">
-        {visibleSections.map(section => (
-          <button
-            key={section.key}
-            onClick={() => { setActiveSection(section.key); onNavigate?.(); }}
-            className={`w-full flex items-center gap-3 px-4 py-3 mb-2 rounded-lg text-left transition-colors ${
-              activeSection === section.key
-                ? 'bg-azul-monte-tabor text-white'
-                : 'text-gris-piedra hover:bg-gray-100'
-            }`}
-            aria-label={`Navegar a sección ${section.label}`}
-            aria-current={activeSection === section.key ? 'page' : undefined}
-          >
-            <span className="text-sm">{section.label}</span>
-          </button>
-        ))}
-      </nav>
-      <div className="px-4 mt-4">
-        <Button
-          variant="primary"
-          className="w-full bg-azul-monte-tabor hover:bg-blue-700 text-white font-medium py-3 transition-all duration-200 shadow-md hover:shadow-lg"
-          onClick={() => setShowLogoutConfirm(true)}
-        >
-          Cerrar Sesión
-        </Button>
-      </div>
-      <div className="flex-1"></div>
-    </>
-  );
 
   // Mostrar estado de carga
   if (isLoading) {
@@ -794,8 +816,10 @@ const FamilyDashboard: React.FC = () => {
         </div>
         <button
           onClick={() => setIsSidebarOpen(prev => !prev)}
-          className="p-2 rounded-lg text-gris-piedra hover:bg-gray-100 transition-colors"
-          aria-label="Abrir menú de secciones"
+          className="p-2.5 min-w-[44px] min-h-[44px] rounded-lg text-gris-piedra hover:bg-gray-100 transition-colors"
+          aria-expanded={isSidebarOpen}
+          aria-controls="mobile-sidebar-apoderado"
+          aria-label={isSidebarOpen ? 'Cerrar menú de secciones' : 'Abrir menú de secciones'}
         >
           {isSidebarOpen ? (
             <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -815,14 +839,32 @@ const FamilyDashboard: React.FC = () => {
       )}
 
       {/* Mobile sidebar drawer */}
-      <div className={`md:hidden fixed top-0 left-0 h-full w-64 bg-white shadow-xl z-50 flex flex-col overflow-y-auto transform transition-transform duration-300 ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full'}`}>
-        <SidebarContent onNavigate={() => setIsSidebarOpen(false)} />
+      <div
+        id="mobile-sidebar-apoderado"
+        aria-hidden={!isSidebarOpen}
+        {...(!isSidebarOpen ? { inert: '' } : {})}
+        className={`md:hidden fixed top-0 left-0 h-full w-64 bg-white shadow-xl z-50 flex flex-col overflow-y-auto transform transition-transform duration-300 ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full'}`}
+      >
+        <SidebarContent
+          user={user}
+          activeSection={activeSection}
+          sections={sections}
+          onSectionChange={setActiveSection}
+          onShowLogout={() => setShowLogoutConfirm(true)}
+          onNavigate={() => setIsSidebarOpen(false)}
+        />
       </div>
 
       <div className="flex">
         {/* Desktop Sidebar */}
         <aside className="w-64 bg-white shadow-md min-h-screen flex-col hidden md:flex sticky top-0 self-start h-screen overflow-y-auto" role="complementary" aria-label="Menú de navegación">
-          <SidebarContent />
+          <SidebarContent
+            user={user}
+            activeSection={activeSection}
+            sections={sections}
+            onSectionChange={setActiveSection}
+            onShowLogout={() => setShowLogoutConfirm(true)}
+          />
         </aside>
 
         {/* Main Content */}


### PR DESCRIPTION
…logo portals

- Extract SidebarContent and SidebarNav as React.memo components outside parent to prevent remounting
- Add icons to all nav items in FamilyDashboard (CheckCircleIcon, UsersIcon, FileTextIcon, FiInfo)
- Unify color scheme: white sidebar with azul-monte-tabor active items across all portals
- Replace blue gradient sidebar in ProfessorDashboard with white background matching admin panel
- Fix logout buttons to variant=outline without color overrides in both portals
- Replace flex-1 spacer with mt-auto grouped footer in FamilyDashboard
- Add ChangePasswordButton above logout in ProfessorDashboard sidebar
- Rename 'Configuración' section to 'Información' and remove ChangePasswordButton from section content
- Add aria-expanded, aria-controls, dynamic aria-label and 44px touch target to all hamburger buttons
- Add id, aria-hidden and inert to all mobile drawers when closed