### PR TITLE
feat(footer): modernize social icons and improve a11y

### DIFF
--- a/src/packages/shared-ui/src/components/layout/Footer.tsx
+++ b/src/packages/shared-ui/src/components/layout/Footer.tsx
@@ -1,25 +1,39 @@
 import React, { useState } from 'react';
-import { Facebook, Instagram, Linkedin } from 'lucide-react';
+import { SiFacebook, SiInstagram, SiLinkedin } from 'react-icons/si';
 import { appUrls } from '../../../../shared-utils/src/appUrls';
+
+const socialLinks = [
+    { href: '#', label: 'Síguenos en Facebook', Icon: SiFacebook },
+    { href: '#', label: 'Síguenos en Instagram', Icon: SiInstagram },
+    { href: '#', label: 'Síguenos en LinkedIn', Icon: SiLinkedin },
+];
 
 const Footer: React.FC = () => {
     const [showModal, setShowModal] = useState(false);
-    const [nombre, setNombre] = useState("");
-    const [correo, setCorreo] = useState("");
-    const [mensaje, setMensaje] = useState("");
+    const [nombre, setNombre] = useState('');
+    const [correo, setCorreo] = useState('');
+    const [mensaje, setMensaje] = useState('');
     const [enviado, setEnviado] = useState(false);
-    const [error, setError] = useState("");
+    const [error, setError] = useState('');
 
     const handleSend = (e: React.FormEvent) => {
         e.preventDefault();
         if (!nombre || !correo || !mensaje) {
-            setError("Todos los campos son obligatorios.");
+            setError('Todos los campos son obligatorios.');
             return;
         }
-        setError("");
-        // Simular envío (mailto)
+        setError('');
         window.location.href = `mailto:admision@mtn.cl?subject=Contacto%20desde%20web%20MTN&body=Nombre:%20${encodeURIComponent(nombre)}%0ACorreo:%20${encodeURIComponent(correo)}%0AMensaje:%20${encodeURIComponent(mensaje)}`;
         setEnviado(true);
+    };
+
+    const closeModal = () => {
+        setShowModal(false);
+        setEnviado(false);
+        setNombre('');
+        setCorreo('');
+        setMensaje('');
+        setError('');
     };
 
     return (
@@ -29,7 +43,7 @@ const Footer: React.FC = () => {
                     {/* Columna 1: Datos del Colegio */}
                     <div className="flex-1 text-center md:text-left">
                         <h3 className="text-lg font-bold text-dorado-nazaret mb-4 font-serif">Colegio Monte Tabor y Nazaret</h3>
-                        <address className="not-italic text-sm text-gray-300 space-y-1">
+                        <address className="not-italic text-sm text-white/65 space-y-1">
                             <p>Avda. Paseo Pie Andino 5894</p>
                             <p>Lo Barnechea</p>
                             <p>Tel: (56-2) 2 7500 900</p>
@@ -40,57 +54,76 @@ const Footer: React.FC = () => {
                     <div className="flex-[1.5] flex flex-col sm:flex-row gap-8">
                         {/* Sub-Col 2a: Enlaces */}
                         <div className="flex-1 text-center sm:text-left">
-                        <h3 className="text-lg font-bold text-dorado-nazaret mb-4 font-serif">Enlaces Rápidos</h3>
-                        <ul className="space-y-2">
-                                <li><a href="#" className="hover:underline text-sm text-gray-300">Nuestro Proyecto Educativo</a></li>
-                                <li><a href="#" className="hover:underline text-sm text-gray-300">Admisión 2025</a></li>
-                                <li><button onClick={() => setShowModal(true)} className="hover:underline text-sm text-gray-300 bg-transparent border-none p-0 m-0 cursor-pointer">Contacto</button></li>
-                        </ul>
-                    </div>
+                            <h3 className="text-lg font-bold text-dorado-nazaret mb-4 font-serif">Enlaces Rápidos</h3>
+                            <ul className="space-y-2">
+                                <li><a href="#" className="hover:underline text-sm text-white/65">Nuestro Proyecto Educativo</a></li>
+                                <li><a href="#" className="hover:underline text-sm text-white/65">Admisión 2025</a></li>
+                                <li><button onClick={() => setShowModal(true)} className="hover:underline text-sm text-white/65 bg-transparent border-none p-0 m-0 cursor-pointer">Contacto</button></li>
+                            </ul>
+                        </div>
                         {/* Sub-Col 2b: Redes */}
                         <div className="flex-1 text-center sm:text-left">
-                        <h3 className="text-lg font-bold text-dorado-nazaret mb-4 font-serif">Síguenos</h3>
-                            <div className="flex justify-center sm:justify-start gap-4 mt-2">
-                               <a href="#" aria-label="Facebook" className="p-2 rounded-full bg-white/10 hover:bg-dorado-nazaret/20 hover:scale-110 transition-all duration-200">
-                                   <Facebook className="w-7 h-7" strokeWidth={2} />
-                               </a>
-                               <a href="#" aria-label="Instagram" className="p-2 rounded-full bg-white/10 hover:bg-dorado-nazaret/20 hover:scale-110 transition-all duration-200">
-                                   <Instagram className="w-7 h-7" strokeWidth={2} />
-                               </a>
-                               <a href="#" aria-label="LinkedIn" className="p-2 rounded-full bg-white/10 hover:bg-dorado-nazaret/20 hover:scale-110 transition-all duration-200">
-                                   <Linkedin className="w-7 h-7" strokeWidth={2} />
-                               </a>
+                            <h3 className="text-lg font-bold text-dorado-nazaret mb-4 font-serif">Síguenos</h3>
+                            <div className="flex justify-center sm:justify-start gap-1 mt-2">
+                                {socialLinks.map(({ href, label, Icon }) => (
+                                    <a
+                                        key={label}
+                                        href={href}
+                                        aria-label={label}
+                                        className="p-2 text-white/55 hover:text-dorado-nazaret transition-colors duration-200"
+                                    >
+                                        <Icon size={20} aria-hidden={true} />
+                                    </a>
+                                ))}
                             </div>
                         </div>
                     </div>
                 </div>
-                <div className="border-t border-blue-800 mt-10 pt-6 flex flex-col sm:flex-row items-center justify-between gap-2 text-sm text-gray-400">
+                <div className="border-t border-white/15 mt-10 pt-6 flex flex-col sm:flex-row items-center justify-between gap-2 text-sm text-white/45">
                     <p>&copy; {new Date().getFullYear()} Colegio Monte Tabor y Nazaret. Todos los derechos reservados.</p>
                     <div className="flex items-center gap-4">
-                        <a href={appUrls.professorLogin} className="text-gray-400 hover:text-dorado-nazaret transition-colors text-xs underline underline-offset-2">Profesores</a>
-                        <a href={appUrls.adminLogin} className="text-gray-400 hover:text-dorado-nazaret transition-colors text-xs underline underline-offset-2">Acceso personal MTN</a>
+                        <a href={appUrls.professorLogin} className="text-white/45 hover:text-dorado-nazaret transition-colors text-xs underline underline-offset-2">Profesores</a>
+                        <a href={appUrls.adminLogin} className="text-white/45 hover:text-dorado-nazaret transition-colors text-xs underline underline-offset-2">Acceso personal MTN</a>
                     </div>
                 </div>
             </div>
             {/* Modal de contacto */}
             {showModal && (
-                <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+                <div
+                    className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+                    role="dialog"
+                    aria-modal="true"
+                    aria-labelledby="contact-modal-title"
+                >
                     <div className="bg-white rounded-lg shadow-lg p-8 max-w-md w-full relative">
-                        <button className="absolute top-2 right-2 text-gray-400 hover:text-rojo-sagrado text-2xl" onClick={() => { setShowModal(false); setEnviado(false); setNombre(""); setCorreo(""); setMensaje(""); setError(""); }}>&times;</button>
+                        <button
+                            className="absolute top-2 right-2 text-gray-400 hover:text-rojo-sagrado text-2xl"
+                            onClick={closeModal}
+                            aria-label="Cerrar formulario de contacto"
+                        >&times;</button>
                         {!enviado ? (
                             <form onSubmit={handleSend} className="space-y-4">
-                                <h2 className="text-2xl font-bold text-azul-monte-tabor mb-2">Contacto</h2>
-                                <input type="text" className="w-full border rounded p-2" placeholder="Nombre" value={nombre} onChange={e => setNombre(e.target.value)} required />
-                                <input type="email" className="w-full border rounded p-2" placeholder="Correo electrónico" value={correo} onChange={e => setCorreo(e.target.value)} required />
-                                <textarea className="w-full border rounded p-2" placeholder="Mensaje" rows={4} value={mensaje} onChange={e => setMensaje(e.target.value)} required />
-                                {error && <p className="text-rojo-sagrado text-sm">{error}</p>}
+                                <h2 id="contact-modal-title" className="text-2xl font-bold text-azul-monte-tabor mb-2">Contacto</h2>
+                                <div>
+                                    <label htmlFor="contact-nombre" className="sr-only">Nombre</label>
+                                    <input id="contact-nombre" type="text" className="w-full border rounded p-2" placeholder="Nombre" value={nombre} onChange={e => setNombre(e.target.value)} required />
+                                </div>
+                                <div>
+                                    <label htmlFor="contact-correo" className="sr-only">Correo electrónico</label>
+                                    <input id="contact-correo" type="email" className="w-full border rounded p-2" placeholder="Correo electrónico" value={correo} onChange={e => setCorreo(e.target.value)} required />
+                                </div>
+                                <div>
+                                    <label htmlFor="contact-mensaje" className="sr-only">Mensaje</label>
+                                    <textarea id="contact-mensaje" className="w-full border rounded p-2" placeholder="Mensaje" rows={4} value={mensaje} onChange={e => setMensaje(e.target.value)} required />
+                                </div>
+                                {error && <p className="text-rojo-sagrado text-sm" role="alert">{error}</p>}
                                 <button type="submit" className="w-full bg-dorado-nazaret text-azul-monte-tabor font-bold py-2 rounded hover:bg-amber-400 transition">Enviar</button>
                             </form>
                         ) : (
                             <div className="text-center py-8">
-                                <h2 className="text-2xl font-bold text-azul-monte-tabor mb-2">¡Mensaje preparado!</h2>
+                                <h2 id="contact-modal-title" className="text-2xl font-bold text-azul-monte-tabor mb-2">¡Mensaje preparado!</h2>
                                 <p className="text-gris-piedra mb-4">Se abrirá tu cliente de correo para enviar el mensaje a <b>admision@mtn.cl</b>.</p>
-                                <button className="mt-4 bg-dorado-nazaret text-azul-monte-tabor font-bold py-2 px-6 rounded hover:bg-amber-400 transition" onClick={() => { setShowModal(false); setEnviado(false); setNombre(""); setCorreo(""); setMensaje(""); setError(""); }}>Cerrar</button>
+                                <button className="mt-4 bg-dorado-nazaret text-azul-monte-tabor font-bold py-2 px-6 rounded hover:bg-amber-400 transition" onClick={closeModal}>Cerrar</button>
                             </div>
                         )}
                     </div>


### PR DESCRIPTION
- Replace lucide-react outline icons with react-icons/si brand-accurate filled icons (SiFacebook, SiInstagram, SiLinkedin)
- Remove ghost circle backgrounds from social links, adopt flat color-transition design
- Replace hardcoded Tailwind colors with opacity-based tokens (text-white/65, border-white/15)
- Add role=dialog, aria-modal, aria-labelledby to contact modal
- Add sr-only labels to modal form inputs and role=alert to error message
- Add aria-label to modal close button
- Extract closeModal() to remove duplicated state reset logic