### PR TITLE
feat(admin): estandarizar módulos al diseño de Calendario Global

### DIFF
--- a/src/features/admin/components/dashboard/InterviewCommandCenter.tsx
+++ b/src/features/admin/components/dashboard/InterviewCommandCenter.tsx
@@ -409,15 +409,42 @@ const InterviewCommandCenter: React.FC<InterviewCommandCenterProps> = ({
 
   return (
     <div className="space-y-5">
-      <section className="sticky top-0 z-20 rounded-lg border border-gray-200 bg-white/95 p-3 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-white/90">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+        <div className="flex flex-col gap-3">
           <div className="min-w-0">
-            <h2 className="text-lg font-bold text-gray-950">Centro operativo de entrevistas</h2>
+            <p className="text-xs font-bold uppercase tracking-[0.2em] text-teal-600">Calendario Global</p>
+            <h2 className="mt-1 text-lg font-bold text-gray-950">Centro operativo de entrevistas</h2>
             <p className="mt-0.5 max-w-3xl text-sm text-gray-600">
               {surface === 'operations' ? rangeLabel : 'Calendario mensual de entrevistas'}
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => setSurface('operations')}
+              aria-pressed={surface === 'operations'}
+              className={`inline-flex min-h-11 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold focus:outline-none focus:ring-2 ${
+                surface === 'operations'
+                  ? 'border-[#008a57] bg-[#008a57] text-white focus:ring-[#008a57]/30'
+                  : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50 focus:ring-blue-100'
+              }`}
+            >
+              <FiGrid className="h-4 w-4" aria-hidden="true" />
+              Vista operativa
+            </button>
+            <button
+              type="button"
+              onClick={() => setSurface('calendar')}
+              aria-pressed={surface === 'calendar'}
+              className={`inline-flex min-h-11 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold focus:outline-none focus:ring-2 ${
+                surface === 'calendar'
+                  ? 'border-[#008a57] bg-[#008a57] text-white focus:ring-[#008a57]/30'
+                  : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50 focus:ring-blue-100'
+              }`}
+            >
+              <FiCalendar className="h-4 w-4" aria-hidden="true" />
+              Calendario
+            </button>
             <button
               type="button"
               onClick={loadOverview}
@@ -428,59 +455,8 @@ const InterviewCommandCenter: React.FC<InterviewCommandCenterProps> = ({
               <FiRefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} aria-hidden="true" />
               Actualizar
             </button>
-            <button
-              type="button"
-              onClick={() => setSurface('calendar')}
-              aria-pressed={surface === 'calendar'}
-              className={`inline-flex min-h-11 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold focus:outline-none focus:ring-2 ${
-                surface === 'calendar'
-                  ? 'border-gray-900 bg-gray-900 text-white focus:ring-gray-300'
-                  : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50 focus:ring-blue-100'
-              }`}
-            >
-              <FiCalendar className="h-4 w-4" aria-hidden="true" />
-              Calendario
-            </button>
-            <button
-              type="button"
-              onClick={() => setSurface('operations')}
-              aria-pressed={surface === 'operations'}
-              className={`inline-flex min-h-11 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold focus:outline-none focus:ring-2 ${
-                surface === 'operations'
-                  ? 'border-gray-900 bg-gray-900 text-white focus:ring-gray-300'
-                  : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50 focus:ring-blue-100'
-              }`}
-            >
-              <FiGrid className="h-4 w-4" aria-hidden="true" />
-              Vista operativa
-            </button>
           </div>
         </div>
-
-        {surface === 'operations' && visibleOverview && (
-          <div className="mt-3 space-y-3 border-t border-gray-100 pt-3">
-            <SummaryBar summary={visibleOverview.summary} rejectedCount={rejectedCount} />
-            <div className="grid gap-3 xl:grid-cols-[minmax(520px,1fr)_minmax(260px,360px)]">
-              <RangeSelector
-                viewMode={viewMode}
-                rangeLabel={rangeLabel}
-                onViewModeChange={setViewMode}
-                onPrevious={() => moveRange(-1)}
-                onNext={() => moveRange(1)}
-                onToday={() => setAnchorDate(new Date())}
-              />
-              <label className="relative block">
-                <FiSearch className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500" aria-hidden="true" />
-                <input
-                  value={searchTerm}
-                  onChange={event => setSearchTerm(event.target.value)}
-                  className="h-11 w-full rounded-lg border border-gray-200 bg-white pl-9 pr-3 text-sm text-gray-900 placeholder:text-gray-500 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
-                  placeholder="Buscar familia o entrevistador"
-                />
-              </label>
-            </div>
-          </div>
-        )}
       </section>
 
       {surface === 'calendar' ? (
@@ -508,11 +484,31 @@ const InterviewCommandCenter: React.FC<InterviewCommandCenterProps> = ({
         </div>
       ) : visibleOverview ? (
         <>
+          <SummaryBar summary={visibleOverview.summary} rejectedCount={rejectedCount} />
           <RejectedInterviewsQueue
             days={visibleOverview.days}
             onInterviewClick={(interview) => onNavigateToInterviews?.(interview.id)}
             onReleaseInterview={(interview) => void handleReleaseHistoricalInterview(interview.id)}
           />
+          <div className="grid gap-3 xl:grid-cols-[minmax(520px,1fr)_minmax(260px,360px)]">
+            <RangeSelector
+              viewMode={viewMode}
+              rangeLabel={rangeLabel}
+              onViewModeChange={setViewMode}
+              onPrevious={() => moveRange(-1)}
+              onNext={() => moveRange(1)}
+              onToday={() => setAnchorDate(new Date())}
+            />
+            <label className="relative block">
+              <FiSearch className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500" aria-hidden="true" />
+              <input
+                value={searchTerm}
+                onChange={event => setSearchTerm(event.target.value)}
+                className="h-11 w-full rounded-lg border border-gray-200 bg-white pl-9 pr-3 text-sm text-gray-900 placeholder:text-gray-500 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                placeholder="Buscar familia o entrevistador"
+              />
+            </label>
+          </div>
           <WeeklyTimeline
             days={visibleOverview.days}
             viewMode={viewMode}

--- a/src/features/admin/components/dashboard/RangeSelector.tsx
+++ b/src/features/admin/components/dashboard/RangeSelector.tsx
@@ -32,7 +32,7 @@ const RangeSelector: React.FC<RangeSelectorProps> = ({
             aria-pressed={viewMode === mode}
             className={`min-h-11 rounded-md px-3 py-2 text-sm font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-blue-100 ${
               viewMode === mode
-                ? 'bg-gray-900 text-white shadow-sm'
+                ? 'bg-dorado-nazaret text-white shadow-sm'
                 : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
             }`}
           >

--- a/src/features/admin/components/interviews/InterviewManagement.tsx
+++ b/src/features/admin/components/interviews/InterviewManagement.tsx
@@ -12,7 +12,7 @@ import {
   XCircleIcon,
   PlusIcon,
 } from '../icons/Icons';
-import { FiCalendar, FiClock, FiUser, FiMapPin, FiMail, FiFilter, FiEye, FiEdit, FiCheck, FiX, FiRefreshCw, FiArrowLeft } from 'react-icons/fi';
+import { FiCalendar, FiCheckCircle, FiClock, FiUser, FiStar, FiMapPin, FiMail, FiFilter, FiEye, FiEdit, FiCheck, FiX, FiRefreshCw, FiArrowLeft } from 'react-icons/fi';
 import {
   Interview,
   InterviewStatus,
@@ -533,86 +533,123 @@ const InterviewManagement: React.FC<InterviewManagementProps> = ({ className = '
   return (
     <div className={`space-y-6 ${className}`}>
       {/* Header */}
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="flex flex-wrap items-center gap-3">
-          {onBack && (
-            <Button 
-              onClick={onBack}
-              variant="outline"
-              className="flex items-center"
+      <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+        <div className="flex flex-col gap-3">
+          <div className="min-w-0">
+            <p className="text-xs font-bold uppercase tracking-[0.2em] text-teal-600">Gestión de Entrevistas</p>
+            <h1 className="mt-1 text-lg font-bold text-gray-950">Gestión de Entrevistas</h1>
+            <p className="mt-0.5 max-w-3xl text-sm text-gray-600">Centro de evaluación de candidatos</p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => setViewMode('students')}
+              aria-pressed={viewMode === 'students'}
+              className={`inline-flex min-h-11 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold focus:outline-none focus:ring-2 ${
+                viewMode === 'students'
+                  ? 'border-[#008a57] bg-[#008a57] text-white focus:ring-[#008a57]/30'
+                  : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50 focus:ring-blue-100'
+              }`}
             >
-              <FiArrowLeft className="w-4 h-4 mr-2" />
-              Volver
-            </Button>
-          )}
-          <CalendarIcon className="w-8 h-8 text-azul-monte-tabor flex-shrink-0" />
-          <div>
-            <h1 className="text-2xl font-bold text-gray-900">
-              Gestión de Entrevistas
-            </h1>
-            <p className="text-sm text-gray-600">
-              Programa, gestiona y evalúa las entrevistas de admisión
-            </p>
+              <FiUser className="h-4 w-4" aria-hidden="true" />
+              Estudiantes
+            </button>
+            <button
+              type="button"
+              onClick={() => setViewMode('table')}
+              aria-pressed={viewMode === 'table'}
+              className={`inline-flex min-h-11 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold focus:outline-none focus:ring-2 ${
+                viewMode === 'table'
+                  ? 'border-[#008a57] bg-[#008a57] text-white focus:ring-[#008a57]/30'
+                  : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50 focus:ring-blue-100'
+              }`}
+            >
+              <FiFilter className="h-4 w-4" aria-hidden="true" />
+              Lista
+            </button>
+            <button
+              type="button"
+              onClick={() => setViewMode('calendar')}
+              aria-pressed={viewMode === 'calendar'}
+              className={`inline-flex min-h-11 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold focus:outline-none focus:ring-2 ${
+                viewMode === 'calendar'
+                  ? 'border-[#008a57] bg-[#008a57] text-white focus:ring-[#008a57]/30'
+                  : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50 focus:ring-blue-100'
+              }`}
+            >
+              <FiCalendar className="h-4 w-4" aria-hidden="true" />
+              Calendario
+            </button>
           </div>
         </div>
-
-        <div className="flex flex-wrap items-center gap-2">
-          <Button
-            variant="outline"
-            onClick={() => setShowFilters(!showFilters)}
-            className={showFilters ? 'bg-blue-50 border-blue-300' : ''}
-          >
-            <FiFilter className="w-5 h-5 mr-2" />
-            Filtros
-          </Button>
-          
-          <Button
-            variant="outline"
-            onClick={loadInterviews}
-            disabled={isLoading}
-          >
-            <FiRefreshCw className={`w-5 h-5 mr-2 ${isLoading ? 'animate-spin' : ''}`} />
-            Actualizar
-          </Button>
-
-          <Button
-            variant="primary"
-            onClick={handleCreateInterview}
-          >
-            <PlusIcon className="w-5 h-5 mr-2" />
-            Nueva Entrevista
-          </Button>
-        </div>
-      </div>
+      </section>
 
       {/* Estadísticas rápidas */}
       {stats && (
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-          <Card className="p-4 text-center">
-            <CalendarIcon className="w-6 h-6 text-blue-500 mx-auto mb-2" />
-            <p className="text-2xl font-bold text-blue-600">{stats.totalInterviews}</p>
-            <p className="text-sm text-gray-600">Total Entrevistas</p>
-          </Card>
-          
-          <Card className="p-4 text-center">
-            <ClockIcon className="w-6 h-6 text-orange-500 mx-auto mb-2" />
-            <p className="text-2xl font-bold text-orange-600">{stats.pendingInterviews}</p>
-            <p className="text-sm text-gray-600">Pendientes</p>
-          </Card>
-          
-          <Card className="p-4 text-center">
-            <CheckCircleIcon className="w-6 h-6 text-green-500 mx-auto mb-2" />
-            <p className="text-2xl font-bold text-green-600">{stats.completedInterviews}</p>
-            <p className="text-sm text-gray-600">Completadas</p>
-          </Card>
-          
-          <Card className="p-4 text-center">
-            <UserIcon className="w-6 h-6 text-purple-500 mx-auto mb-2" />
-            <p className="text-2xl font-bold text-purple-600">{(stats.averageScore || 0).toFixed(1)}</p>
-            <p className="text-sm text-gray-600">Puntuación Promedio</p>
-          </Card>
+        <div className="flex gap-2 overflow-x-auto pb-1" aria-label="Resumen de entrevistas">
+          <div className="min-w-[148px] rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-blue-700">
+            <div className="flex items-center gap-2">
+              <FiCalendar className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+              <p className="min-w-0 truncate text-xs font-semibold">Total Entrevistas</p>
+              <p className="ml-auto text-lg font-bold leading-none">{stats.totalInterviews}</p>
+            </div>
+          </div>
+          <div className="min-w-[132px] rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-amber-700">
+            <div className="flex items-center gap-2">
+              <FiClock className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+              <p className="min-w-0 truncate text-xs font-semibold">Pendientes</p>
+              <p className="ml-auto text-lg font-bold leading-none">{stats.pendingInterviews}</p>
+            </div>
+          </div>
+          <div className="min-w-[132px] rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-emerald-700">
+            <div className="flex items-center gap-2">
+              <FiCheckCircle className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+              <p className="min-w-0 truncate text-xs font-semibold">Completadas</p>
+              <p className="ml-auto text-lg font-bold leading-none">{stats.completedInterviews}</p>
+            </div>
+          </div>
+          <div className="min-w-[160px] rounded-lg border border-purple-200 bg-purple-50 px-3 py-2 text-purple-700">
+            <div className="flex items-center gap-2">
+              <FiStar className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+              <p className="min-w-0 truncate text-xs font-semibold">Puntuación Promedio</p>
+              <p className="ml-auto text-lg font-bold leading-none">{(stats.averageScore || 0).toFixed(1)}</p>
+            </div>
+          </div>
         </div>
       )}
+
+      {/* Acciones */}
+      <div className="flex flex-wrap justify-end gap-2">
+        <button
+          type="button"
+          onClick={() => setShowFilters(!showFilters)}
+          className={`inline-flex min-h-11 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold focus:outline-none focus:ring-2 focus:ring-blue-100 ${
+            showFilters
+              ? 'border-blue-300 bg-blue-50 text-blue-700'
+              : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'
+          }`}
+        >
+          <FiFilter className="h-4 w-4" aria-hidden="true" />
+          Filtros
+        </button>
+        <button
+          type="button"
+          onClick={loadInterviews}
+          disabled={isLoading}
+          className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-100 disabled:opacity-60"
+        >
+          <FiRefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} aria-hidden="true" />
+          Actualizar
+        </button>
+        <button
+          type="button"
+          onClick={handleCreateInterview}
+          className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-dorado-nazaret bg-dorado-nazaret px-3 py-2 text-sm font-semibold text-white hover:bg-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200"
+        >
+          <PlusIcon className="h-4 w-4" aria-hidden="true" />
+          Nueva Entrevista
+        </button>
+      </div>
 
       {/* Filtros expansibles */}
       {showFilters && (
@@ -689,31 +726,6 @@ const InterviewManagement: React.FC<InterviewManagementProps> = ({ className = '
           </div>
         </Card>
       )}
-
-      {/* Navegación de vistas */}
-      <div className="flex gap-2">
-        <Button
-          variant={viewMode === 'students' ? 'primary' : 'outline'}
-          onClick={() => setViewMode('students')}
-        >
-          <FiUser className="w-5 h-5 mr-2" />
-          Estudiantes
-        </Button>
-        <Button
-          variant={viewMode === 'table' ? 'primary' : 'outline'}
-          onClick={() => setViewMode('table')}
-        >
-          <FiFilter className="w-5 h-5 mr-2" />
-          Lista
-        </Button>
-        <Button
-          variant={viewMode === 'calendar' ? 'primary' : 'outline'}
-          onClick={() => setViewMode('calendar')}
-        >
-          <FiCalendar className="w-5 h-5 mr-2" />
-          Calendario
-        </Button>
-      </div>
 
       {/* Vista principal según modo seleccionado */}
       {isLoading ? (

--- a/src/features/admin/pages/AdminDashboard.tsx
+++ b/src/features/admin/pages/AdminDashboard.tsx
@@ -7,8 +7,9 @@ import Modal from '../components/ui/Modal';
 import ConfirmDialog from '../../../packages/shared-ui/src/components/ui/ConfirmDialog';
 import { DashboardIcon, FileTextIcon, UsersIcon, BarChartIcon, CheckCircleIcon, ClockIcon, UserIcon, LogoIcon } from '../components/icons/Icons';
 import { 
-  FiFileText, 
-  FiBarChart2, 
+  FiFileText,
+  FiUsers,
+  FiBarChart2,
   FiFile, 
   FiKey, 
   FiMail, 
@@ -566,23 +567,42 @@ Esta acción:
       case 'evaluaciones':
         return (
           <div className="space-y-6">
-            {/* Navigation tabs for subsections */}
-            <div className="flex flex-wrap gap-2">
-              <Button
-                variant={evaluationSubsection === 'management' ? 'primary' : 'outline'}
-                onClick={() => setEvaluationSubsection('management')}
-              >
-                <FiList className="w-5 h-5 mr-2" />
-                Gestión de Evaluaciones
-              </Button>
-              <Button
-                variant={evaluationSubsection === 'reports' ? 'primary' : 'outline'}
-                onClick={() => setEvaluationSubsection('reports')}
-              >
-                <FiFile className="w-5 h-5 mr-2" />
-                Informes y Reportes
-              </Button>
-            </div>
+            {/* Header CalGlobal-style */}
+            <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+              <div className="flex flex-col gap-3">
+                <div className="min-w-0">
+                  <p className="text-xs font-bold uppercase tracking-[0.2em] text-teal-600">Gestión de Evaluaciones</p>
+                  <h1 className="mt-1 text-lg font-bold text-gray-950">Gestión de Evaluaciones</h1>
+                  <p className="mt-0.5 max-w-3xl text-sm text-gray-600">Administra y supervisa las evaluaciones del proceso de admisión</p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setEvaluationSubsection('management')}
+                    className={`inline-flex min-h-11 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold focus:outline-none focus:ring-2 ${
+                      evaluationSubsection === 'management'
+                        ? 'border-[#008a57] bg-[#008a57] text-white focus:ring-[#008a57]/30'
+                        : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50 focus:ring-blue-100'
+                    }`}
+                  >
+                    <FiList className="h-4 w-4" aria-hidden="true" />
+                    Gestión de Evaluaciones
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setEvaluationSubsection('reports')}
+                    className={`inline-flex min-h-11 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold focus:outline-none focus:ring-2 ${
+                      evaluationSubsection === 'reports'
+                        ? 'border-[#008a57] bg-[#008a57] text-white focus:ring-[#008a57]/30'
+                        : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50 focus:ring-blue-100'
+                    }`}
+                  >
+                    <FiFile className="h-4 w-4" aria-hidden="true" />
+                    Informes y Reportes
+                  </button>
+                </div>
+              </div>
+            </section>
 
             {/* Render appropriate subsection */}
             {evaluationSubsection === 'management' ? (
@@ -590,6 +610,7 @@ Esta acción:
                 applications={applications}
                 onRefresh={loadApplications}
                 onAssign={handleAssignEvaluator}
+                hideHeader
               />
             ) : (
               <EvaluationReports
@@ -624,79 +645,77 @@ Esta acción:
 
         return (
           <div className="space-y-6">
-            {/* Header */}
-            <div className="flex flex-wrap items-start justify-between gap-3">
-              <div className="flex items-center space-x-3">
-                <FileTextIcon className="w-8 h-8 text-azul-monte-tabor" />
-                <div>
-                  <h1 className="text-2xl font-bold text-gray-900">
-                    Gestión de Postulaciones
-                  </h1>
-                  <p className="text-sm text-gray-600">
+            {/* Header CalGlobal-style */}
+            <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+              <div className="flex flex-col gap-3">
+                <div className="min-w-0">
+                  <p className="text-xs font-bold uppercase tracking-[0.2em] text-teal-600">Gestión de Postulaciones</p>
+                  <h1 className="mt-1 text-lg font-bold text-gray-950">Gestión de Postulaciones</h1>
+                  <p className="mt-0.5 max-w-3xl text-sm text-gray-600">
+                    Mostrando {filteredApplications.length} de {adminApplications.length} postulaciones
                     {statusFilter !== 'all' && (
-                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 mr-2">
+                      <span className="ml-2 inline-flex items-center rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-800">
                         Filtro: {getStatusLabel(statusFilter)}
                       </span>
                     )}
-                    Mostrando {filteredApplications.length} de {adminApplications.length} postulaciones
                   </p>
                 </div>
               </div>
+            </section>
 
-              <div className="flex flex-wrap items-center gap-2">
+            {/* Estadísticas + Actualizar */}
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="flex flex-wrap gap-2" aria-label="Resumen de postulaciones">
+                <div className="min-w-[132px] rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-blue-700">
+                  <div className="flex items-center gap-2">
+                    <FiFileText className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+                    <p className="min-w-0 truncate text-xs font-semibold">Total Activas</p>
+                    <p className="ml-auto text-lg font-bold leading-none">{applicationsToFilter.length}</p>
+                  </div>
+                </div>
+                <div className="min-w-[100px] rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-amber-700">
+                  <div className="flex items-center gap-2">
+                    <FiClock className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+                    <p className="min-w-0 truncate text-xs font-semibold">Nuevas</p>
+                    <p className="ml-auto text-lg font-bold leading-none">{applicationsToFilter.filter(app => app.status === 'PENDING').length}</p>
+                  </div>
+                </div>
+                <div className="min-w-[116px] rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-emerald-700">
+                  <div className="flex items-center gap-2">
+                    <FiCheckCircle className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+                    <p className="min-w-0 truncate text-xs font-semibold">Aceptadas</p>
+                    <p className="ml-auto text-lg font-bold leading-none">{applicationsToFilter.filter(app => app.status === 'APPROVED').length}</p>
+                  </div>
+                </div>
+                <div className="min-w-[116px] rounded-lg border border-purple-200 bg-purple-50 px-3 py-2 text-purple-700">
+                  <div className="flex items-center gap-2">
+                    <FiUsers className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+                    <p className="min-w-0 truncate text-xs font-semibold">En Revisión</p>
+                    <p className="ml-auto text-lg font-bold leading-none">{applicationsToFilter.filter(app => app.status === 'UNDER_REVIEW').length}</p>
+                  </div>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2">
                 {statusFilter !== 'all' && (
-                  <Button
-                    variant="outline"
+                  <button
+                    type="button"
                     onClick={() => setStatusFilter('all')}
+                    className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-100"
                   >
-                    <FiX className="w-5 h-5 mr-2" />
+                    <FiX className="h-4 w-4" aria-hidden="true" />
                     Limpiar Filtro
-                  </Button>
+                  </button>
                 )}
-                <Button
-                  variant="outline"
+                <button
+                  type="button"
                   onClick={loadAdminApplications}
                   disabled={isLoadingAdminApplications}
+                  className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-100 disabled:opacity-60"
                 >
-                  <FiRefreshCw className={`w-5 h-5 mr-2 ${isLoadingAdminApplications ? 'animate-spin' : ''}`} />
+                  <FiRefreshCw className={`h-4 w-4 ${isLoadingAdminApplications ? 'animate-spin' : ''}`} aria-hidden="true" />
                   Actualizar
-                </Button>
+                </button>
               </div>
-            </div>
-
-            {/* Estadísticas rápidas */}
-            <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-              <Card className="p-4 text-center">
-                <FileTextIcon className="w-6 h-6 text-blue-500 mx-auto mb-2" />
-                <p className="text-2xl font-bold text-blue-600">
-                  {applicationsToFilter.length}
-                </p>
-                <p className="text-sm text-gray-600">Total Activas</p>
-              </Card>
-
-              <Card className="p-4 text-center">
-                <ClockIcon className="w-6 h-6 text-yellow-500 mx-auto mb-2" />
-                <p className="text-2xl font-bold text-yellow-600">
-                  {applicationsToFilter.filter(app => app.status === 'PENDING').length}
-                </p>
-                <p className="text-sm text-gray-600">Nuevas</p>
-              </Card>
-
-              <Card className="p-4 text-center">
-                <CheckCircleIcon className="w-6 h-6 text-green-500 mx-auto mb-2" />
-                <p className="text-2xl font-bold text-green-600">
-                  {applicationsToFilter.filter(app => app.status === 'APPROVED').length}
-                </p>
-                <p className="text-sm text-gray-600">Aceptadas</p>
-              </Card>
-
-              <Card className="p-4 text-center">
-                <UsersIcon className="w-6 h-6 text-purple-500 mx-auto mb-2" />
-                <p className="text-2xl font-bold text-purple-600">
-                  {applicationsToFilter.filter(app => app.status === 'UNDER_REVIEW').length}
-                </p>
-                <p className="text-sm text-gray-600">En Revisión</p>
-              </Card>
             </div>
 
             {/* Tabla de postulaciones */}
@@ -715,29 +734,48 @@ Esta acción:
       case 'usuarios':
         return (
           <div className="space-y-6">
-            {/* Navigation tabs for subsections */}
-            <div className="flex flex-wrap gap-2">
-              <Button
-                variant={userSubsection === 'staff' ? 'primary' : 'outline'}
-                onClick={() => setUserSubsection('staff')}
-              >
-                <FiUser className="w-5 h-5 mr-2" />
-                Personal del Colegio
-              </Button>
-              <Button
-                variant={userSubsection === 'guardians' ? 'primary' : 'outline'}
-                onClick={() => setUserSubsection('guardians')}
-              >
-                <UsersIcon className="w-5 h-5 mr-2" />
-                Apoderados
-              </Button>
-            </div>
+            {/* Header CalGlobal-style */}
+            <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+              <div className="flex flex-col gap-3">
+                <div className="min-w-0">
+                  <p className="text-xs font-bold uppercase tracking-[0.2em] text-teal-600">Gestión de Usuarios</p>
+                  <h1 className="mt-1 text-lg font-bold text-gray-950">Gestión de Usuarios</h1>
+                  <p className="mt-0.5 max-w-3xl text-sm text-gray-600">Administra el personal del colegio y apoderados</p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setUserSubsection('staff')}
+                    className={`inline-flex min-h-11 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold focus:outline-none focus:ring-2 ${
+                      userSubsection === 'staff'
+                        ? 'border-[#008a57] bg-[#008a57] text-white focus:ring-[#008a57]/30'
+                        : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50 focus:ring-blue-100'
+                    }`}
+                  >
+                    <FiUser className="h-4 w-4" aria-hidden="true" />
+                    Personal del Colegio
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setUserSubsection('guardians')}
+                    className={`inline-flex min-h-11 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold focus:outline-none focus:ring-2 ${
+                      userSubsection === 'guardians'
+                        ? 'border-[#008a57] bg-[#008a57] text-white focus:ring-[#008a57]/30'
+                        : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50 focus:ring-blue-100'
+                    }`}
+                  >
+                    <UsersIcon className="h-4 w-4" aria-hidden="true" />
+                    Apoderados
+                  </button>
+                </div>
+              </div>
+            </section>
 
             {/* Render appropriate subsection */}
             {userSubsection === 'staff' ? (
-              <StaffManagement onBack={() => setActiveSection('dashboard')} />
+              <StaffManagement hideHeader />
             ) : (
-              <GuardianManagement onBack={() => setActiveSection('dashboard')} />
+              <GuardianManagement hideHeader />
             )}
           </div>
         );

--- a/src/packages/shared-ui/src/components/admin/ApplicantMetricsView.tsx
+++ b/src/packages/shared-ui/src/components/admin/ApplicantMetricsView.tsx
@@ -334,33 +334,34 @@ export const ApplicantMetricsView: React.FC = () => {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-2xl font-bold text-gray-900">Métricas Detalladas de Postulantes</h2>
-          <p className="text-gray-600 mt-1">
-            Rendimiento académico y entrevistas de cada postulante
-          </p>
+      <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+        <div className="flex flex-col gap-3">
+          <div className="min-w-0">
+            <p className="text-xs font-bold uppercase tracking-[0.2em] text-teal-600">Métricas de Postulantes</p>
+            <h1 className="mt-1 text-lg font-bold text-gray-950">Métricas de Postulantes</h1>
+            <p className="mt-0.5 max-w-3xl text-sm text-gray-600">Rendimiento académico y entrevistas de cada postulante</p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => setShowFilters(!showFilters)}
+              className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-100"
+            >
+              <FiFilter className="h-4 w-4" aria-hidden="true" />
+              {showFilters ? 'Ocultar Filtros' : 'Mostrar Filtros'}
+            </button>
+            <button
+              type="button"
+              onClick={exportToExcel}
+              disabled={applicants.length === 0}
+              className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-dorado-nazaret bg-dorado-nazaret px-3 py-2 text-sm font-semibold text-white hover:bg-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200 disabled:opacity-60"
+            >
+              <FiDownload className="h-4 w-4" aria-hidden="true" />
+              Exportar a Excel
+            </button>
+          </div>
         </div>
-        <div className="flex items-center gap-3">
-          <Button
-            variant="outline"
-            onClick={() => setShowFilters(!showFilters)}
-            className="flex items-center gap-2"
-          >
-            <FiFilter className="h-4 w-4" />
-            {showFilters ? 'Ocultar Filtros' : 'Mostrar Filtros'}
-          </Button>
-          <Button
-            variant="primary"
-            onClick={exportToExcel}
-            disabled={applicants.length === 0}
-            className="flex items-center gap-2"
-          >
-            <FiDownload className="h-4 w-4" />
-            Exportar a Excel
-          </Button>
-        </div>
-      </div>
+      </section>
 
       {showFilters && (
         <Card className="p-6">
@@ -464,60 +465,49 @@ export const ApplicantMetricsView: React.FC = () => {
         </Card>
       )}
 
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <Card className="p-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm font-medium text-gray-600">Total Postulantes</p>
-              <p className="text-3xl font-bold text-blue-600 mt-2">{applicants.length}</p>
-            </div>
-            <FiUser className="h-8 w-8 text-blue-500" />
+      <div className="flex flex-wrap gap-2" aria-label="Resumen de métricas">
+        <div className="min-w-[148px] rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-blue-700">
+          <div className="flex items-center gap-2">
+            <FiUser className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+            <p className="min-w-0 truncate text-xs font-semibold">Total Postulantes</p>
+            <p className="ml-auto text-lg font-bold leading-none">{applicants.length}</p>
           </div>
-        </Card>
-
-        <Card className="p-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm font-medium text-gray-600">Evaluaciones Completadas</p>
-              <p className="text-3xl font-bold text-green-600 mt-2">
-                {applicants.length > 0 ? Math.round(
-                  applicants.reduce((sum, a) => {
-                    const completed = [a.examScores?.mathematics, a.examScores?.language, a.examScores?.english]
-                      .filter(e => e && e.status === 'COMPLETED').length;
-                    return sum + (completed / 3) * 100;
-                  }, 0) / applicants.length
-                ) : 0}%
-              </p>
-            </div>
-            <FiAward className="h-8 w-8 text-green-500" />
+        </div>
+        <div className="min-w-[180px] rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-emerald-700">
+          <div className="flex items-center gap-2">
+            <FiAward className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+            <p className="min-w-0 truncate text-xs font-semibold">Evaluaciones Completadas</p>
+            <p className="ml-auto text-lg font-bold leading-none">
+              {applicants.length > 0 ? Math.round(
+                applicants.reduce((sum, a) => {
+                  const completed = [a.examScores?.mathematics, a.examScores?.language, a.examScores?.english]
+                    .filter(e => e && e.status === 'COMPLETED').length;
+                  return sum + (completed / 3) * 100;
+                }, 0) / applicants.length
+              ) : 0}%
+            </p>
           </div>
-        </Card>
-
-        <Card className="p-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm font-medium text-gray-600">Entrevistas Realizadas</p>
-              <p className="text-3xl font-bold text-purple-600 mt-2">
-                {applicants.reduce((sum, a) => sum + (a.familyInterviews?.length || 0), 0)}
-              </p>
-            </div>
-            <FiFileText className="h-8 w-8 text-purple-500" />
+        </div>
+        <div className="min-w-[164px] rounded-lg border border-purple-200 bg-purple-50 px-3 py-2 text-purple-700">
+          <div className="flex items-center gap-2">
+            <FiFileText className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+            <p className="min-w-0 truncate text-xs font-semibold">Entrevistas Realizadas</p>
+            <p className="ml-auto text-lg font-bold leading-none">
+              {applicants.reduce((sum, a) => sum + (a.familyInterviews?.length || 0), 0)}
+            </p>
           </div>
-        </Card>
-
-        <Card className="p-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm font-medium text-gray-600">Documentos Aprobados</p>
-              <p className="text-3xl font-bold text-orange-600 mt-2">
-                {applicants.length > 0 ? Math.round(
-                  applicants.reduce((sum, a) => sum + parseFloat(String(a.documents?.completionRate || '0')), 0) / applicants.length
-                ) : 0}%
-              </p>
-            </div>
-            <FiTrendingUp className="h-8 w-8 text-orange-500" />
+        </div>
+        <div className="min-w-[164px] rounded-lg border border-orange-200 bg-orange-50 px-3 py-2 text-orange-700">
+          <div className="flex items-center gap-2">
+            <FiTrendingUp className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+            <p className="min-w-0 truncate text-xs font-semibold">Documentos Aprobados</p>
+            <p className="ml-auto text-lg font-bold leading-none">
+              {applicants.length > 0 ? Math.round(
+                applicants.reduce((sum, a) => sum + parseFloat(String(a.documents?.completionRate || '0')), 0) / applicants.length
+              ) : 0}%
+            </p>
           </div>
-        </Card>
+        </div>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/src/packages/shared-ui/src/components/admin/EvaluationManagement.tsx
+++ b/src/packages/shared-ui/src/components/admin/EvaluationManagement.tsx
@@ -47,6 +47,7 @@ interface EvaluationManagementProps {
   applications: Application[];
   onRefresh: () => void;
   onAssign: (applicationId: number, assignments: EvaluatorAssignment[]) => Promise<void>;
+  hideHeader?: boolean;
 }
 
 interface EvaluatorAssignment {
@@ -62,7 +63,8 @@ interface EvaluatorCache {
 const EvaluationManagement: React.FC<EvaluationManagementProps> = ({
   applications,
   onRefresh,
-  onAssign
+  onAssign,
+  hideHeader = false
 }) => {
   const [evaluators, setEvaluators] = useState<any[]>([]);
   const [evaluatorCache, setEvaluatorCache] = useState<EvaluatorCache>({});
@@ -296,10 +298,12 @@ const EvaluationManagement: React.FC<EvaluationManagementProps> = ({
     <div className="space-y-4">
       <Card className="p-6">
         {/* Header: título + filtros */}
-        <div className="flex items-center space-x-3 mb-4">
-          <BarChart3 className="w-5 h-5 text-azul-monte-tabor" />
-          <h2 className="text-lg font-semibold text-gray-900">Gestión de Evaluaciones</h2>
-        </div>
+        {!hideHeader && (
+          <div className="flex items-center space-x-3 mb-4">
+            <BarChart3 className="w-5 h-5 text-azul-monte-tabor" />
+            <h2 className="text-lg font-semibold text-gray-900">Gestión de Evaluaciones</h2>
+          </div>
+        )}
 
         {/* Filtros */}
         <div className="flex flex-wrap items-center gap-3 mb-4 p-3 bg-gray-50 rounded-lg">

--- a/src/packages/shared-ui/src/components/users/GuardianManagement.tsx
+++ b/src/packages/shared-ui/src/components/users/GuardianManagement.tsx
@@ -29,9 +29,10 @@ import {
 
 interface GuardianManagementProps {
   onBack?: () => void;
+  hideHeader?: boolean;
 }
 
-const GuardianManagement: React.FC<GuardianManagementProps> = ({ onBack }) => {
+const GuardianManagement: React.FC<GuardianManagementProps> = ({ onBack, hideHeader = false }) => {
   // Función para calcular el mejor tamaño de página
   const getOptimalPageSize = (totalUsers: number): number => {
     if (totalUsers <= 20) return Math.max(10, totalUsers);  // Mínimo 10, pero si hay menos, mostrar todos
@@ -273,48 +274,47 @@ const GuardianManagement: React.FC<GuardianManagementProps> = ({ onBack }) => {
     <div className="space-y-6">
 
       {/* Header */}
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="flex flex-wrap items-center gap-3">
-          {onBack && (
-            <Button 
-              onClick={onBack}
-              variant="outline"
-              className="flex items-center"
-            >
-              <ArrowLeftIcon className="w-4 h-4 mr-2" />
-              Volver
-            </Button>
-          )}
-          <UsersIcon className="w-8 h-8 text-azul-monte-tabor flex-shrink-0" />
-          <div>
-            <h1 className="text-2xl font-bold text-gray-900">
-              Gestión de Usuarios
-            </h1>
-            <p className="text-sm text-gray-600">
-              Administra los usuarios del sistema de admisión
-            </p>
-          </div>
-        </div>
-
-        <div className="flex flex-wrap items-center gap-2">
-          <Button
-            variant="outline"
-            onClick={() => setShowStats(!showStats)}
+      {hideHeader ? (
+        <div className="flex flex-wrap justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => openForm(UserFormMode.CREATE)}
+            className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-amber-400 bg-dorado-nazaret px-3 py-2 text-sm font-semibold text-white hover:bg-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200"
           >
-            <ChartBarIcon className="w-5 h-5 mr-2" />
-            {showStats ? 'Ocultar' : 'Ver'} Estadísticas
-          </Button>
-          
-          <Button onClick={() => openForm(UserFormMode.CREATE)}>
-            <PlusIcon className="w-5 h-5 mr-2" />
+            <PlusIcon className="h-4 w-4" aria-hidden="true" />
             Nuevo Usuario
-          </Button>
+          </button>
         </div>
-      </div>
-
-      {/* Estadísticas */}
-      {showStats && state.stats && (
-        <UserStats stats={state.stats} />
+      ) : (
+        <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+          <div className="flex flex-col gap-3">
+            <div className="min-w-0">
+              <p className="text-xs font-bold uppercase tracking-[0.2em] text-teal-600">Gestión de Usuarios</p>
+              <h1 className="mt-1 text-lg font-bold text-gray-950">Gestión de Usuarios</h1>
+              <p className="mt-0.5 max-w-3xl text-sm text-gray-600">Apoderados y responsables del proceso de admisión</p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {onBack && (
+                <button
+                  type="button"
+                  onClick={onBack}
+                  className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                >
+                  <ArrowLeftIcon className="h-4 w-4" aria-hidden="true" />
+                  Volver
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => openForm(UserFormMode.CREATE)}
+                className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-amber-400 bg-dorado-nazaret px-3 py-2 text-sm font-semibold text-white hover:bg-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200"
+              >
+                <PlusIcon className="h-4 w-4" aria-hidden="true" />
+                Nuevo Usuario
+              </button>
+            </div>
+          </div>
+        </section>
       )}
 
       {/* Filtros */}

--- a/src/packages/shared-ui/src/components/users/StaffManagement.tsx
+++ b/src/packages/shared-ui/src/components/users/StaffManagement.tsx
@@ -31,9 +31,10 @@ import {
 
 interface StaffManagementProps {
   onBack?: () => void;
+  hideHeader?: boolean;
 }
 
-const StaffManagement: React.FC<StaffManagementProps> = ({ onBack }) => {
+const StaffManagement: React.FC<StaffManagementProps> = ({ onBack, hideHeader = false }) => {
   // Función para calcular el mejor tamaño de página
   const getOptimalPageSize = (totalUsers: number): number => {
     if (totalUsers <= 20) return Math.max(10, totalUsers);  // Mínimo 10, pero si hay menos, mostrar todos
@@ -329,49 +330,49 @@ const StaffManagement: React.FC<StaffManagementProps> = ({ onBack }) => {
     <div className="space-y-6">
 
       {/* Header */}
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="flex flex-wrap items-center gap-3">
-          {onBack && (
-            <Button 
-              onClick={onBack}
-              variant="outline"
-              className="flex items-center"
-            >
-              <ArrowLeftIcon className="w-4 h-4 mr-2" />
-              Volver
-            </Button>
-          )}
-          <UsersIcon className="w-8 h-8 text-azul-monte-tabor flex-shrink-0" />
-          <div>
-            <h1 className="text-2xl font-bold text-gray-900">
-              Gestión de Usuarios
-            </h1>
-            <p className="text-sm text-gray-600">
-              Administra los usuarios del sistema de admisión
-            </p>
-          </div>
-        </div>
-
-        <div className="flex flex-wrap items-center gap-2">
-          <Button
-            variant="outline"
-            onClick={() => setShowStats(!showStats)}
+      {hideHeader ? (
+        <div className="flex flex-wrap justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => openForm(UserFormMode.CREATE)}
+            className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-amber-400 bg-dorado-nazaret px-3 py-2 text-sm font-semibold text-white hover:bg-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200"
           >
-            <ChartBarIcon className="w-5 h-5 mr-2" />
-            {showStats ? 'Ocultar' : 'Ver'} Estadísticas
-          </Button>
-          
-          <Button onClick={() => openForm(UserFormMode.CREATE)}>
-            <PlusIcon className="w-5 h-5 mr-2" />
+            <PlusIcon className="h-4 w-4" aria-hidden="true" />
             Nuevo Usuario
-          </Button>
+          </button>
         </div>
-      </div>
-
-      {/* Estadísticas */}
-      {showStats && state.stats && (
-        <UserStats stats={state.stats} />
+      ) : (
+        <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+          <div className="flex flex-col gap-3">
+            <div className="min-w-0">
+              <p className="text-xs font-bold uppercase tracking-[0.2em] text-teal-600">Gestión de Usuarios</p>
+              <h1 className="mt-1 text-lg font-bold text-gray-950">Gestión de Usuarios</h1>
+              <p className="mt-0.5 max-w-3xl text-sm text-gray-600">Personal del colegio y administradores del sistema</p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {onBack && (
+                <button
+                  type="button"
+                  onClick={onBack}
+                  className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                >
+                  <ArrowLeftIcon className="h-4 w-4" aria-hidden="true" />
+                  Volver
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => openForm(UserFormMode.CREATE)}
+                className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-amber-400 bg-dorado-nazaret px-3 py-2 text-sm font-semibold text-white hover:bg-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200"
+              >
+                <PlusIcon className="h-4 w-4" aria-hidden="true" />
+                Nuevo Usuario
+              </button>
+            </div>
+          </div>
+        </section>
       )}
+
 
       {/* Filtros */}
       <UserFilters


### PR DESCRIPTION
Estandarización de módulos admin al diseño de Calendario Global
Objetivo
Unificar el diseño visual de todos los módulos del panel de administración para que coincidan con el estilo de Calendario Global (InterviewCommandCenter.tsx): card de encabezado con etiqueta teal + título grande + subtítulo, pills horizontales en lugar de tarjetas de estadísticas grandes, y botones con estilos consistentes.

Archivos modificados
InterviewCommandCenter.tsx (Calendario Global)
Color del botón activo cambiado de negro a verde #008a57
Orden de botones reordenado: Vista operativa → Calendario → Actualizar
RangeSelector.tsx
Tab activo (Día / Semana / 2 Sem / Mes) cambiado a bg-dorado-nazaret text-white (amarillo con letras blancas)
InterviewManagement.tsx (Gestión de Entrevistas)
Eliminado botón "Volver"
Añadido card de encabezado estilo CalGlobal: etiqueta teal + título + subtítulo
Tabs Estudiantes / Lista / Calendario movidos al interior del card de encabezado, con color activo verde #008a57
Estadísticas convertidas de tarjetas grandes a pills horizontales (azul, ámbar, esmeralda, morado)
Botones Filtros / Actualizar / + Nueva Entrevista movidos debajo de los pills, alineados a la derecha
"Nueva Entrevista" con color dorado-nazaret (amarillo) y texto blanco
Panel de filtros movido para que aparezca debajo de los botones al expandirse
AdminDashboard.tsx (enrutador de módulos)
Gestión de Usuarios: card CalGlobal + tabs Personal del Colegio / Apoderados con color activo verde #008a57, pasando hideHeader a los subcomponentes para evitar encabezados duplicados
Gestión de Evaluaciones: card CalGlobal + tabs con verde #008a57, pasando hideHeader
Gestión de Postulaciones: card CalGlobal + pills horizontales de estadísticas + botón Actualizar alineado a la derecha
StaffManagement.tsx (Personal del Colegio)
Añadida prop hideHeader?: boolean
Cuando hideHeader=true: solo muestra botón "Nuevo Usuario", sin encabezado propio
Eliminado botón "Ver Estadísticas" de todos los contextos
Eliminado panel de estadísticas (UserStats)
GuardianManagement.tsx (Apoderados)
Añadida prop hideHeader?: boolean (mismo patrón que StaffManagement)
Eliminado botón "Ver Estadísticas" de todos los contextos
Eliminado panel de estadísticas (UserStats)
EvaluationManagement.tsx (Gestión de Evaluaciones)
Añadida prop hideHeader?: boolean
Encabezado propio ocultado cuando hideHeader=true
ApplicantMetricsView.tsx (Métricas de Postulantes)
Reemplazado encabezado antiguo por card estilo CalGlobal: "MÉTRICAS DE POSTULANTES" + título + subtítulo
Botones: "Mostrar/Ocultar Filtros" (outline) + "Exportar a Excel" (dorado-nazaret + texto blanco)
4 tarjetas grandes de estadísticas reemplazadas por pills horizontales: Total Postulantes, Evaluaciones Completadas, Entrevistas Realizadas, Documentos Aprobados