### PR TITLE
feat(vacancies): add grade availability management for admissions

### DIFF
--- a/src/features/admin/components/gradeAvailability/GradeAvailabilityManager.tsx
+++ b/src/features/admin/components/gradeAvailability/GradeAvailabilityManager.tsx
@@ -1,0 +1,209 @@
+import React, { useState, useEffect } from 'react';
+import Card from '../ui/Card';
+import Button from '../ui/Button';
+import { useGradeAvailability } from '../../../../packages/shared-ui/src/hooks/useGradeAvailability';
+import { GRADE_LEVELS } from '../../../../packages/shared-ui/src/types/gradeAvailability';
+import type { GradeAvailabilityUpdate } from '../../../../packages/shared-ui/src/types/gradeAvailability';
+
+interface GradeAvailabilityManagerProps {
+  onClose?: () => void;
+}
+
+const GradeAvailabilityManager: React.FC<GradeAvailabilityManagerProps> = ({ onClose }) => {
+  const { grades, loading, error, saveGrades, refetch } = useGradeAvailability();
+  const [localGrades, setLocalGrades] = useState<Record<string, boolean>>({});
+  const [hasChanges, setHasChanges] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveMessage, setSaveMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  useEffect(() => {
+    if (grades.length > 0) {
+      const initial: Record<string, boolean> = {};
+      grades.forEach((g) => {
+        initial[g.gradeLevel] = g.hasVacancy;
+      });
+      setLocalGrades(initial);
+    }
+  }, [grades]);
+
+  const handleToggle = (gradeLevel: string) => {
+    setLocalGrades((prev) => {
+      const newValue = !prev[gradeLevel];
+      const newState = { ...prev, [gradeLevel]: newValue };
+
+      // Check if there are changes
+      const original = grades.find((g) => g.gradeLevel === gradeLevel);
+      const changed = original ? original.hasVacancy !== newValue : false;
+
+      const anyChanged = grades.some((g) => {
+        const originalValue = g.hasVacancy;
+        const newVal = newState[g.gradeLevel];
+        return originalValue !== newVal;
+      });
+
+      setHasChanges(anyChanged);
+      return newState;
+    });
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaveMessage(null);
+
+    const updates: GradeAvailabilityUpdate[] = Object.entries(localGrades).map(
+      ([gradeLevel, hasVacancy]) => ({
+        gradeLevel,
+        hasVacancy,
+      })
+    );
+
+    const success = await saveGrades(updates);
+
+    if (success) {
+      setSaveMessage({ type: 'success', text: 'Disponibilidad de vacantes actualizada correctamente' });
+      setHasChanges(false);
+      setTimeout(() => setSaveMessage(null), 3000);
+    } else {
+      setSaveMessage({ type: 'error', text: 'Error al guardar. Intente nuevamente.' });
+    }
+
+    setSaving(false);
+  };
+
+  const handleCancel = () => {
+    // Reset to original values
+    const initial: Record<string, boolean> = {};
+    grades.forEach((g) => {
+      initial[g.gradeLevel] = g.hasVacancy;
+    });
+    setLocalGrades(initial);
+    setHasChanges(false);
+  };
+
+  if (loading && grades.length === 0) {
+    return (
+      <Card className="p-6">
+        <div className="flex items-center justify-center py-8">
+          <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-azul-monte-tabor" />
+          <span className="ml-3 text-gray-500">Cargando niveles...</span>
+        </div>
+      </Card>
+    );
+  }
+
+  const availableCount = Object.values(localGrades).filter(Boolean).length;
+  const totalCount = GRADE_LEVELS.length;
+
+  return (
+    <Card className="p-6">
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold text-gray-800">Disponibilidad de Vacantes por Nivel</h2>
+        <p className="mt-1 text-sm text-gray-500">
+          Marca los niveles que tienen vacantes disponibles para postulación.
+          Actualmente {availableCount} de {totalCount} niveles tienen vacantes.
+        </p>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-lg bg-red-50 p-4 text-sm text-red-700">
+          {error}
+          <button onClick={refetch} className="ml-2 underline hover:no-underline">
+            Reintentar
+          </button>
+        </div>
+      )}
+
+      {saveMessage && (
+        <div
+          className={`mb-4 rounded-lg p-4 text-sm ${
+            saveMessage.type === 'success'
+              ? 'bg-green-50 text-green-700'
+              : 'bg-red-50 text-red-700'
+          }`}
+        >
+          {saveMessage.text}
+        </div>
+      )}
+
+      <div className="mb-6 space-y-3">
+        {GRADE_LEVELS.map((level) => {
+          const isAvailable = localGrades[level.value] ?? false;
+
+          return (
+            <div
+              key={level.value}
+              className={`flex items-center justify-between rounded-lg border p-4 transition-colors ${
+                isAvailable
+                  ? 'border-green-200 bg-green-50'
+                  : 'border-gray-200 bg-gray-50'
+              }`}
+            >
+              <div className="flex items-center gap-3">
+                <div
+                  className={`flex h-10 w-10 items-center justify-center rounded-full ${
+                    isAvailable ? 'bg-green-100 text-green-600' : 'bg-gray-200 text-gray-500'
+                  }`}
+                >
+                  {isAvailable ? (
+                    <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                  ) : (
+                    <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  )}
+                </div>
+                <div>
+                  <span className={`font-medium ${isAvailable ? 'text-gray-800' : 'text-gray-500'}`}>
+                    {level.label}
+                  </span>
+                  <span className="ml-2 text-xs text-gray-400">({level.value})</span>
+                </div>
+              </div>
+
+              <label className="relative cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={isAvailable}
+                  onChange={() => handleToggle(level.value)}
+                  className="peer sr-only"
+                />
+                <div className="h-6 w-11 rounded-full bg-gray-300 transition-colors peer-checked:bg-green-500 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-green-500 peer-focus:ring-offset-2" />
+                <div className="absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-white transition-transform peer-checked:translate-x-5" />
+              </label>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center justify-between border-t pt-4">
+        <div className="text-sm text-gray-500">
+          {hasChanges ? (
+            <span className="text-amber-600">Hay cambios sin guardar</span>
+          ) : (
+            <span>Sin cambios pendientes</span>
+          )}
+        </div>
+
+        <div className="flex gap-3">
+          {hasChanges && (
+            <Button variant="outline" onClick={handleCancel} disabled={saving}>
+              Cancelar
+            </Button>
+          )}
+          <Button
+            variant="primary"
+            onClick={handleSave}
+            disabled={!hasChanges || saving}
+            isLoading={saving}
+          >
+            {saving ? 'Guardando...' : 'Guardar Cambios'}
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+export default GradeAvailabilityManager;

--- a/src/features/admin/pages/AdminDashboard.tsx
+++ b/src/features/admin/pages/AdminDashboard.tsx
@@ -6,17 +6,18 @@ import Badge from '../components/ui/Badge';
 import Modal from '../components/ui/Modal';
 import ConfirmDialog from '../../../packages/shared-ui/src/components/ui/ConfirmDialog';
 import { DashboardIcon, FileTextIcon, UsersIcon, BarChartIcon, CheckCircleIcon, ClockIcon, UserIcon, LogoIcon } from '../components/icons/Icons';
-import { 
+import GradeAvailabilityManager from '../components/gradeAvailability/GradeAvailabilityManager';
+import {
   FiFileText,
   FiUsers,
   FiBarChart2,
-  FiFile, 
-  FiKey, 
-  FiMail, 
-  FiAlertTriangle, 
-  FiCheckCircle, 
-  FiXCircle, 
-  FiRefreshCw, 
+  FiFile,
+  FiKey,
+  FiMail,
+  FiAlertTriangle,
+  FiCheckCircle,
+  FiXCircle,
+  FiRefreshCw,
   FiEdit,
   FiUser,
   FiBookOpen,
@@ -33,7 +34,8 @@ import {
   FiInfo,
   FiCheck,
   FiX,
-  FiSearch
+  FiSearch,
+  FiGrid
 } from 'react-icons/fi';
 import CreateUserForm from '../components/admin/CreateUserForm';
 import { CreateUserRequest, UserRole, User } from '../types/user';
@@ -71,13 +73,14 @@ import interviewService from '../services/interviewService';
 import InterviewCommandCenter from '../components/dashboard/InterviewCommandCenter';
 
 const sections = [
-  { key: 'metricas',      label: 'Métricas de Postulantes',  icon: BarChartIcon },
+  { key: 'metricas',      label: 'Métricas de Postulantes',   icon: BarChartIcon },
   { key: 'postulaciones', label: 'Gestión de Postulaciones', icon: FileTextIcon },
   { key: 'evaluaciones',  label: 'Gestión de Evaluaciones',  icon: CheckCircleIcon },
   { key: 'entrevistas',   label: 'Gestión de Entrevistas',   icon: ClockIcon },
-  { key: 'calendario',    label: 'Calendario Global',        icon: DashboardIcon },
-  { key: 'usuarios',      label: 'Gestión de Usuarios',      icon: UsersIcon },
-  { key: 'configuracion', label: 'Configuración',            icon: UserIcon },
+  { key: 'calendario',    label: 'Calendario Global',         icon: DashboardIcon },
+  { key: 'usuarios',       label: 'Gestión de Usuarios',      icon: UsersIcon },
+  { key: 'vacantes',       label: 'Disponibilidad de Vacantes', icon: FiGrid },
+  { key: 'configuracion', label: 'Configuración',             icon: UserIcon },
 ];
 
 interface SidebarContentProps {
@@ -551,6 +554,21 @@ Esta acción:
           </div>
         );
 
+      case 'vacantes':
+        return (
+          <div className="space-y-6">
+            <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+              <div className="flex flex-col gap-3">
+                <div className="min-w-0">
+                  <p className="text-xs font-bold uppercase tracking-[0.2em] text-teal-600">Gestión de Vacantes</p>
+                  <h1 className="mt-1 text-lg font-bold text-gray-950">Disponibilidad de Vacantes por Nivel</h1>
+                  <p className="mt-0.5 max-w-3xl text-sm text-gray-600">Configura qué niveles tienen vacantes disponibles para los postulantes</p>
+                </div>
+              </div>
+            </section>
+            <GradeAvailabilityManager />
+          </div>
+        );
 
       case 'dashboard':
         return (

--- a/src/features/admissions/pages/ApplicationForm.tsx
+++ b/src/features/admissions/pages/ApplicationForm.tsx
@@ -12,6 +12,7 @@ import { CheckCircleIcon, LogoIcon, UploadIcon } from '../../admin/components/ic
 import { useApplications, useNotifications } from '../../admin/context/AppContext';
 import { useAuth } from '../context/AuthContext';
 import { educationalLevelsForForm as educationalLevels } from '../../admin/services/staticData';
+import { gradeAvailabilityService } from '../../../packages/shared-ui/src/services/gradeAvailabilityService';
 import { appUrls } from '../../admin/utils/appUrls';
 import { applicationService } from '../services/applicationService';
 import { checkStudentRutExists } from '../services/studentService';
@@ -139,6 +140,39 @@ const ApplicationForm: React.FC = () => {
 
     // Flag to indicate if user is adding another child (skip family data steps)
     const [isAddingAnotherChild, setIsAddingAnotherChild] = useState(false);
+
+    // Estado para disponibilidad de vacantes
+    const [gradeOptionsWithAvailability, setGradeOptionsWithAvailability] = useState(educationalLevels.map(level => ({
+        value: level.value,
+        label: level.label,
+        disabled: false
+    })));
+
+    // Cargar disponibilidad de vacantes al montar
+    useEffect(() => {
+        const fetchAvailability = async () => {
+            try {
+                const available = await gradeAvailabilityService.getAvailable();
+                // Normalizar: remover guiones bajos para comparar (backend usa "1_BASICO", frontend usa "1BASICO")
+                const availableGrades = new Set(
+                    available
+                        .filter((g: any) => g.hasVacancy === true)
+                        .map((g: any) => g.gradeLevel.replace(/_/g, '').toUpperCase())
+                );
+                setGradeOptionsWithAvailability(
+                    educationalLevels.map(level => ({
+                        value: level.value,
+                        label: level.label,
+                        disabled: !availableGrades.has(level.value.toUpperCase().replace(/_/g, ''))
+                    }))
+                );
+            } catch (error) {
+                // Si falla, mostrar todos como disponibles
+                console.warn('No se pudo obtener disponibilidad de vacantes');
+            }
+        };
+        fetchAvailability();
+    }, []);
 
     // Estado para el modal de errores
     const [showErrorModal, setShowErrorModal] = useState(false);
@@ -1918,7 +1952,7 @@ const ApplicationForm: React.FC = () => {
                         <Select
                             id="grade"
                             label="Nivel al que postula"
-                            options={gradeOptions}
+                            options={gradeOptionsWithAvailability}
                             isRequired
                             value={data.grade || ''}
                             onChange={(e) => updateField('grade', e.target.value)}

--- a/src/packages/shared-ui/src/components/ui/Select.tsx
+++ b/src/packages/shared-ui/src/components/ui/Select.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 interface SelectOption {
     value: string;
     label: string;
+    disabled?: boolean;
 }
 
 interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
@@ -42,8 +43,8 @@ const Select: React.FC<SelectProps> = ({
             >
                 <option value="">{placeholder}</option>
                 {options.map((option) => (
-                    <option key={option.value} value={option.value}>
-                        {option.label}
+                    <option key={option.value} value={option.value} disabled={option.disabled}>
+                        {option.label}{option.disabled ? ' (Sin vacantes)' : ''}
                     </option>
                 ))}
             </select>

--- a/src/packages/shared-ui/src/hooks/useGradeAvailability.ts
+++ b/src/packages/shared-ui/src/hooks/useGradeAvailability.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect, useCallback } from 'react';
+import { gradeAvailabilityService } from '../services/gradeAvailabilityService';
+import type { GradeAvailability, GradeAvailabilityUpdate } from '../types/gradeAvailability';
+
+interface UseGradeAvailabilityReturn {
+  grades: GradeAvailability[];
+  loading: boolean;
+  error: string | null;
+  saveGrades: (updates: GradeAvailabilityUpdate[]) => Promise<boolean>;
+  refetch: () => Promise<void>;
+}
+
+export function useGradeAvailability(): UseGradeAvailabilityReturn {
+  const [grades, setGrades] = useState<GradeAvailability[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchGrades = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await gradeAvailabilityService.getAll();
+      setGrades(data);
+    } catch (err: any) {
+      setError(err.message || 'Error al cargar disponibilidad de niveles');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchGrades();
+  }, [fetchGrades]);
+
+  const saveGrades = useCallback(async (updates: GradeAvailabilityUpdate[]): Promise<boolean> => {
+    try {
+      setLoading(true);
+      setError(null);
+      const updated = await gradeAvailabilityService.updateAvailability(updates);
+      setGrades(updated);
+      return true;
+    } catch (err: any) {
+      setError(err.message || 'Error al guardar disponibilidad');
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return {
+    grades,
+    loading,
+    error,
+    saveGrades,
+    refetch: fetchGrades,
+  };
+}

--- a/src/packages/shared-ui/src/services/gradeAvailabilityService.ts
+++ b/src/packages/shared-ui/src/services/gradeAvailabilityService.ts
@@ -1,0 +1,46 @@
+import api from './api';
+import type {
+  GradeAvailability,
+  GradeAvailabilityResponse,
+  GradeAvailabilityUpdate,
+} from '../types/gradeAvailability';
+
+const ADMIN_URL = '/v1/grade-availability';
+const PUBLIC_URL = '/v1/public/grade-availability';
+
+export const gradeAvailabilityService = {
+  /**
+   * Obtener todos los niveles con su disponibilidad (requiere auth ADMIN)
+   */
+  async getAll(): Promise<GradeAvailability[]> {
+    const response = await api.get<GradeAvailabilityResponse>(ADMIN_URL);
+    return response.data.data || [];
+  },
+
+  /**
+   * Actualizar disponibilidad de niveles (bulk update)
+   */
+  async updateAvailability(updates: GradeAvailabilityUpdate[]): Promise<GradeAvailability[]> {
+    const response = await api.put<GradeAvailabilityResponse>(ADMIN_URL, { updates });
+    return response.data.data || [];
+  },
+
+  /**
+   * Obtener solo niveles con vacantes (sin auth - para formulario público)
+   */
+  async getAvailable(): Promise<Pick<GradeAvailability, 'gradeLevel' | 'hasVacancy'>[]> {
+    const response = await api.get<{ success: boolean; data: Pick<GradeAvailability, 'gradeLevel' | 'hasVacancy'>[] }>(PUBLIC_URL);
+    return response.data.data || [];
+  },
+
+  /**
+   * Obtener niveles disponibles como array de strings (gradeLevel)
+   * Útil para validar directamente
+   */
+  async getAvailableGradeLevels(): Promise<string[]> {
+    const available = await this.getAvailable();
+    return available
+      .filter((g) => g.hasVacancy)
+      .map((g) => g.gradeLevel);
+  },
+};

--- a/src/packages/shared-ui/src/types/gradeAvailability.ts
+++ b/src/packages/shared-ui/src/types/gradeAvailability.ts
@@ -1,0 +1,37 @@
+export interface GradeAvailability {
+  id?: number;
+  gradeLevel: string;
+  hasVacancy: boolean;
+  updatedAt?: string;
+  updatedBy?: string;
+}
+
+export interface GradeAvailabilityUpdate {
+  gradeLevel: string;
+  hasVacancy: boolean;
+}
+
+export interface GradeAvailabilityResponse {
+  success: boolean;
+  data: GradeAvailability[];
+  message?: string;
+}
+
+export const GRADE_LEVELS = [
+  { value: 'PREKINDER', label: 'Prekínder' },
+  { value: 'KINDER', label: 'Kínder' },
+  { value: '1_BASICO', label: '1° Básico' },
+  { value: '2_BASICO', label: '2° Básico' },
+  { value: '3_BASICO', label: '3° Básico' },
+  { value: '4_BASICO', label: '4° Básico' },
+  { value: '5_BASICO', label: '5° Básico' },
+  { value: '6_BASICO', label: '6° Básico' },
+  { value: '7_BASICO', label: '7° Básico' },
+  { value: '8_BASICO', label: '8° Básico' },
+  { value: '1_MEDIO', label: 'I Medio' },
+  { value: '2_MEDIO', label: 'II Medio' },
+  { value: '3_MEDIO', label: 'III Medio' },
+  { value: '4_MEDIO', label: 'IV Medio' },
+] as const;
+
+export type GradeLevel = typeof GRADE_LEVELS[number]['value'];


### PR DESCRIPTION
- Add GradeAvailabilityManager component in admin for managing vacancies
- Add useGradeAvailability hook for fetching and updating vacancy data
- Add gradeAvailabilityService with getAll, updateAvailability, getAvailable methods
- Add gradeAvailability types with GRADE_LEVELS constant
- Modify Select component to support disabled options
- Integrate vacancy availability check in ApplicationForm public form
- Normalize grade level format comparison (1_BASICO vs 1BASICO)
- Add "Disponibilidad de Vacantes" section in admin menu