### PR TITLE
Feature/eliminar footer post login

### DIFF
--- a/src/features/admin/App.tsx
+++ b/src/features/admin/App.tsx
@@ -9,7 +9,6 @@ import ProcessActiveGuard from '../../packages/shared-ui/src/components/auth/Pro
 import { AppProvider } from './context/AppContext';
 import { AuthProvider } from './context/AuthContext';
 import Header from './components/layout/Header';
-import Footer from './components/layout/Footer';
 import ToastContainer from './components/ui/ToastContainer';
 import GlobalToastHost from './components/ui/GlobalToastHost';
 import { ErrorBoundary } from './components/ErrorBoundary';
@@ -51,7 +50,6 @@ function App() {
                 </Routes>
               </Suspense>
             </main>
-            <Footer />
             <ToastContainer />
             <GlobalToastHost />
           </div>

--- a/src/features/admin/pages/AdminDashboard.tsx
+++ b/src/features/admin/pages/AdminDashboard.tsx
@@ -833,7 +833,7 @@ Esta acción:
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="h-screen flex flex-col overflow-hidden bg-gray-50">
       {/* Overlay global de carga */}
       {isPageLoading && (
         <div className="fixed inset-0 z-[9999] bg-black/40 backdrop-blur-sm flex items-center justify-center">
@@ -844,7 +844,7 @@ Esta acción:
         </div>
       )}
       {/* Mobile top bar */}
-      <div className="md:hidden bg-white shadow-sm px-4 py-3 flex items-center justify-between sticky top-0 z-30">
+      <div className="md:hidden bg-white shadow-sm px-4 py-3 flex items-center justify-between z-30">
         <div>
           <h1 className="text-lg font-bold text-azul-monte-tabor">Panel Admin</h1>
           <p className="text-xs text-gris-piedra">{user?.firstName} {user?.lastName}</p>
@@ -890,9 +890,9 @@ Esta acción:
         />
       </div>
 
-      <div className="flex">
+      <div className="flex flex-1 overflow-hidden">
         {/* Desktop Sidebar */}
-        <aside className="w-64 bg-white shadow-md min-h-screen flex-col hidden md:flex sticky top-0 self-start h-screen overflow-y-auto">
+        <aside className="w-64 bg-white shadow-md flex-col hidden md:flex overflow-y-auto">
           <SidebarContent
             user={user}
             activeSection={activeSection}
@@ -903,7 +903,7 @@ Esta acción:
         </aside>
 
         {/* Main Content */}
-        <main className="flex-1 p-4 sm:p-6 min-w-0" role="main" aria-label="Contenido principal del dashboard">
+        <main className="flex-1 p-4 sm:p-6 min-w-0 overflow-y-auto" role="main" aria-label="Contenido principal del dashboard">
           {renderSection()}
         </main>
       </div>

--- a/src/features/admissions/App.tsx
+++ b/src/features/admissions/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Suspense } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import HomePage from './pages/HomePage';
 import ApplicationForm from './pages/ApplicationForm';
 import ComplementaryApplicationForm from '../admin/pages/ComplementaryApplicationForm';
@@ -29,6 +29,9 @@ const LoadingFallback = () => (
 );
 
 function App() {
+  const location = useLocation();
+  const isLoginPage = location.pathname === '/apoderado/login';
+
   return (
     <ErrorBoundary>
       <AuthProvider>
@@ -48,7 +51,7 @@ function App() {
                 </Routes>
               </Suspense>
             </main>
-            <Footer />
+            {!isLoginPage && <Footer />}
             <ToastContainer />
             <GlobalToastHost />
           </div>

--- a/src/features/coordinator/App.tsx
+++ b/src/features/coordinator/App.tsx
@@ -10,7 +10,6 @@ import AdvancedSearchView from '../admin/src/components/coordinator/AdvancedSear
 import { AppProvider } from '../admin/context/AppContext';
 import { AuthProvider } from './context/AuthContext';
 import Header from './components/layout/Header';
-import Footer from '../admissions/components/layout/Footer';
 import ToastContainer from '../admin/components/ui/ToastContainer';
 import GlobalToastHost from '../admin/components/ui/GlobalToastHost';
 import { ErrorBoundary } from '../admin/components/ErrorBoundary';
@@ -44,7 +43,6 @@ function App() {
                 </Routes>
               </Suspense>
             </main>
-            <Footer />
             <ToastContainer />
             <GlobalToastHost />
           </div>

--- a/src/features/evaluations/App.tsx
+++ b/src/features/evaluations/App.tsx
@@ -14,7 +14,6 @@ import ProcessActiveGuard from '../../packages/shared-ui/src/components/auth/Pro
 import { AppProvider } from '../admin/context/AppContext';
 import { AuthProvider } from './context/AuthContext';
 import Header from '../coordinator/components/layout/Header';
-import Footer from '../admissions/components/layout/Footer';
 import ToastContainer from '../admin/components/ui/ToastContainer';
 import GlobalToastHost from './components/ui/GlobalToastHost';
 import { ErrorBoundary } from '../admin/components/ErrorBoundary';
@@ -55,7 +54,6 @@ function App() {
                 </Routes>
               </Suspense>
             </main>
-            <Footer />
             <ToastContainer />
             <GlobalToastHost />
           </div>

--- a/src/features/evaluations/pages/ProfessorDashboard.tsx
+++ b/src/features/evaluations/pages/ProfessorDashboard.tsx
@@ -1814,9 +1814,9 @@ const ProfessorDashboard: React.FC = () => {
     };
 
     return (
-        <div className="bg-gray-50 min-h-screen">
+        <div className="h-screen flex flex-col overflow-hidden bg-gray-50">
             {/* Mobile top bar */}
-            <div className="md:hidden bg-white shadow-sm px-4 py-3 flex items-center justify-between sticky top-0 z-30">
+            <div className="md:hidden bg-white shadow-sm px-4 py-3 flex items-center justify-between z-30">
                 <div>
                     <span className="font-bold text-azul-monte-tabor">Portal Profesores</span>
                     <p className="text-gris-piedra text-xs">Sistema de Evaluaciones</p>
@@ -1863,9 +1863,9 @@ const ProfessorDashboard: React.FC = () => {
                 />
             </div>
 
-            <div className="flex">
+            <div className="flex flex-1 overflow-hidden">
                 {/* Desktop Sidebar */}
-                <aside className="w-64 bg-white shadow-md min-h-screen p-6 hidden md:flex flex-col sticky top-0 self-start h-screen overflow-y-auto">
+                <aside className="w-64 bg-white shadow-md p-6 hidden md:flex flex-col overflow-y-auto">
                     <SidebarNav
                         sections={sections}
                         activeSection={activeSection}
@@ -1877,7 +1877,7 @@ const ProfessorDashboard: React.FC = () => {
                 </aside>
 
                 {/* Main Content */}
-                <main className="flex-1 p-4 sm:p-8 min-w-0" role="main" aria-label="Contenido principal del dashboard del profesor">
+                <main className="flex-1 p-4 sm:p-8 min-w-0 overflow-y-auto" role="main" aria-label="Contenido principal del dashboard del profesor">
                     {renderSection()}
                 </main>
             </div>

--- a/src/features/guardian/App.tsx
+++ b/src/features/guardian/App.tsx
@@ -8,7 +8,6 @@ import ProtectedApoderadoRoute from './components/auth/ProtectedApoderadoRoute';
 import { AppProvider } from '../admin/context/AppContext';
 import { AuthProvider } from '../coordinator/context/AuthContext';
 import Header from '../coordinator/components/layout/Header';
-import Footer from '../admissions/components/layout/Footer';
 import ToastContainer from '../admin/components/ui/ToastContainer';
 import GlobalToastHost from '../admin/components/ui/GlobalToastHost';
 import { ErrorBoundary } from '../admin/components/ErrorBoundary';
@@ -45,7 +44,6 @@ function App() {
                 </Routes>
               </Suspense>
             </main>
-            {!isConfirmationResult && <Footer />}
             <ToastContainer />
             <GlobalToastHost />
           </div>

--- a/src/features/guardian/pages/FamilyDashboard.tsx
+++ b/src/features/guardian/pages/FamilyDashboard.tsx
@@ -807,9 +807,9 @@ const FamilyDashboard: React.FC = () => {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="h-screen flex flex-col overflow-hidden bg-gray-50">
       {/* Mobile top bar */}
-      <div className="md:hidden bg-white shadow-sm px-4 py-3 flex items-center justify-between sticky top-0 z-30">
+      <div className="md:hidden bg-white shadow-sm px-4 py-3 flex items-center justify-between z-30">
         <div>
           <h1 className="text-lg font-bold text-azul-monte-tabor">Portal Apoderados</h1>
           <p className="text-xs text-gris-piedra">{user?.firstName} {user?.lastName}</p>
@@ -855,9 +855,9 @@ const FamilyDashboard: React.FC = () => {
         />
       </div>
 
-      <div className="flex">
+      <div className="flex flex-1 overflow-hidden">
         {/* Desktop Sidebar */}
-        <aside className="w-64 bg-white shadow-md min-h-screen flex-col hidden md:flex sticky top-0 self-start h-screen overflow-y-auto" role="complementary" aria-label="Menú de navegación">
+        <aside className="w-64 bg-white shadow-md flex-col hidden md:flex overflow-y-auto" role="complementary" aria-label="Menú de navegación">
           <SidebarContent
             user={user}
             activeSection={activeSection}
@@ -868,7 +868,7 @@ const FamilyDashboard: React.FC = () => {
         </aside>
 
         {/* Main Content */}
-        <main className="flex-1 p-4 sm:p-6 min-w-0" role="main" aria-label="Contenido principal del portal de apoderados">
+        <main className="flex-1 p-4 sm:p-6 min-w-0 overflow-y-auto" role="main" aria-label="Contenido principal del portal de apoderados">
           {renderSection()}
         </main>
       </div>

--- a/src/features/interviews/App.tsx
+++ b/src/features/interviews/App.tsx
@@ -10,7 +10,6 @@ import ProcessActiveGuard from '../../packages/shared-ui/src/components/auth/Pro
 import { AppProvider } from '../admin/context/AppContext';
 import { AuthProvider } from '../coordinator/context/AuthContext';
 import Header from '../coordinator/components/layout/Header';
-import Footer from '../admissions/components/layout/Footer';
 import ToastContainer from '../admin/components/ui/ToastContainer';
 import GlobalToastHost from '../admin/components/ui/GlobalToastHost';
 import { ErrorBoundary } from '../admin/components/ErrorBoundary';
@@ -42,7 +41,6 @@ function App() {
                 </Routes>
               </Suspense>
             </main>
-            <Footer />
             <ToastContainer />
             <GlobalToastHost />
           </div>

--- a/src/features/reports/App.tsx
+++ b/src/features/reports/App.tsx
@@ -7,7 +7,6 @@ import ProtectedAdminRoute from './components/auth/ProtectedAdminRoute';
 import { AppProvider } from '../admin/context/AppContext';
 import { AuthProvider } from '../coordinator/context/AuthContext';
 import Header from '../coordinator/components/layout/Header';
-import Footer from '../admissions/components/layout/Footer';
 import ToastContainer from '../admin/components/ui/ToastContainer';
 import GlobalToastHost from '../evaluations/components/ui/GlobalToastHost';
 import { ErrorBoundary } from '../admin/components/ErrorBoundary';
@@ -40,7 +39,6 @@ function App() {
                 </Routes>
               </Suspense>
             </main>
-            <Footer />
             <ToastContainer />
             <GlobalToastHost />
           </div>

--- a/src/features/reports/pages/AdminDashboard.tsx
+++ b/src/features/reports/pages/AdminDashboard.tsx
@@ -866,9 +866,9 @@ Esta acción:
   );
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="h-screen flex flex-col overflow-hidden bg-gray-50">
       {/* Mobile top bar */}
-      <div className="md:hidden bg-white shadow-sm px-4 py-3 flex items-center justify-between sticky top-0 z-30">
+      <div className="md:hidden bg-white shadow-sm px-4 py-3 flex items-center justify-between z-30">
         <div>
           <h1 className="text-lg font-bold text-azul-monte-tabor">Panel Admin</h1>
           <p className="text-xs text-gris-piedra">{user?.firstName} {user?.lastName}</p>
@@ -900,14 +900,14 @@ Esta acción:
         <SidebarContent onNavigate={() => setIsSidebarOpen(false)} />
       </div>
 
-      <div className="flex">
+      <div className="flex flex-1 overflow-hidden">
         {/* Desktop Sidebar */}
-        <aside className="w-64 bg-white shadow-md min-h-screen flex-col hidden md:flex sticky top-0 self-start h-screen overflow-y-auto">
+        <aside className="w-64 bg-white shadow-md flex-col hidden md:flex overflow-y-auto">
           <SidebarContent />
         </aside>
 
         {/* Main Content */}
-        <main className="flex-1 p-4 sm:p-6 min-w-0" role="main" aria-label="Contenido principal del dashboard">
+        <main className="flex-1 p-4 sm:p-6 min-w-0 overflow-y-auto" role="main" aria-label="Contenido principal del dashboard">
           {renderSection()}
         </main>
       </div>

--- a/src/features/student/App.tsx
+++ b/src/features/student/App.tsx
@@ -6,7 +6,6 @@ import ExamSubjectDetail from './pages/ExamSubjectDetail';
 import { AppProvider } from '../admin/context/AppContext';
 import { AuthProvider } from './context/AuthContext';
 import Header from './components/layout/Header';
-import Footer from '../admissions/components/layout/Footer';
 import ToastContainer from '../admin/components/ui/ToastContainer';
 import GlobalToastHost from '../admin/components/ui/GlobalToastHost';
 import { ErrorBoundary } from '../admin/components/ErrorBoundary';
@@ -36,7 +35,6 @@ function App() {
                 </Routes>
               </Suspense>
             </main>
-            <Footer />
             <ToastContainer />
             <GlobalToastHost />
           </div>

--- a/src/features/student/App.tsx
+++ b/src/features/student/App.tsx
@@ -6,6 +6,7 @@ import ExamSubjectDetail from './pages/ExamSubjectDetail';
 import { AppProvider } from '../admin/context/AppContext';
 import { AuthProvider } from './context/AuthContext';
 import Header from './components/layout/Header';
+import Footer from '../admissions/components/layout/Footer';
 import ToastContainer from '../admin/components/ui/ToastContainer';
 import GlobalToastHost from '../admin/components/ui/GlobalToastHost';
 import { ErrorBoundary } from '../admin/components/ErrorBoundary';
@@ -35,6 +36,7 @@ function App() {
                 </Routes>
               </Suspense>
             </main>
+            <Footer />
             <ToastContainer />
             <GlobalToastHost />
           </div>


### PR DESCRIPTION
Footer

- Eliminado el footer de todos los paneles autenticados: admin, coordinator, evaluations, guardian, interviews, reports y student.
- El footer del landing page de admisiones se conserva (se muestra en inicio y formulario de postulación, se oculta solo en la página de login de apoderado).
- Se limpiaron imports y variables (isLoginPage, useLocation) que quedaron sin uso tras la eliminación.

Sidebar fijo en dashboards

- Corregido el comportamiento del sidebar en los 4 dashboards con panel lateral: AdminDashboard (admin), AdminDashboard (reports), FamilyDashboard (guardian) y ProfessorDashboard (evaluations).
- Problema raíz: overflow-x-hidden en el wrapper de App.tsx creaba un contexto de scroll que anulaba el sticky del sidebar.
- Solución: El wrapper externo de cada dashboard cambia de min-h-screen a h-screen flex flex-col overflow-hidden, el sidebar usa overflow-y-auto (scroll interno independiente) y el área de contenido principal también usa overflow-y-auto. Así el sidebar permanece fijo y solo el contenido interior hace scroll.