### PR TITLE
fix(evaluations): remove redundant Ver button from Informes Finales

### DIFF
--- a/src/features/evaluations/pages/ProfessorDashboard.tsx
+++ b/src/features/evaluations/pages/ProfessorDashboard.tsx
@@ -937,22 +937,13 @@ const ProfessorDashboard: React.FC = () => {
                                                                     {report.status === 'COMPLETED' ? 'Completado' :
                                                                      report.status === 'IN_PROGRESS' ? 'En Progreso' : 'Pendiente'}
                                                                 </Badge>
-                                                                <div className="flex gap-2 mt-2">
-                                                                    <Button
-                                                                        variant="primary"
-                                                                        size="sm"
-                                                                        onClick={() => navigate(`/profesor/informe-director/${report.id}`)}
-                                                                    >
-                                                                        {report.status === 'COMPLETED' ? 'Modificar' : 'Completar Informe'}
-                                                                    </Button>
-                                                                    <Button
-                                                                        variant="outline"
-                                                                        size="sm"
-                                                                        onClick={() => navigate(`/profesor/informe-director/${report.id}`)}
-                                                                    >
-                                                                        Ver
-                                                                    </Button>
-                                                                </div>
+                                                                <Button
+                                                                    variant="primary"
+                                                                    size="sm"
+                                                                    onClick={() => navigate(`/profesor/informe-director/${report.id}`)}
+                                                                >
+                                                                    {report.status === 'COMPLETED' ? 'Modificar' : 'Completar Informe'}
+                                                                </Button>
                                                             </div>
                                                         </div>
                                                     </div>


### PR DESCRIPTION
## Summary
- Remove redundant "Ver" button from Informes Finales section in ProfessorDashboard
- Both buttons were navigating to the same URL, causing confusion
- Now each card only shows "Completar Informe" or "Modificar" as appropriate

## Test plan
- [ ] Navigate to Mis Entrevistas → Informes Finales tab
- [ ] Verify each card has only one action button
- [ ] Verify buttons work correctly for pending and completed reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)