### PR TITLE
refactor(routing): migrate from HashRouter to BrowserRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,22 +37,22 @@ npm run preview
 La app local corre en:
 
 ```text
-http://localhost:5200/#/
+http://localhost:5200/
 ```
 
 ## Rutas Principales
 
-- `/#/`
-- `/#/postulacion`
-- `/#/apoderado/login`
-- `/#/familia`
-- `/#/examenes`
-- `/#/profesor/login`
-- `/#/profesor`
-- `/#/entrevistas`
-- `/#/admin`
-- `/#/reportes`
-- `/#/coordinador`
+- `/`
+- `/postulacion`
+- `/apoderado/login`
+- `/familia`
+- `/examenes`
+- `/profesor/login`
+- `/profesor`
+- `/entrevistas`
+- `/admin`
+- `/reportes`
+- `/coordinador`
 
 ## Reglas De Trabajo
 

--- a/index.html
+++ b/index.html
@@ -34,23 +34,26 @@
     </script>
 </head>
 <body class="bg-gray-100">
-    <!-- HashRouter redirect bridge ──────────────────────────────────
-         Los HTTP 302 del BFF no preservan el fragmento "#" en la URL.
-         Cuando el navegador llega a /interview/confirmation-result?params,
-         este script se ejecuta ANTES de cargar React/Vite y redirige a
-         /#/interview/confirmation-result?params para que HashRouter lo procese.
-    ───────────────────────────────────────────────────────────────── -->
+    <!-- Compatibilidad con URLs históricas de HashRouter.
+         Se ejecuta antes de React y normaliza tanto /#/admin como
+         /login#/admin a /admin, preservando query params antiguos. -->
     <script>
       (function () {
-        var hashRedirectPaths = ['/interview/confirmation-result'];
-        var p = window.location.pathname;
-        // Normalizar: quitar trailing slash para comparar
-        if (p.length > 1 && p.charAt(p.length - 1) === '/') p = p.slice(0, -1);
-        if (hashRedirectPaths.indexOf(p) !== -1) {
-          window.location.replace(
-            window.location.origin + '/#' + p + window.location.search
-          );
-        }
+        if (!window.location.hash || window.location.hash.indexOf('#/') !== 0) return;
+
+        var legacyRoute = new URL(window.location.hash.slice(1), window.location.origin);
+        var oldParams = new URLSearchParams(window.location.search);
+        var routeParams = new URLSearchParams(legacyRoute.search);
+        oldParams.forEach(function (value, key) {
+          if (!routeParams.has(key)) routeParams.append(key, value);
+        });
+
+        var query = routeParams.toString();
+        window.history.replaceState(
+          null,
+          '',
+          legacyRoute.pathname + (query ? '?' + query : '')
+        );
       })();
     </script>
     <div id="root"></div>

--- a/src/app/components/AuthNavigationBridge.tsx
+++ b/src/app/components/AuthNavigationBridge.tsx
@@ -7,7 +7,7 @@
  * que descarta formularios en curso, pierde estado React y reinstancia
  * Firebase/QueryClient innecesariamente.
  *
- * Este componente vive dentro del `HashRouter` (en `AppProviders`) y, al
+ * Este componente vive dentro del router SPA (en `AppProviders`) y, al
  * recibir un evento de pérdida de sesión, ejecuta una navegación SPA con
  * `react-router-dom`, preservando `state.from` para post-login redirect.
  *

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { HashRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 import SessionTimeoutManager from '../packages/shared-ui/src/components/auth/SessionTimeoutManager';
 import { AuthNavigationBridge } from './components/AuthNavigationBridge';
 
@@ -18,7 +18,7 @@ const queryClient = new QueryClient({
 export function AppProviders({ children }: PropsWithChildren) {
   return (
     <QueryClientProvider client={queryClient}>
-      <HashRouter>
+      <BrowserRouter>
         {/* Bridge SPA-nav: convierte eventos de auth (expired/terminal/
             cross-tab-logout/idle-expire) en navegación SPA con useNavigate,
             evitando full reload y preservando state.from para post-login. */}
@@ -27,7 +27,7 @@ export function AppProviders({ children }: PropsWithChildren) {
             cuando hay sesión activa (lee authStore). Sin sesión es no-op. */}
         <SessionTimeoutManager />
         {children}
-      </HashRouter>
+      </BrowserRouter>
     </QueryClientProvider>
   );
 }

--- a/src/features/admissions/context/AuthContext.tsx
+++ b/src/features/admissions/context/AuthContext.tsx
@@ -179,7 +179,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       BASE_STORAGE_KEYS.AUTHENTICATED_USER,
     ].forEach((k) => { try { localStorage.removeItem(getStorageKey(k)); } catch { /* no-op */ } });
     setUser(null);
-    window.location.href = '/apoderado-login';
+    window.location.href = '/apoderado/login';
   }, [setUser]);
 
   const linkFirebaseAccount = useCallback(async () => {

--- a/src/features/coordinator/components/auth/ProtectedCoordinatorRoute.tsx
+++ b/src/features/coordinator/components/auth/ProtectedCoordinatorRoute.tsx
@@ -62,7 +62,7 @@ const ProtectedCoordinatorRoute: React.FC<ProtectedCoordinatorRouteProps> = ({ c
               Volver Atrás
             </button>
             <a
-              href="/#/admin"
+              href="/admin"
               className="text-sm text-blue-600 hover:text-blue-800 transition-colors"
             >
               Ir al Dashboard Principal

--- a/src/features/student/context/AuthContext.tsx
+++ b/src/features/student/context/AuthContext.tsx
@@ -2,7 +2,7 @@
  * AuthContext (student) — portal de estudiantes / exámenes.
  *
  * `legacyIdTokenExchange='sdk-helper'` (igual que admin).
- * Logout y cross-tab redirigen a `/#/examenes`.
+ * Logout y cross-tab redirigen a `/examenes`.
  *
  * Antes este archivo tenía 412 líneas; ahora ~140.
  */
@@ -42,7 +42,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     clearStoreOnRefreshFailure: false,
     legacyIdTokenExchange: 'sdk-helper',
     portalType: 'GUARDIAN',
-    crossTabLogoutRedirectUrl: (reason) => `/#/examenes?reason=${reason}`,
+    crossTabLogoutRedirectUrl: (reason) => `/examenes?reason=${reason}`,
   });
 
   const login = async (email: string, password: string, _role: string) => {
@@ -114,7 +114,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       BASE_STORAGE_KEYS.AUTHENTICATED_USER,
     ].forEach((k) => { try { localStorage.removeItem(getStorageKey(k)); } catch { /* no-op */ } });
     setUser(null);
-    window.location.href = '/#/examenes';
+    window.location.href = '/examenes';
   }, [setUser]);
 
   const linkFirebaseAccount = useCallback(async () => {

--- a/src/packages/shared-ui/src/components/auth/SessionTimeoutManager.tsx
+++ b/src/packages/shared-ui/src/components/auth/SessionTimeoutManager.tsx
@@ -68,7 +68,7 @@ const SessionTimeoutManagerInner: React.FC<Required<SessionTimeoutManagerProps>>
     emitAuthEvent({ type: 'idle-expire', cause: 'inactivity' });
     try { authStore.clear(); } catch { /* no-op */ }
     try { broadcastLogout('expired'); } catch { /* no-op */ }
-    // AuthNavigationBridge procesa idle-expire y navega dentro del HashRouter.
+    // AuthNavigationBridge procesa idle-expire y navega dentro del router SPA.
   }, []);
 
   // Wire de los timers (inactividad + hard-cap absoluto).

--- a/src/packages/shared-ui/src/context/AuthContext.tsx
+++ b/src/packages/shared-ui/src/context/AuthContext.tsx
@@ -131,7 +131,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children, portalType
       BASE_STORAGE_KEYS.AUTHENTICATED_USER,
     ].forEach((k) => { try { localStorage.removeItem(getStorageKey(k)); } catch { /* no-op */ } });
     setUser(null);
-    window.location.href = '/apoderado-login';
+    window.location.href = '/apoderado/login';
   }, [setUser]);
 
   const linkFirebaseAccount = useCallback(async () => {

--- a/src/packages/shared-utils/src/appUrls.ts
+++ b/src/packages/shared-utils/src/appUrls.ts
@@ -1,30 +1,30 @@
-const buildHashUrl = (hashPath: string) => {
-  const normalizedPath = hashPath.startsWith('/') ? hashPath : `/${hashPath}`;
+const buildAppUrl = (path: string) => {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
 
   if (typeof window === 'undefined') {
-    return `#${normalizedPath}`;
+    return normalizedPath;
   }
 
-  return `${window.location.origin}${window.location.pathname}#${normalizedPath}`;
+  return `${window.location.origin}${normalizedPath}`;
 };
 
 export const appUrls = {
-  home: buildHashUrl('/'),
-  admissions: buildHashUrl('/postulacion'),
-  freshAdmissions: `${buildHashUrl('/postulacion').replace('#', '?fresh=1#')}`,
-  admissionsComplementary: buildHashUrl('/postulacion/complementaria'),
-  guardianLogin: buildHashUrl('/apoderado/login'),
-  guardianRegister: `${buildHashUrl('/apoderado/login').replace('#', '?register=1#')}`,
-  guardianDashboard: buildHashUrl('/familia'),
-  studentExams: buildHashUrl('/examenes'),
-  professorLogin: buildHashUrl('/profesor/login'),
-  professorDashboard: buildHashUrl('/profesor'),
-  adminLogin: buildHashUrl('/login'),
-  adminDashboard: buildHashUrl('/admin'),
-  interviews: buildHashUrl('/entrevistas'),
-  calendar: buildHashUrl('/calendario'),
-  reports: buildHashUrl('/reportes'),
-  coordinator: buildHashUrl('/coordinador'),
-  coordinatorTrends: buildHashUrl('/coordinador/tendencias'),
-  coordinatorSearch: buildHashUrl('/coordinador/busqueda'),
+  home: buildAppUrl('/'),
+  admissions: buildAppUrl('/postulacion'),
+  freshAdmissions: `${buildAppUrl('/postulacion')}?fresh=1`,
+  admissionsComplementary: buildAppUrl('/postulacion/complementaria'),
+  guardianLogin: buildAppUrl('/apoderado/login'),
+  guardianRegister: `${buildAppUrl('/apoderado/login')}?register=1`,
+  guardianDashboard: buildAppUrl('/familia'),
+  studentExams: buildAppUrl('/examenes'),
+  professorLogin: buildAppUrl('/profesor/login'),
+  professorDashboard: buildAppUrl('/profesor'),
+  adminLogin: buildAppUrl('/login'),
+  adminDashboard: buildAppUrl('/admin'),
+  interviews: buildAppUrl('/entrevistas'),
+  calendar: buildAppUrl('/calendario'),
+  reports: buildAppUrl('/reportes'),
+  coordinator: buildAppUrl('/coordinador'),
+  coordinatorTrends: buildAppUrl('/coordinador/tendencias'),
+  coordinatorSearch: buildAppUrl('/coordinador/busqueda'),
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -64,7 +64,9 @@ export default defineConfig(({ mode }) => {
   return {
     root: __dirname,
     envDir: envRoot,
-    base: './',
+    // BrowserRouter requiere assets absolutos: una ruta relativa haría que
+    // /profesor/login busque el bundle en /profesor/assets y falle al recargar.
+    base: '/',
     define: {
       'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
       'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),


### PR DESCRIPTION
- Replace HashRouter with BrowserRouter in AppProviders
- Update vite.config base from './' to '/' for absolute asset paths
- Add legacy hash route compatibility script in index.html to normalize /#/admin → /admin
- Remove hash fragments from all route paths in README and appUrls utility
- Update logout redirects across auth contexts (admissions, student, shared-ui) to use clean paths
- Fix ProtectedCoordinatorRoute dashboard link to use /admin instead of /#/admin
- Update comments referencing HashRouter to reflect SPA router architecture