### PR TITLE
Arreglos portal profesores: información de padres, filtro exámenes por rol, resultados académicos y años 2027

### DIFF
--- a/src/features/evaluations/components/evaluations/AdmissionReportForm.tsx
+++ b/src/features/evaluations/components/evaluations/AdmissionReportForm.tsx
@@ -254,7 +254,7 @@ const AdmissionReportForm: React.FC = () => {
                 newWindow.document.write(`
                     <html>
                         <head>
-                            <title>Informe de Admisión 2025 - ${reportData.subject}</title>
+                            <title>Informe de Admisión 2027 - ${reportData.subject}</title>
                             <style>
                                 body { font-family: Arial, sans-serif; margin: 20px; }
                                 .header { text-align: center; margin-bottom: 30px; }
@@ -307,7 +307,7 @@ const AdmissionReportForm: React.FC = () => {
                     
                     <div className="flex justify-between items-center">
                         <h1 className="text-2xl font-bold text-azul-monte-tabor">
-                            Informe de Admisión 2025
+                            Informe de Admisión 2027
                         </h1>
                         <div className="flex gap-3">
                             <Button
@@ -335,7 +335,7 @@ const AdmissionReportForm: React.FC = () => {
                     {/* Encabezado del informe */}
                     <div className="text-center mb-8 pb-4 border-b-4 border-azul-monte-tabor">
                         <h1 className="text-3xl font-bold text-azul-monte-tabor mb-2">
-                            INFORME ADMISIÓN 2026
+                            INFORME ADMISIÓN 2027
                         </h1>
                         <h2 className="text-xl font-semibold text-gris-piedra">
                             {reportData.subject}
@@ -676,7 +676,7 @@ const AdmissionReportForm: React.FC = () => {
                     <div className="mt-8 pt-4 border-t border-gray-300 text-xs text-gray-600">
                         <p>Fecha de evaluación: {new Date().toLocaleDateString('es-CL')}</p>
                         <p>Evaluador: {reportData.evaluatorName}</p>
-                        <p>Colegio Monte Tabor y Nazaret - Sistema de Admisión 2025</p>
+                        <p>Colegio Monte Tabor y Nazaret - Sistema de Admisión 2027</p>
                     </div>
                 </Card>
             </div>

--- a/src/features/evaluations/components/evaluations/CycleDirectorReportForm.tsx
+++ b/src/features/evaluations/components/evaluations/CycleDirectorReportForm.tsx
@@ -201,16 +201,16 @@ const CycleDirectorReportForm: React.FC = () => {
 
     const loadSubjectEvaluations = async (applicationId: number) => {
         try {
-
             // Obtener todas las evaluaciones de esta aplicación desde el backend
             const response = await api.get(`/api/evaluations?applicationId=${applicationId}`);
             const data = response.data;
             const allEvaluations = data.data || data;
 
-
-            // Filtrar solo las evaluaciones académicas completadas
+            // Filtrar solo las evaluaciones académicas completadas de ESTA aplicación
+            // IMPORTANTE: el backend usa 'type' no 'evaluationType'
             const subjectEvals = allEvaluations.filter((evalItem: any) =>
-                ['MATHEMATICS_EXAM', 'LANGUAGE_EXAM', 'ENGLISH_EXAM'].includes(evalItem.evaluationType) &&
+                evalItem.applicationId === applicationId &&
+                ['MATHEMATICS_EXAM', 'LANGUAGE_EXAM', 'ENGLISH_EXAM'].includes(evalItem.type) &&
                 evalItem.status === 'COMPLETED'
             );
 
@@ -218,12 +218,12 @@ const CycleDirectorReportForm: React.FC = () => {
             const mappedEvals = subjectEvals.map((evalItem: any) => ({
                 id: evalItem.id,
                 applicationId: evalItem.applicationId,
-                evaluationType: evalItem.evaluationType,
+                evaluationType: evalItem.type, // Usar 'type' del backend
                 status: evalItem.status,
                 score: evalItem.score,
-                maxScore: evalItem.maxScore || getMaxScoreForType(evalItem.evaluationType),
+                maxScore: evalItem.maxScore || getMaxScoreForType(evalItem.type),
                 observations: evalItem.observations || '',
-                recommendations: evalItem.recommendations || '',
+                recommendations: evalItem.recommendations || evalItem.observations || '',
                 strengths: evalItem.strengths || '',
                 areasForImprovement: evalItem.areasForImprovement || '',
                 studentName: evalItem.student ? `${evalItem.student.firstName} ${evalItem.student.lastName}` : '',
@@ -231,7 +231,6 @@ const CycleDirectorReportForm: React.FC = () => {
             }));
 
             setSubjectEvaluations(mappedEvals as any);
-
         } catch (error) {
             addNotification({
                 type: 'warning',
@@ -246,6 +245,7 @@ const CycleDirectorReportForm: React.FC = () => {
         const evaluationTypes = ['MATHEMATICS_EXAM', 'LANGUAGE_EXAM', 'ENGLISH_EXAM'];
 
         return subjects.map((subject, index) => {
+            // Buscar por evaluationType (que ahora viene del mapeo como 'type')
             const evaluation = subjectEvaluations.find(evalItem =>
                 evalItem.evaluationType === evaluationTypes[index]
             );
@@ -477,7 +477,7 @@ const CycleDirectorReportForm: React.FC = () => {
                                 <Input
                                     value={reportData.gradeApplied}
                                     onChange={(e) => updateReportData('gradeApplied', e.target.value)}
-                                    placeholder="Ej: 1º Básico 2025"
+                                    placeholder="Ej: 1º Básico 2027"
                                 />
                             </div>
                         </div>

--- a/src/features/evaluations/pages/ProfessorDashboard.tsx
+++ b/src/features/evaluations/pages/ProfessorDashboard.tsx
@@ -368,12 +368,17 @@ const ProfessorDashboard: React.FC = () => {
         window.location.href = appUrls.home;
     };
 
-    // Filtrar secciones según el rol - TEACHER no ve "Mis Entrevistas" ni "Mis Horarios"
+    // Filtrar secciones según el rol
     const filteredSections = baseSections.filter(section => {
+        // TEACHER no ve "Mis Entrevistas" ni "Mis Horarios"
         if (currentProfessor?.role === 'TEACHER') {
             if (section.key === 'entrevistas' || section.key === 'horarios') {
                 return false;
             }
+        }
+        // Solo TEACHER ve "Mis Exámenes" (no CYCLE_DIRECTOR, PSYCHOLOGIST, INTERVIEWER, etc.)
+        if (section.key === 'examenes' && currentProfessor?.role !== 'TEACHER') {
+            return false;
         }
         return true;
     });
@@ -1017,6 +1022,9 @@ const ProfessorDashboard: React.FC = () => {
                                         <div>Entrevistadores: {interview.interviewerName} y {interview.secondInterviewerName}</div>
                                     ) : (
                                         <div>Entrevistador: {interview.interviewerName}</div>
+                                    )}
+                                    {activeInterviewTab === 'familiares' && interview.parentNames && (
+                                        <div className="font-medium mt-1">Padres: {interview.parentNames}</div>
                                     )}
                                 </div>
                             )}

--- a/src/features/interviews/pages/FamilyInterviewPage.tsx
+++ b/src/features/interviews/pages/FamilyInterviewPage.tsx
@@ -246,18 +246,18 @@ const FamilyInterviewPage: React.FC = () => {
               <h3 className="font-semibold text-azul-monte-tabor">Padre</h3>
               <div>
                 <label className="text-sm font-medium text-gris-piedra">Nombre</label>
-                <p className="text-lg">{evaluation.father?.name || 'No registrado'}</p>
+                <p className="text-lg">{evaluation.application?.father?.fullName || 'No registrado'}</p>
               </div>
-              {evaluation.father?.email && (
+              {evaluation.application?.father?.email && (
                 <div>
                   <label className="text-sm font-medium text-gris-piedra">Email</label>
-                  <p className="text-lg">{evaluation.father.email}</p>
+                  <p className="text-lg">{evaluation.application.father.email}</p>
                 </div>
               )}
-              {evaluation.father?.phone && (
+              {evaluation.application?.father?.phone && (
                 <div>
                   <label className="text-sm font-medium text-gris-piedra">Teléfono</label>
-                  <p className="text-lg">{evaluation.father.phone}</p>
+                  <p className="text-lg">{evaluation.application.father.phone}</p>
                 </div>
               )}
             </div>
@@ -267,18 +267,18 @@ const FamilyInterviewPage: React.FC = () => {
               <h3 className="font-semibold text-azul-monte-tabor">Madre</h3>
               <div>
                 <label className="text-sm font-medium text-gris-piedra">Nombre</label>
-                <p className="text-lg">{evaluation.mother?.name || 'No registrado'}</p>
+                <p className="text-lg">{evaluation.application?.mother?.fullName || 'No registrado'}</p>
               </div>
-              {evaluation.mother?.email && (
+              {evaluation.application?.mother?.email && (
                 <div>
                   <label className="text-sm font-medium text-gris-piedra">Email</label>
-                  <p className="text-lg">{evaluation.mother.email}</p>
+                  <p className="text-lg">{evaluation.application.mother.email}</p>
                 </div>
               )}
-              {evaluation.mother?.phone && (
+              {evaluation.application?.mother?.phone && (
                 <div>
                   <label className="text-sm font-medium text-gris-piedra">Teléfono</label>
-                  <p className="text-lg">{evaluation.mother.phone}</p>
+                  <p className="text-lg">{evaluation.application.mother.phone}</p>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Resumen de cambios

### 1. Información de padres en entrevistas familiares
- **FamilyInterviewPage.tsx**: Los campos `father` y `mother` ahora leen de `evaluation.application.father` y `evaluation.application.mother` con el campo `fullName`

### 2. Menú "Mis Exámenes" solo para profesores
- **ProfessorDashboard.tsx**: Agregado filtro para que "Mis Exámenes" solo sea visible para rol `TEACHER`

### 3. Resultados académicos por estudiante en informes
- **CycleDirectorReportForm.tsx**: 
  - Corregido filtro para usar `type` en vez de `evaluationType`
  - Agregado filtro por `applicationId` para obtener solo evaluaciones del estudiante del informe

### 4. Años hardcodeados 2025/2026 actualizados a 2027
- **AdmissionReportForm.tsx**: Todos los años hardcodeados cambiados a 2027
- **CycleDirectorReportForm.tsx**: Placeholder actualizado a 2027

## Test plan
- [ ] Verificar que la información de padres aparece en formulario de entrevista familiar
- [ ] Verificar que "Mis Exámenes" no aparece para CYCLE_DIRECTOR ni PSYCHOLOGIST
- [ ] Verificar que resultados académicos se muestran correctamente por estudiante
- [ ] Verificar que años en informes son 2027