### PR TITLE
feat(admissions): vacantes separadas por género M/F

### DIFF
--- a/src/features/admin/components/gradeAvailability/GradeAvailabilityManager.tsx
+++ b/src/features/admin/components/gradeAvailability/GradeAvailabilityManager.tsx
@@ -9,36 +9,44 @@ interface GradeAvailabilityManagerProps {
   onClose?: () => void;
 }
 
+type GenderKey = 'M' | 'F';
+
 const GradeAvailabilityManager: React.FC<GradeAvailabilityManagerProps> = ({ onClose }) => {
   const { grades, loading, error, saveGrades, refetch } = useGradeAvailability();
-  const [localGrades, setLocalGrades] = useState<Record<string, boolean>>({});
+  const [localGrades, setLocalGrades] = useState<Record<string, { M: boolean; F: boolean }>>({});
   const [hasChanges, setHasChanges] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveMessage, setSaveMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
   useEffect(() => {
     if (grades.length > 0) {
-      const initial: Record<string, boolean> = {};
+      const initial: Record<string, { M: boolean; F: boolean }> = {};
       grades.forEach((g) => {
-        initial[g.gradeLevel] = g.hasVacancy;
+        initial[g.gradeLevel] = {
+          M: g.hasVacancyM,
+          F: g.hasVacancyF,
+        };
       });
       setLocalGrades(initial);
     }
   }, [grades]);
 
-  const handleToggle = (gradeLevel: string) => {
+  const handleToggle = (gradeLevel: string, gender: GenderKey) => {
     setLocalGrades((prev) => {
-      const newValue = !prev[gradeLevel];
-      const newState = { ...prev, [gradeLevel]: newValue };
-
-      // Check if there are changes
-      const original = grades.find((g) => g.gradeLevel === gradeLevel);
-      const changed = original ? original.hasVacancy !== newValue : false;
+      const newState = {
+        ...prev,
+        [gradeLevel]: {
+          ...prev[gradeLevel],
+          [gender]: !prev[gradeLevel][gender],
+        },
+      };
 
       const anyChanged = grades.some((g) => {
-        const originalValue = g.hasVacancy;
-        const newVal = newState[g.gradeLevel];
-        return originalValue !== newVal;
+        const originalM = g.hasVacancyM;
+        const originalF = g.hasVacancyF;
+        const newM = newState[g.gradeLevel].M;
+        const newF = newState[g.gradeLevel].F;
+        return originalM !== newM || originalF !== newF;
       });
 
       setHasChanges(anyChanged);
@@ -51,9 +59,10 @@ const GradeAvailabilityManager: React.FC<GradeAvailabilityManagerProps> = ({ onC
     setSaveMessage(null);
 
     const updates: GradeAvailabilityUpdate[] = Object.entries(localGrades).map(
-      ([gradeLevel, hasVacancy]) => ({
+      ([gradeLevel, genders]) => ({
         gradeLevel,
-        hasVacancy,
+        hasVacancyM: genders.M,
+        hasVacancyF: genders.F,
       })
     );
 
@@ -71,10 +80,12 @@ const GradeAvailabilityManager: React.FC<GradeAvailabilityManagerProps> = ({ onC
   };
 
   const handleCancel = () => {
-    // Reset to original values
-    const initial: Record<string, boolean> = {};
+    const initial: Record<string, { M: boolean; F: boolean }> = {};
     grades.forEach((g) => {
-      initial[g.gradeLevel] = g.hasVacancy;
+      initial[g.gradeLevel] = {
+        M: g.hasVacancyM,
+        F: g.hasVacancyF,
+      };
     });
     setLocalGrades(initial);
     setHasChanges(false);
@@ -91,16 +102,43 @@ const GradeAvailabilityManager: React.FC<GradeAvailabilityManagerProps> = ({ onC
     );
   }
 
-  const availableCount = Object.values(localGrades).filter(Boolean).length;
+  const totalWithVacancyM = Object.values(localGrades).filter((g) => g.M).length;
+  const totalWithVacancyF = Object.values(localGrades).filter((g) => g.F).length;
   const totalCount = GRADE_LEVELS.length;
+
+  const GradeToggle = ({
+    gradeLevel,
+    gender,
+    isAvailable,
+  }: {
+    gradeLevel: string;
+    gender: GenderKey;
+    isAvailable: boolean;
+  }) => (
+    <label className="relative cursor-pointer">
+      <input
+        type="checkbox"
+        checked={isAvailable}
+        onChange={() => handleToggle(gradeLevel, gender)}
+        className="peer sr-only"
+      />
+      <div
+        className={`h-6 w-11 rounded-full transition-colors peer-checked:bg-green-500 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-green-500 peer-focus:ring-offset-2 ${
+          isAvailable ? 'bg-green-500' : 'bg-gray-300'
+        }`}
+      />
+      <div className="absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-white transition-transform peer-checked:translate-x-5" />
+    </label>
+  );
 
   return (
     <Card className="p-6">
       <div className="mb-6">
-        <h2 className="text-xl font-semibold text-gray-800">Disponibilidad de Vacantes por Nivel</h2>
+        <h2 className="text-xl font-semibold text-gray-800">Disponibilidad de Vacantes por Nivel y Género</h2>
         <p className="mt-1 text-sm text-gray-500">
-          Marca los niveles que tienen vacantes disponibles para postulación.
-          Actualmente {availableCount} de {totalCount} niveles tienen vacantes.
+          Marca las vacantes disponibles según el género del postulante.
+          Actualmente {totalWithVacancyM} de {totalCount} niveles tienen vacantes masculinas y{' '}
+          {totalWithVacancyF} de {totalCount} tienen vacantes femeninas.
         </p>
       </div>
 
@@ -125,56 +163,69 @@ const GradeAvailabilityManager: React.FC<GradeAvailabilityManagerProps> = ({ onC
         </div>
       )}
 
-      <div className="mb-6 space-y-3">
-        {GRADE_LEVELS.map((level) => {
-          const isAvailable = localGrades[level.value] ?? false;
+      <div className="mb-6">
+        {/* Header */}
+        <div className="mb-2 grid grid-cols-3 gap-4 px-4">
+          <div className="font-medium text-gray-700">Nivel</div>
+          <div className="text-center font-medium text-gray-700">
+            <span className="inline-flex items-center justify-center rounded-full bg-blue-100 px-3 py-1 text-sm font-semibold text-blue-700">
+              Masculino (M)
+            </span>
+          </div>
+          <div className="text-center font-medium text-gray-700">
+            <span className="inline-flex items-center justify-center rounded-full bg-pink-100 px-3 py-1 text-sm font-semibold text-pink-700">
+              Femenino (F)
+            </span>
+          </div>
+        </div>
 
-          return (
-            <div
-              key={level.value}
-              className={`flex items-center justify-between rounded-lg border p-4 transition-colors ${
-                isAvailable
-                  ? 'border-green-200 bg-green-50'
-                  : 'border-gray-200 bg-gray-50'
-              }`}
-            >
-              <div className="flex items-center gap-3">
-                <div
-                  className={`flex h-10 w-10 items-center justify-center rounded-full ${
-                    isAvailable ? 'bg-green-100 text-green-600' : 'bg-gray-200 text-gray-500'
-                  }`}
-                >
-                  {isAvailable ? (
-                    <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
-                  ) : (
-                    <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                  )}
+        {/* Grade rows */}
+        <div className="space-y-2">
+          {GRADE_LEVELS.map((level) => {
+            const isM = localGrades[level.value]?.M ?? false;
+            const isF = localGrades[level.value]?.F ?? false;
+
+            return (
+              <div
+                key={level.value}
+                className={`grid grid-cols-3 items-center gap-4 rounded-lg p-4 transition-colors ${
+                  isM || isF ? 'bg-green-50' : 'bg-gray-50'
+                }`}
+              >
+                <div className="flex items-center gap-3">
+                  <div
+                    className={`flex h-8 w-8 items-center justify-center rounded-full ${
+                      isM || isF ? 'bg-green-100 text-green-700' : 'bg-gray-200 text-gray-700'
+                    }`}
+                  >
+                    {isM || isF ? (
+                      <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                      </svg>
+                    ) : (
+                      <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                    )}
+                  </div>
+                  <div>
+                    <span className={`font-medium ${isM || isF ? 'text-gray-800' : 'text-gray-500'}`}>
+                      {level.label}
+                    </span>
+                  </div>
                 </div>
-                <div>
-                  <span className={`font-medium ${isAvailable ? 'text-gray-800' : 'text-gray-500'}`}>
-                    {level.label}
-                  </span>
-                  <span className="ml-2 text-xs text-gray-400">({level.value})</span>
+
+                <div className="flex justify-center">
+                  <GradeToggle gradeLevel={level.value} gender="M" isAvailable={isM} />
+                </div>
+
+                <div className="flex justify-center">
+                  <GradeToggle gradeToggle gradeLevel={level.value} gender="F" isAvailable={isF} />
                 </div>
               </div>
-
-              <label className="relative cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={isAvailable}
-                  onChange={() => handleToggle(level.value)}
-                  className="peer sr-only"
-                />
-                <div className="h-6 w-11 rounded-full bg-gray-300 transition-colors peer-checked:bg-green-500 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-green-500 peer-focus:ring-offset-2" />
-                <div className="absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-white transition-transform peer-checked:translate-x-5" />
-              </label>
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
       </div>
 
       <div className="flex items-center justify-between border-t pt-4">

--- a/src/features/admissions/pages/ApplicationForm.tsx
+++ b/src/features/admissions/pages/ApplicationForm.tsx
@@ -51,8 +51,8 @@ const gradeOptions = educationalLevels.map(level => ({
     label: level.label
 }));
 
-const schoolOptions = [
-    { value: '', label: 'Seleccione un género...' },
+const genderOptions = [
+    { value: '', label: 'Seleccione el género...' },
     { value: 'MALE', label: 'Masculino' },
     { value: 'FEMALE', label: 'Femenino' }
 ];
@@ -65,11 +65,11 @@ const getDocumentTypesConfig = () => {
 
     return [
         { key: DocumentType.BIRTH_CERTIFICATE, label: 'Certificado de Nacimiento', required: true },
-        { key: DocumentType.GRADES_YEAR_2, label: `Certificado de Estudios ${year2}`, required: true },
-        { key: DocumentType.GRADES_YEAR_1, label: `Certificado de Estudios ${year1}`, required: true },
-        { key: DocumentType.GRADES_SEMESTER_1, label: `Certificado de Estudios ${currentYear} - Primer Semestre`, required: true },
-        { key: DocumentType.PERSONALITY_YEAR_1, label: `Informe de Personalidad ${year1}`, required: false },
-        { key: DocumentType.PERSONALITY_SEMESTER_1, label: `Informe de Personalidad ${currentYear} - Primer Semestre`, required: false },
+        { key: DocumentType.GRADES_YEAR_2, label: `Certificado de Estudios ${year2}`, required: false, recommended: true },
+        { key: DocumentType.GRADES_YEAR_1, label: `Certificado de Estudios ${year1}`, required: false, recommended: true },
+        { key: DocumentType.GRADES_SEMESTER_1, label: `Certificado de Estudios ${currentYear} - Primer Semestre`, required: false, recommended: true },
+        { key: DocumentType.PERSONALITY_YEAR_1, label: `Informe de Desarrollo Personal ${year1}`, required: false },
+        { key: DocumentType.PERSONALITY_SEMESTER_1, label: `Informe de Desarrollo Personal ${currentYear} - Primer Semestre`, required: false },
         { key: DocumentType.MEDICAL_CERTIFICATE, label: 'Certificado Médico', required: false },
         { key: DocumentType.PSYCHOLOGICAL_REPORT, label: 'Informe Psicológico (si aplica)', required: false }
     ];
@@ -149,7 +149,8 @@ const ApplicationForm: React.FC = () => {
     const [gradeOptionsWithAvailability, setGradeOptionsWithAvailability] = useState(educationalLevels.map(level => ({
         value: level.value,
         label: level.label,
-        disabled: false
+        disabled: false,
+        vacancyInfo: null as { hasM: boolean; hasF: boolean } | null
     })));
 
     // Cargar disponibilidad de vacantes al montar
@@ -157,18 +158,36 @@ const ApplicationForm: React.FC = () => {
         const fetchAvailability = async () => {
             try {
                 const available = await gradeAvailabilityService.getAvailable();
-                // Normalizar: remover guiones bajos para comparar (backend usa "1_BASICO", frontend usa "1BASICO")
-                const availableGrades = new Set(
-                    available
-                        .filter((g: any) => g.hasVacancy === true)
-                        .map((g: any) => g.gradeLevel.replace(/_/g, '').toUpperCase())
-                );
+                // Map para acceso rápido: normalizar key (remover guiones bajos)
+                const availabilityMap: Record<string, { hasM: boolean; hasF: boolean }> = {};
+                available.forEach((g: any) => {
+                    const key = g.gradeLevel.replace(/_/g, '').toUpperCase();
+                    availabilityMap[key] = {
+                        hasM: g.hasVacancyM === true,
+                        hasF: g.hasVacancyF === true
+                    };
+                });
+
+                // Helper para generar label con info de género
+                const getLabelWithVacancyInfo = (levelLabel: string, hasM: boolean, hasF: boolean): string => {
+                    if (hasM && hasF) return `${levelLabel} (M/F)`;
+                    if (hasM) return `${levelLabel} (M)`;
+                    if (hasF) return `${levelLabel} (F)`;
+                    return levelLabel;
+                };
+
                 setGradeOptionsWithAvailability(
-                    educationalLevels.map(level => ({
-                        value: level.value,
-                        label: level.label,
-                        disabled: !availableGrades.has(level.value.toUpperCase().replace(/_/g, ''))
-                    }))
+                    educationalLevels.map(level => {
+                        const key = level.value.toUpperCase().replace(/_/g, '');
+                        const vacancy = availabilityMap[key] || { hasM: false, hasF: false };
+                        const hasVacancy = vacancy.hasM || vacancy.hasF;
+                        return {
+                            value: level.value,
+                            label: getLabelWithVacancyInfo(level.label, vacancy.hasM, vacancy.hasF),
+                            disabled: !hasVacancy,
+                            vacancyInfo: vacancy
+                        };
+                    })
                 );
             } catch (error) {
                 // Si falla, mostrar todos como disponibles
@@ -193,6 +212,24 @@ const ApplicationForm: React.FC = () => {
     // Estado del formulario simplificado
     const [data, setData] = useState<any>({});
     const [errors, setErrors] = useState<any>({});
+
+    // Opciones filtradas por género del estudiante
+    const gradeOptionsFiltered = useMemo(() => {
+        if (!data.gender) {
+            // Sin género seleccionado: mostrar solo cursos con vacantes para ambos
+            return gradeOptionsWithAvailability.filter(opt => {
+                if (!opt.vacancyInfo) return false;
+                return opt.vacancyInfo.hasM && opt.vacancyInfo.hasF;
+            });
+        }
+        // Filtrar por género del estudiante
+        return gradeOptionsWithAvailability.filter(opt => {
+            if (!opt.vacancyInfo) return false;
+            if (data.gender === 'MALE') return opt.vacancyInfo.hasM;
+            if (data.gender === 'FEMALE') return opt.vacancyInfo.hasF;
+            return false;
+        });
+    }, [gradeOptionsWithAvailability, data.gender]);
     const [isCheckingRut, setIsCheckingRut] = useState(false);
 
     // Estado para autenticación
@@ -932,7 +969,7 @@ const ApplicationForm: React.FC = () => {
             // Step 0: Información del Postulante
             case 0:
                 if (!data.firstName?.trim() || !data.paternalLastName?.trim() || !data.maternalLastName?.trim() ||
-                    !data.rut?.trim() || !data.birthDate) {
+                    !data.rut?.trim() || !data.birthDate || !data.gender) {
                     return false;
                 }
                 // Bloquear si el RUT ya existe como postulante (validación async onBlur)
@@ -965,6 +1002,13 @@ const ApplicationForm: React.FC = () => {
                 }
                 if (requiresCurrentSchool(data.grade || '') && !data.currentSchool?.trim()) {
                     return false;
+                }
+                // Validar vacante por género
+                const selectedGradeOption = gradeOptionsWithAvailability.find(g => g.value === data.grade);
+                if (selectedGradeOption?.vacancyInfo) {
+                    const { hasM, hasF } = selectedGradeOption.vacancyInfo;
+                    if (data.gender === 'MALE' && !hasM) return false;
+                    if (data.gender === 'FEMALE' && !hasF) return false;
                 }
                 return true;
 
@@ -1355,6 +1399,7 @@ const ApplicationForm: React.FC = () => {
                 if (!data.rut?.trim()) missing.push('RUT');
                 else if (errors.rut) missing.push('RUT (ya registrado)');
                 if (!data.birthDate) missing.push('Fecha de Nacimiento');
+                if (!data.gender) missing.push('Género');
                 break;
 
             // Step 1: Lugar de Residencia
@@ -1373,6 +1418,13 @@ const ApplicationForm: React.FC = () => {
                 if (requiresCurrentSchool(data.grade || '') && !data.currentSchool?.trim()) missing.push('Colegio de Procedencia');
                 if (!data.applicationYear) missing.push('Año al que postula');
                 if (!data.admissionPreference) missing.push('Tipo de Relación Familiar');
+                // Verificar vacante por género
+                const gradeOption = gradeOptionsWithAvailability.find(g => g.value === data.grade);
+                if (gradeOption?.vacancyInfo) {
+                    const { hasM, hasF } = gradeOption.vacancyInfo;
+                    if (data.gender === 'MALE' && !hasM) missing.push('No hay vacantes masculinas en este nivel');
+                    if (data.gender === 'FEMALE' && !hasF) missing.push('No hay vacantes femeninas en este nivel');
+                }
                 break;
 
             // Step 3: Datos del Padre
@@ -1801,6 +1853,16 @@ const ApplicationForm: React.FC = () => {
                                 })()}
                             </div>
                         </div>
+                        <Select
+                            id="gender"
+                            label="Género del Postulante"
+                            options={genderOptions}
+                            isRequired
+                            value={data.gender || ''}
+                            onChange={(e) => updateField('gender', e.target.value)}
+                            onBlur={() => touchField('gender')}
+                            error={errors.gender}
+                        />
                         <Input
                             id="studentEmail"
                             label="Correo Electrónico"
@@ -1962,13 +2024,21 @@ const ApplicationForm: React.FC = () => {
                         <Select
                             id="grade"
                             label="Nivel al que postula"
-                            options={gradeOptionsWithAvailability}
+                            options={gradeOptionsFiltered}
                             isRequired
                             value={data.grade || ''}
                             onChange={(e) => updateField('grade', e.target.value)}
                             onBlur={() => touchField('grade')}
                             error={errors.grade}
                         />
+
+                        {data.gender && gradeOptionsFiltered.length === 0 && (
+                            <div className="p-4 bg-red-50 border border-red-200 rounded-lg">
+                                <p className="text-sm text-red-700">
+                                    <strong>Sin vacantes disponibles:</strong> No hay vacantes para el género seleccionado en ningún nivel. Por favor contacte a administración.
+                                </p>
+                            </div>
+                        )}
 
                         {requiresCurrentSchool(data.grade || '') && (
                             <Input
@@ -2508,14 +2578,14 @@ const ApplicationForm: React.FC = () => {
                                     <div className="mb-6">
                                         <h4 className="text-lg font-semibold text-azul-monte-tabor mb-3">Documentos Obligatorios</h4>
                                         <div className="space-y-3">
-                                            {getDocumentTypesConfig().filter(doc => doc.required).map(doc => (
+                                            {getDocumentTypesConfig().filter(doc => doc.required && !doc.recommended).map(doc => (
                                                 <div key={doc.key} className="flex justify-between items-center p-3 border rounded-lg bg-red-50">
                                                     <label className="font-medium">
                                                         {doc.label} <span className="text-rojo-sagrado">*</span>
                                                     </label>
                                                     <div className="flex items-center gap-2">
-                                                        <input 
-                                                            type="file" 
+                                                        <input
+                                                            type="file"
                                                             accept=".pdf,.jpg,.jpeg,.png"
                                                             onChange={(e) => {
                                                                 const file = e.target.files?.[0];
@@ -2531,17 +2601,49 @@ const ApplicationForm: React.FC = () => {
                                             ))}
                                         </div>
                                     </div>
-                                    
+
+                                    {/* Documentos recomendados (no obligatorios pero importante tenerlos) */}
+                                    <div className="mb-6">
+                                        <h4 className="text-lg font-semibold text-azul-monte-tabor mb-3">Documentos Recomendados</h4>
+                                        <div className="space-y-3">
+                                            {getDocumentTypesConfig().filter(doc => doc.recommended).map(doc => (
+                                                <div key={doc.key} className="flex justify-between items-center p-3 border rounded-lg bg-amber-50">
+                                                    <label className="font-medium">
+                                                        {doc.label} <span className="text-amber-600">*</span>
+                                                        <span className="text-xs text-gris-piedra ml-2">(Recomendado)</span>
+                                                    </label>
+                                                    <div className="flex items-center gap-2">
+                                                        <input
+                                                            type="file"
+                                                            accept=".pdf,.jpg,.jpeg,.png"
+                                                            onChange={(e) => {
+                                                                const file = e.target.files?.[0];
+                                                                if (file) handleFileSelect(doc.key, file);
+                                                            }}
+                                                            className="text-sm"
+                                                        />
+                                                        {uploadedDocuments.has(doc.key) && (
+                                                            <span className="text-verde-esperanza text-sm">Seleccionado</span>
+                                                        )}
+                                                    </div>
+                                                </div>
+                                            ))}
+                                        </div>
+                                        <p className="text-xs text-gris-piedra mt-2">
+                                            Estos documentos son importantes para evaluar al postulante. Si no están disponibles (ej: Kinder o 1° Básico sin historial académico previo), puede omitirlos y completar más tarde desde su dashboard.
+                                        </p>
+                                    </div>
+
                                     {/* Documentos opcionales */}
                                     <div>
                                         <h4 className="text-lg font-semibold text-azul-monte-tabor mb-3">Documentos Opcionales</h4>
                                         <div className="space-y-3">
-                                            {getDocumentTypesConfig().filter(doc => !doc.required).map(doc => (
+                                            {getDocumentTypesConfig().filter(doc => !doc.required && !doc.recommended).map(doc => (
                                                 <div key={doc.key} className="flex justify-between items-center p-3 border rounded-lg">
                                                     <label className="font-medium">{doc.label}</label>
                                                     <div className="flex items-center gap-2">
-                                                        <input 
-                                                            type="file" 
+                                                        <input
+                                                            type="file"
                                                             accept={doc.key === 'STUDENT_PHOTO' ? '.jpg,.jpeg,.png' : '.pdf,.jpg,.jpeg,.png'}
                                                             onChange={(e) => {
                                                                 const file = e.target.files?.[0];
@@ -2577,10 +2679,9 @@ const ApplicationForm: React.FC = () => {
                                 <strong>Notas importantes:</strong>
                             </p>
                             <ul className="text-sm text-amber-800 mt-2 list-disc list-inside space-y-1">
-                                <li>Los certificados de estudios e informes de personalidad son obligatorios solo para estudiantes de 3° básico en adelante.</li>
-                                <li>Para estudiantes menores, adjunte los documentos que correspondan según su nivel educativo actual.</li>
-                                <li>La fotografía del postulante es opcional pero recomendada para agilizar el proceso.</li>
-                                <li>Los informes de personalidad deben ser emitidos por el colegio o jardín infantil de origen.</li>
+                                <li><strong>Solo el Certificado de Nacimiento es obligatorio.</strong> Los demás documentos son recomendados (con *) u opcionales.</li>
+                                <li>Los certificados de estudios marcados con (*) son muy importantes para evaluar al postulante, pero no son obligatorios si no existen (ej: postulantes a Kinder o 1° Básico sin historial académico previo).</li>
+                                <li>Para estudiantes que vienen de jardines infantiles, puede omitir los certificados de estudios de años anteriores.</li>
                                 <li><strong>Puede enviar su postulación aunque no haya subido todos los documentos.</strong> Podrá completarlos más tarde desde su dashboard.</li>
                             </ul>
                         </div>

--- a/src/packages/shared-ui/src/services/gradeAvailabilityService.ts
+++ b/src/packages/shared-ui/src/services/gradeAvailabilityService.ts
@@ -28,8 +28,8 @@ export const gradeAvailabilityService = {
   /**
    * Obtener solo niveles con vacantes (sin auth - para formulario público)
    */
-  async getAvailable(): Promise<Pick<GradeAvailability, 'gradeLevel' | 'hasVacancy'>[]> {
-    const response = await api.get<{ success: boolean; data: Pick<GradeAvailability, 'gradeLevel' | 'hasVacancy'>[] }>(PUBLIC_URL);
+  async getAvailable(): Promise<Pick<GradeAvailability, 'gradeLevel' | 'hasVacancyM' | 'hasVacancyF'>[]> {
+    const response = await api.get<{ success: boolean; data: Pick<GradeAvailability, 'gradeLevel' | 'hasVacancyM' | 'hasVacancyF'>[] }>(PUBLIC_URL);
     return response.data.data || [];
   },
 
@@ -40,7 +40,7 @@ export const gradeAvailabilityService = {
   async getAvailableGradeLevels(): Promise<string[]> {
     const available = await this.getAvailable();
     return available
-      .filter((g) => g.hasVacancy)
+      .filter((g) => g.hasVacancyM || g.hasVacancyF)
       .map((g) => g.gradeLevel);
   },
 };

--- a/src/packages/shared-ui/src/types/gradeAvailability.ts
+++ b/src/packages/shared-ui/src/types/gradeAvailability.ts
@@ -1,14 +1,16 @@
 export interface GradeAvailability {
   id?: number;
   gradeLevel: string;
-  hasVacancy: boolean;
+  hasVacancyM: boolean;
+  hasVacancyF: boolean;
   updatedAt?: string;
   updatedBy?: string;
 }
 
 export interface GradeAvailabilityUpdate {
   gradeLevel: string;
-  hasVacancy: boolean;
+  hasVacancyM: boolean;
+  hasVacancyF: boolean;
 }
 
 export interface GradeAvailabilityResponse {


### PR DESCRIPTION
## Resumen
- Separar vacantes por género: `hasVacancy` → `hasVacancyM` + `hasVacancyF`
- Nueva UI en admin con toggles independientes para M y F
- Campo género obligatorio en formulario de postulación (Step 0)
- Dropdown de niveles filtra según género del postulante
- Validación de vacantes por género antes de avanzar

## Cambios
- `GradeAvailabilityManager.tsx`: UI con 2 columnas M/F
- `ApplicationForm.tsx`: campo género + filtro de cursos por género
- `gradeAvailabilityService.ts`: actualización de tipos
- `gradeAvailability.ts`: nuevos campos `hasVacancyM` y `hasVacancyF`

## Testing
Verificado manualmente:
- Masculino → solo muestra cursos con vacantes masculinas (3°-7° Básico)
- Femenino → solo muestra cursos con vacantes femeninas (8° Básico-4° Medio)

## Notas
El backend debe estar actualizado para retornar `hasVacancyM` y `hasVacancyF` en los endpoints de vacantes.